### PR TITLE
Add node slot mouseover effect

### DIFF
--- a/src/litegraph.js
+++ b/src/litegraph.js
@@ -5631,6 +5631,7 @@ LGraphNode.prototype.executeAction = function(action)
         // why mousemove and mouseup were not binded here?
         this._mousemove_callback = this.processMouseMove.bind(this);
         this._mouseup_callback = this.processMouseUp.bind(this);
+        this._mouseout_callback = this.processMouseOut.bind(this);
         
         //touch events -- TODO IMPLEMENT
         //this._touch_callback = this.touchHandler.bind(this);
@@ -5640,6 +5641,7 @@ LGraphNode.prototype.executeAction = function(action)
 
         LiteGraph.pointerListenerAdd(canvas,"up", this._mouseup_callback, true); // CHECK: ??? binded or not
 		LiteGraph.pointerListenerAdd(canvas,"move", this._mousemove_callback);
+		LiteGraph.pointerListenerAdd(canvas,"out", this._mouseout_callback);
         
         canvas.addEventListener("contextmenu", this._doNothing);
         canvas.addEventListener(
@@ -5689,6 +5691,7 @@ LGraphNode.prototype.executeAction = function(action)
         var ref_window = this.getCanvasWindow();
         var document = ref_window.document;
 
+		LiteGraph.pointerListenerRemove(this.canvas,"out", this._mouseout_callback);
 		LiteGraph.pointerListenerRemove(this.canvas,"move", this._mousedown_callback);
         LiteGraph.pointerListenerRemove(this.canvas,"up", this._mousedown_callback);
         LiteGraph.pointerListenerRemove(this.canvas,"down", this._mousedown_callback);
@@ -5838,6 +5841,33 @@ LGraphNode.prototype.executeAction = function(action)
 		this.block_click = true;
 		this.last_mouseclick = 0;
 	}
+
+    /**
+     * Clears highlight and mouse-over information from nodes that should not have it.
+     * 
+     * Intended to be called when the pointer moves away from a node.
+     * @param {LGraphNode} node The node that the mouse is now over
+     * @param {MouseEvent} e MouseEvent that is triggering this
+     */
+    LGraphCanvas.prototype.updateMouseOverNodes = function(node, e) {
+        const nodes = this.graph._nodes
+        const l = nodes.length
+        for (let i = 0; i < l; ++i) {
+            if (nodes[i].mouseOver && node != nodes[i]) {
+                //mouse leave
+                nodes[i].mouseOver = null;
+                this._highlight_input = null;
+                this._highlight_input_slot = null
+                this._highlight_output = null;
+
+                if (this.node_over && this.node_over.onMouseLeave) {
+                    this.node_over.onMouseLeave(e);
+                }
+                this.node_over = null;
+                this.dirty_canvas = true;
+            }
+        }
+    }
 	
     LGraphCanvas.prototype.processMouseDown = function(e) {
     	
@@ -6470,17 +6500,7 @@ LGraphNode.prototype.executeAction = function(action)
             }
 
             //remove mouseover flag
