### PR TITLE
Only publish litegraph.core.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@comfyorg/litegraph",
-    "version": "0.7.15",
+    "version": "0.7.16",
     "description": "A graph node editor similar to PD or UDK Blueprints. It works in an HTML5 Canvas and allows to export graphs to be included in applications.",
     "main": "build/litegraph.js",
     "types": "src/litegraph.d.ts",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "author": "comfyorg",
     "license": "MIT",
     "files": [
-        "build",
+        "build/litegraph.core.js",
         "css/litegraph.css",
         "src/litegraph.d.ts"
     ],


### PR DESCRIPTION
ComfyUI only uses `litegraph.core.js`, importing the full version results unexpected nodes to be available.