### PR TITLE
Fix zoom

### DIFF
--- a/src/litegraph.js
+++ b/src/litegraph.js
@@ -7581,9 +7581,14 @@ LGraphNode.prototype.executeAction = function(action)
         	clientX_rel = e.clientX;
         	clientY_rel = e.clientY;
         }
-    	
-        e.deltaX = clientX_rel - this.last_mouse_position[0];
-        e.deltaY = clientY_rel- this.last_mouse_position[1];
+
+        // Only set deltaX and deltaY if not already set.
+        // If deltaX and deltaY are already present, they are read-only.
+        // Setting them would result browser error => zoom in/out feature broken.
+        if (e.deltaX === undefined)
+            e.deltaX = clientX_rel - this.last_mouse_position[0];
+        if (e.deltaY === undefined)
+            e.deltaY = clientY_rel- this.last_mouse_position[1];
 
         this.last_mouse_position[0] = clientX_rel;
         this.last_mouse_position[1] = clientY_rel;


### PR DESCRIPTION
`adjustMouseEvent` is trying to handle `PointerEvent` and `WheelEvent` at the same time. However, for `WheelEvent`, `deltaX` and `deltaY` are readonly attributes, so writing to them results an error.

![image](https://github.com/Comfy-Org/litegraph.js/assets/20929282/609f25e6-bfa5-44d1-9c83-8d7dd69ca807)

![image](https://github.com/Comfy-Org/litegraph.js/assets/20929282/7354e0c9-dd4a-431b-a06a-50409fff3491)


## References
- https://developer.mozilla.org/en-US/docs/Web/API/PointerEvent
- https://developer.mozilla.org/en-US/docs/Web/API/WheelEvent/deltaX
- https://github.com/Comfy-Org/ComfyUI_frontend/actions/runs/9814493426 (Scroll Test)