### PR TITLE
Fix undefined var 'cloned'

### DIFF
--- a/src/litegraph.js
+++ b/src/litegraph.js
@@ -5920,7 +5920,8 @@ LGraphNode.prototype.executeAction = function(action)
             // clone node ALT dragging
             if (LiteGraph.alt_drag_do_clone_nodes && e.altKey && node && this.allow_interaction && !skip_action && !this.read_only)
             {
-                if (cloned = node.clone()){
+                const cloned = node.clone()
+                if (cloned) {
                     cloned.pos[0] += 5;
                     cloned.pos[1] += 5;
                     this.graph.add(cloned,false,{doCalcSize: false});


### PR DESCRIPTION
Before we convert litegraph to module, the cloned was referencing field on the global window object.