### PR TITLE
Fix event detail

### DIFF
--- a/src/litegraph.js
+++ b/src/litegraph.js
@@ -6196,7 +6196,7 @@ LGraphNode.prototype.executeAction = function(action)
                             {
                                 bubbles: true,
                                 detail: {
-                                    type: "empty-double-click",
+                                    subType: "empty-double-click",
                                     originalEvent: e,
                                 }
                             },


### PR DESCRIPTION
Fix event detail to match typescript schema declaration.

```ts
export type LiteGraphCanvasEvent = CustomEvent<{
    subType: string;
    originalEvent: Event,
    linkReleaseContext?: LinkReleaseContext;
}>;
```