### PR TITLE
Fix empty input not used when connecting links

### DIFF
--- a/src/litegraph.js
+++ b/src/litegraph.js
@@ -4048,7 +4048,7 @@
 					if (aSource[sI]=="*") aSource[sI] = 0;
 					if (aDest[sI]=="*") aDest[sI] = 0;
 					if (aSource[sI] == aDest[dI]) {
-                        if (preferFreeSlot && aSlots[i].links && aSlots[i].links !== null) continue;
+                        if (preferFreeSlot && (aSlots[i].links && aSlots[i].links !== null) || (aSlots[i].link && aSlots[i].link !== null)) continue;
                         return !returnObj ? i : aSlots[i];
                     }
                 }


### PR DESCRIPTION
### UX improvement - drag/drop inputs
When dragging a link onto a node, it will always replace the first matching input type, unless you drop in the (respectively tiny) input hit box.

This commit fixes that, honouring the intended behaviour (preferFreeSlot is true in internal calls).

### Example - connecting positive / negative prompts
#### Positive prompt to sampler
![image](https://github.com/user-attachments/assets/166f3af3-4614-4b4e-9640-c8c21c0d8d37)
#### Negative prompt to sampler
![image](https://github.com/user-attachments/assets/d0f2484c-0bed-42d6-8e38-e5b7c35d857e)
#### Magic!
![image](https://github.com/user-attachments/assets/f36b9820-a060-4dc3-9fa7-b97a346a3a0e)

This _is_ a breaking change.  But you know, in the good way.