### PR TITLE
Fix #42 - incorrect lines merged by hand

### DIFF
--- a/src/litegraph.js
+++ b/src/litegraph.js
@@ -6646,9 +6646,6 @@ LGraphNode.prototype.executeAction = function(action)
     	
     	//console.log("pointerevents: processMouseUp "+e.pointerId+" "+e.isPrimary+" :: "+e.clientX+" "+e.clientY);
     	
-		if( this.set_canvas_dirty_on_mouse_event )
-			this.dirty_canvas = true;
-
         if (!this.graph)
             return;
 

--- a/src/litegraph.js
+++ b/src/litegraph.js
@@ -6391,9 +6391,6 @@ LGraphNode.prototype.executeAction = function(action)
             this.resize();
         }
 
-		if( this.set_canvas_dirty_on_mouse_event )
-			this.dirty_canvas = true;
-
         if (!this.graph) {
             return;
         }
@@ -6651,6 +6648,9 @@ LGraphNode.prototype.executeAction = function(action)
     	
         if (!this.graph)
             return;
+
+		if( this.set_canvas_dirty_on_mouse_event )
+			this.dirty_canvas = true;
 
         var window = this.getCanvasWindow();
         var document = window.document;

--- a/src/litegraph.js
+++ b/src/litegraph.js
@@ -6646,11 +6646,11 @@ LGraphNode.prototype.executeAction = function(action)
     	
     	//console.log("pointerevents: processMouseUp "+e.pointerId+" "+e.isPrimary+" :: "+e.clientX+" "+e.clientY);
     	
-        if (!this.graph)
-            return;
-
 		if( this.set_canvas_dirty_on_mouse_event )
 			this.dirty_canvas = true;
+
+        if (!this.graph)
+            return;
 
         var window = this.getCanvasWindow();
         var document = window.document;


### PR DESCRIPTION
#42 removed two lines from `processMouseUp` - these were redundant, and can stay removed.

It should have been the identical lines from `processMouseMove` - removed by this PR