-            for (var i = 0, l = this.graph._nodes.length; i < l; ++i) {
-                if (this.graph._nodes[i].mouseOver && node != this.graph._nodes[i] ) {
-                    //mouse leave
-                    this.graph._nodes[i].mouseOver = false;
-                    if (this.node_over && this.node_over.onMouseLeave) {
-                        this.node_over.onMouseLeave(e);
-                    }
-                    this.node_over = null;
-                    this.dirty_canvas = true;
-                }
-            }
+            this.updateMouseOverNodes(node, e);
 
             //mouse over a node
             if (node) {
@@ -6488,16 +6508,31 @@ LGraphNode.prototype.executeAction = function(action)
 				if(node.redraw_on_mouse)
                     this.dirty_canvas = true;
 
+                // For input/output hovering
+                const pos = [0, 0]; //to store the output of isOverNodeInput
+                const inputId = this.isOverNodeInput(node, e.canvasX, e.canvasY, pos)
+                const outputId = this.isOverNodeOutput(node, e.canvasX, e.canvasY, pos);
+
                 //this.canvas.style.cursor = "move";
                 if (!node.mouseOver) {
                     //mouse enter
-                    node.mouseOver = true;
+                    node.mouseOver = {
+                        inputId: inputId,
+                        outputId: outputId
+                    }
                     this.node_over = node;
                     this.dirty_canvas = true;
 
                     if (node.onMouseEnter) {
                         node.onMouseEnter(e);
                     }
+                }
+
+                // The input the mouse is over has changed
+                if (node.mouseOver.inputId !== inputId || node.mouseOver.outputId !== outputId) {
+                    node.mouseOver.inputId = inputId
+                    node.mouseOver.outputId = outputId
+                    this.dirty_canvas = true
                 }
 
                 //in case the node wants to do something
@@ -6510,21 +6545,15 @@ LGraphNode.prototype.executeAction = function(action)
                     const firstLink = this.connecting_links[0];
                     
                     if (firstLink.output) {
-                        
-                        var pos = this._highlight_input || [0, 0]; //to store the output of isOverNodeInput
 
                         //on top of input
                         if (this.isOverNodeBox(node, e.canvasX, e.canvasY)) {
                             //mouse on top of the corner box, don't know what to do
                         } else {
                             //check if I have a slot below de mouse
-                            var slot = this.isOverNodeInput( node, e.canvasX, e.canvasY, pos );
-                            if (slot != -1 && node.inputs[slot]) {
-                                var slot_type = node.inputs[slot].type;
-                                if ( LiteGraph.isValidConnection( firstLink.output.type, slot_type ) ) {
-                                    this._highlight_input = pos;
-									this._highlight_input_slot = node.inputs[slot]; // XXX CHECK THIS
-                                }
+                            if (inputId != -1 && node.inputs[inputId] && LiteGraph.isValidConnection(firstLink.output.type, node.inputs[inputId].type)) {
+                                this._highlight_input = pos;
+                                this._highlight_input_slot = node.inputs[inputId]; // XXX CHECK THIS
                             } else {
                                 this._highlight_input = null;
 								this._highlight_input_slot = null;  // XXX CHECK THIS
@@ -6532,20 +6561,14 @@ LGraphNode.prototype.executeAction = function(action)
                         }
                         
                     }else if(firstLink.input){
-                        
-                        var pos = this._highlight_output || [0, 0]; //to store the output of isOverNodeOutput
 
                         //on top of output
                         if (this.isOverNodeBox(node, e.canvasX, e.canvasY)) {
                             //mouse on top of the corner box, don't know what to do
                         } else {
                             //check if I have a slot below de mouse
-                            var slot = this.isOverNodeOutput( node, e.canvasX, e.canvasY, pos );
-                            if (slot != -1 && node.outputs[slot]) {
-                                var slot_type = node.outputs[slot].type;
-                                if ( LiteGraph.isValidConnection( firstLink.input.type, slot_type ) ) {
-                                    this._highlight_output = pos;
-                                }
+                            if (outputId != -1 && node.outputs[outputId] && LiteGraph.isValidConnection(firstLink.input.type, node.outputs[outputId].type)) {
+                                this._highlight_output = pos;
                             } else {
                                 this._highlight_output = null;
                             }
@@ -6951,6 +6974,15 @@ LGraphNode.prototype.executeAction = function(action)
     };
 
     /**
+     * Called when the mouse moves off the canvas.  Clears all node hover states.
+     * @param {MouseEvent} e 
+     */
+    LGraphCanvas.prototype.processMouseOut = function(e) {
+        // TODO: Check if document.contains(e.relatedTarget) - handle mouseover node textarea etc.
+        this.updateMouseOverNodes(null, e)
+    }
+
+    /**
      * Called when a mouse wheel event has to be processed
      * @method processMouseWheel
      **/
@@ -7036,9 +7068,9 @@ LGraphNode.prototype.executeAction = function(action)
                         canvasx,
                         canvasy,
                         link_pos[0] - 10,
-                        link_pos[1] - 5,
-                        40,
-                        10
+                        link_pos[1] - 10,
+                        80,
+                        20
                     );
                 }
                 if (is_inside) {
@@ -7082,9 +7114,9 @@ LGraphNode.prototype.executeAction = function(action)
                         canvasx,
                         canvasy,
                         link_pos[0] - 10,
-                        link_pos[1] - 5,
+                        link_pos[1] - 10,
                         40,
-                        10
+                        20
                     );
                 }
                 if (is_inside) {
@@ -8632,11 +8664,10 @@ LGraphNode.prototype.executeAction = function(action)
                     var slot_type = slot.type;
                     var slot_shape = slot.shape;
                     
-                    ctx.globalAlpha = editor_alpha;
                     //change opacity of incompatible slots when dragging a connection
-                    if ( out_slot && !LiteGraph.isValidConnection( slot.type , out_slot.type) ) {
-                        ctx.globalAlpha = 0.4 * editor_alpha;
-                    }
+                    const isValid = !this.connecting_links || (out_slot && LiteGraph.isValidConnection(slot.type, out_slot.type))
+                    const isMouseOverSlot = node.mouseOver?.inputId === i
+                    ctx.globalAlpha = isValid ? editor_alpha : 0.4 * editor_alpha
 
                     ctx.fillStyle =
                         slot.link != null
@@ -8699,10 +8730,13 @@ LGraphNode.prototype.executeAction = function(action)
                         ctx.rect(pos[0] + 2, pos[1] + 2, 2, 2);
                         doStroke = false;
                     } else {
-						if(low_quality)
+						if (low_quality) {
 	                        ctx.rect(pos[0] - 4, pos[1] - 4, 8, 8 ); //faster
-						else
-	                        ctx.arc(pos[0], pos[1], 4, 0, Math.PI * 2);
+                        }
+						else {
+                            const radius = isValid && isMouseOverSlot ? 5 : 4
+                            ctx.arc(pos[0], pos[1], radius, 0, Math.PI * 2);
+                        }
                     }
                     ctx.fill();
 
@@ -8710,7 +8744,10 @@ LGraphNode.prototype.executeAction = function(action)
                     if (render_text) {
                         var text = slot.label != null ? slot.label : slot.name;
                         if (text) {
-                            ctx.fillStyle = LiteGraph.NODE_TEXT_COLOR;
+                            // Highlight text on mouseover unless we're connecting links.
+                            ctx.fillStyle = isValid && isMouseOverSlot
+                                ? lightenColorEased(LiteGraph.NODE_TEXT_COLOR, 0.2)
+                                : LiteGraph.NODE_TEXT_COLOR;
                             if (horizontal || slot.dir == LiteGraph.UP) {
                                 ctx.fillText(text, pos[0], pos[1] - 10);
                             } else {
@@ -8733,9 +8770,9 @@ LGraphNode.prototype.executeAction = function(action)
                     var slot_shape = slot.shape;
                     
                     //change opacity of incompatible slots when dragging a connection
-                    if (in_slot && !LiteGraph.isValidConnection( slot_type , in_slot.type) ) {
-                        ctx.globalAlpha = 0.4 * editor_alpha;
-                    }
+                    const isValid = !this.connecting_links || (in_slot && LiteGraph.isValidConnection(slot_type, in_slot.type))
+                    const isMouseOverSlot = node.mouseOver?.outputId === i
+                    ctx.globalAlpha = isValid ? editor_alpha : 0.4 * editor_alpha
                     
                     var pos = node.getConnectionPos(false, i, slot_pos);
                     pos[0] -= node.pos[0];
@@ -8798,10 +8835,13 @@ LGraphNode.prototype.executeAction = function(action)
                         ctx.rect(pos[0] + 2, pos[1] + 2, 2, 2);
                         doStroke = false;
                     } else {
-						if(low_quality)
+						if (low_quality) {
 	                        ctx.rect(pos[0] - 4, pos[1] - 4, 8, 8 );
-						else
-	                        ctx.arc(pos[0], pos[1], 4, 0, Math.PI * 2);
+                        }
+						else {
+                            const radius = isValid && isMouseOverSlot ? 5 : 4
+	                        ctx.arc(pos[0], pos[1], radius, 0, Math.PI * 2);
+                        }
                     }
 
                     //trigger
@@ -8817,7 +8857,10 @@ LGraphNode.prototype.executeAction = function(action)
                     if (render_text) {
                         var text = slot.label != null ? slot.label : slot.name;
                         if (text) {
-                            ctx.fillStyle = LiteGraph.NODE_TEXT_COLOR;
+                            // Highlight text on mouseover unless we're connecting links.
+                            ctx.fillStyle = isValid && isMouseOverSlot
+                                ? lightenColorEased(LiteGraph.NODE_TEXT_COLOR, 0.2)
+                                : LiteGraph.NODE_TEXT_COLOR;
                             if (horizontal || slot.dir == LiteGraph.DOWN) {
                                 ctx.fillText(text, pos[0], pos[1] - 8);
                             } else {


### PR DESCRIPTION
Does things:
- Hover effects added for node inputs and outputs
- Adds "mouseout" handler to properly clear node state when mousing off a node
- Fixes bug that causes outputs to always be dimmed out when connecting from inputs
- Slight performance improvement

This is in draft because there is a circular dependency - I used code from `ComfyUI_frontend` -> `colorUtil.ts` instead of reinventing the wheel.

I also altered `lightenColor` to be a little closer to human expectation: the difference between black and black + 20% should "feel" roughly like it does for +20% on lighter colours.

The bad stuff is all in a separate commit.  The main commit just requires a function called `lightenColorEased` with the same declaration as `lightenColor`.