### PR TITLE
Truncate overflowing combo widget text

### DIFF
--- a/src/litegraph.js
+++ b/src/litegraph.js
@@ -9965,9 +9965,18 @@ LGraphNode.prototype.executeAction = function(action)
                             if (textWidth > availableWidth) {
                                 const ellipsis = "...";
                                 const ellipsisWidth = ctx.measureText(ellipsis).width;
-                                if (availableWidth <= ellipsisWidth) {
+                                const maxCharWidth = ctx.measureText("W").width;
+                                if (availableWidth == 0) {
+                                    v = "";
+                                }
+                                else if (availableWidth <= ellipsisWidth) {
                                     v = ellipsis;
                                 } else {
+                                    const overflowWidth = (textWidth + ellipsisWidth) - availableWidth;
+                                    // Only last 3 truncated characters need to be measured for exact precision
+                                    if ( overflowWidth + maxCharWidth * 4 > availableWidth) {
+                                        v = v.substr(0, v.length - 3)
+                                    }
                                     while (ctx.measureText(v).width + ellipsisWidth > availableWidth) {
                                         v = v.substr(0, v.length - 1);
                                     }

--- a/src/litegraph.js
+++ b/src/litegraph.js
@@ -9963,14 +9963,11 @@ LGraphNode.prototype.executeAction = function(action)
                             const availableWidth = inputWidth - labelWidth
                             const textWidth = ctx.measureText(v).width;
                             if (textWidth > availableWidth) {
-                                const ellipsis = "...";
-                                const ellipsisWidth = ctx.measureText(ellipsis).width;
+                                const ELLIPSIS = "\u2026";
+                                const ellipsisWidth = ctx.measureText(ELLIPSIS).width;
                                 const maxCharWidth = ctx.measureText("W").width;
-                                if (availableWidth == 0) {
-                                    v = "";
-                                }
-                                else if (availableWidth <= ellipsisWidth) {
-                                    v = ellipsis;
+                                if (availableWidth <= ellipsisWidth) {
+                                    v = "\u2024"; // One dot leader
                                 } else {
                                     const overflowWidth = (textWidth + ellipsisWidth) - availableWidth;
                                     // Only last 3 truncated characters need to be measured for exact precision
@@ -9980,7 +9977,7 @@ LGraphNode.prototype.executeAction = function(action)
                                     while (ctx.measureText(v).width + ellipsisWidth > availableWidth) {
                                         v = v.substr(0, v.length - 1);
                                     }
-                                    v += ellipsis;
+                                    v += ELLIPSIS;
                                 }
                             } 
                             ctx.fillText(

--- a/src/litegraph.js
+++ b/src/litegraph.js
@@ -9965,14 +9965,16 @@ LGraphNode.prototype.executeAction = function(action)
                             if (textWidth > availableWidth) {
                                 const ELLIPSIS = "\u2026";
                                 const ellipsisWidth = ctx.measureText(ELLIPSIS).width;
-                                const maxCharWidth = ctx.measureText("W").width;
+                                const charWidthAvg = ctx.measureText("a").width;
                                 if (availableWidth <= ellipsisWidth) {
                                     v = "\u2024"; // One dot leader
                                 } else {
                                     const overflowWidth = (textWidth + ellipsisWidth) - availableWidth;
-                                    // Only last 3 truncated characters need to be measured for exact precision
-                                    if ( overflowWidth + maxCharWidth * 4 > availableWidth) {
-                                        v = v.substr(0, v.length - 3)
+                                    // Only first 3 characters need to be measured precisely
+                                    if ( overflowWidth + charWidthAvg * 3 > availableWidth) {
+                                        const preciseRange = availableWidth + charWidthAvg * 3;
+                                        const preTruncateCt = Math.floor((preciseRange - ellipsisWidth) / charWidthAvg);
+                                        v = v.substr(0, preTruncateCt)
                                     }
                                     while (ctx.measureText(v).width + ellipsisWidth > availableWidth) {
                                         v = v.substr(0, v.length - 1);

--- a/src/litegraph.js
+++ b/src/litegraph.js
@@ -9958,6 +9958,22 @@ LGraphNode.prototype.executeAction = function(action)
 								if(values && values.constructor !== Array)
 									v = values[ w.value ];
 							}
+                            const labelWidth = ctx.measureText(w.label || w.name).width + margin * 2;
+                            const inputWidth = widget_width - margin * 4
+                            const availableWidth = inputWidth - labelWidth
+                            const textWidth = ctx.measureText(v).width;
+                            if (textWidth > availableWidth) {
+                                const ellipsis = "...";
+                                const ellipsisWidth = ctx.measureText(ellipsis).width;
+                                if (availableWidth <= ellipsisWidth) {
+                                    v = ellipsis;
+                                } else {
+                                    while (ctx.measureText(v).width + ellipsisWidth > availableWidth) {
+                                        v = v.substr(0, v.length - 1);
+                                    }
+                                    v += ellipsis;
+                                }
+                            } 
                             ctx.fillText(
                                 v,
                                 widget_width - margin * 2 - 20,


### PR DESCRIPTION
Some widgets (combo, number) render overflowing text currently:

![Selection_045](https://github.com/user-attachments/assets/0b0a5336-0069-423a-b599-7acbc6f9dc99)

This change truncates the displayed text on the combo widgets, without changing the underlying values:


https://github.com/user-attachments/assets/e66bf60b-f505-4635-9235-d96a982a6d52