### PR TITLE
Prompt dialog improvements

### DIFF
--- a/src/litegraph.js
+++ b/src/litegraph.js
@@ -11455,14 +11455,16 @@ LGraphNode.prototype.executeAction = function(action)
         }, 10);
 
         setTimeout(function() {
-            canvas.parentNode.addEventListener("click", function onmouseclick(e) {
+            function handleEvent(e) {
                 if (e.target == canvas) {
                     dialog.close();
-                    canvas.parentNode.removeEventListener("click", onmouseclick);
                 }
-            });
+            }
+            const handlerOptions = { once: true, passive: true };
+            canvas.parentNode.addEventListener("click", handleEvent, handlerOptions);
+            canvas.parentNode.addEventListener("touchend", handleEvent, handlerOptions);
         }, 128);
-
+        
         return dialog;
     };
 

--- a/src/litegraph.js
+++ b/src/litegraph.js
@@ -11436,6 +11436,15 @@ LGraphNode.prototype.executeAction = function(action)
             input.focus();
         }, 10);
 
+        setTimeout(function() {
+            canvas.parentNode.addEventListener("click", function onmouseclick(e) {
+                if (e.target == canvas) {
+                    dialog.close();
+                    canvas.parentNode.removeEventListener("click", onmouseclick);
+                }
+            });
+        }, 128);
+
         return dialog;
     };
 

--- a/src/litegraph.js
+++ b/src/litegraph.js
@@ -11458,11 +11458,12 @@ LGraphNode.prototype.executeAction = function(action)
             function handleEvent(e) {
                 if (e.target == canvas) {
                     dialog.close();
+                    canvas.parentNode.removeEventListener("click", handleEvent);
+                    canvas.parentNode.removeEventListener("touchend", handleEvent);
                 }
             }
-            const handlerOptions = { once: true, passive: true };
-            canvas.parentNode.addEventListener("click", handleEvent, handlerOptions);
-            canvas.parentNode.addEventListener("touchend", handleEvent, handlerOptions);
+            canvas.parentNode.addEventListener("click", handleEvent, { passive: true });
+            canvas.parentNode.addEventListener("touchend", handleEvent, { passive: true });
         }, 128);
         
         return dialog;

--- a/src/litegraph.js
+++ b/src/litegraph.js
@@ -10151,8 +10151,8 @@ LGraphNode.prototype.executeAction = function(action)
                             const promptOptions = {
                                 inputType: "number",
                                 step: w.options.step || 1,
-                                min: w.options.min || -Infinity,
-                                max: w.options.max || Infinity,
+                                min: w.options.min ?? -Infinity,
+                                max: w.options.max ?? Infinity,
                             }
 							this.prompt("Value",w.value,function(v) {
 									// check if v is a valid equation or a number


### PR DESCRIPTION
- Use widget's type to set the type of dialog inputs. If it's a number, pass the `min`, `max`, and `step` options as well. From [ComfyUI#1612](https://github.com/comfyanonymous/ComfyUI/issues/1612)
    > Switching those inputs to type="number" and adding step="0.05" would show the arrows, and allow keyboard up/down arrows and mouse wheel to change the value in 0.05 increments/decrements. Also, min and max attributes can limit the values whenever needed. Having to manually type values while you could use the mouse wheel to change them is rather cumbersome.
    ![Selection_049](https://github.com/user-attachments/assets/3f185077-14a2-4734-8f5f-8fca68322fde)

- Close widget prompt dialogs by clicking canvas. From  [ComfyUI#90](https://github.com/comfyanonymous/ComfyUI/issues/90)

- Allow closing with touch event. Currently if the dialog is rendered offscreen on touch device, there is no way to get rid of it other than refreshing

- [ComfyUI#1023](https://github.com/comfyanonymous/ComfyUI/issues/1023) is also fixed