### PR TITLE
`centerOnNode` use DPI

### DIFF
--- a/src/litegraph.js
+++ b/src/litegraph.js
@@ -7614,14 +7614,15 @@ LGraphNode.prototype.executeAction = function(action)
      * @method centerOnNode
      **/
     LGraphCanvas.prototype.centerOnNode = function(node) {
+        const dpi = window?.devicePixelRatio || 1;
         this.ds.offset[0] =
             -node.pos[0] -
             node.size[0] * 0.5 +
-            (this.canvas.width * 0.5) / this.ds.scale;
+            (this.canvas.width * 0.5) / (this.ds.scale * dpi);
         this.ds.offset[1] =
             -node.pos[1] -
             node.size[1] * 0.5 +
-            (this.canvas.height * 0.5) / this.ds.scale;
+            (this.canvas.height * 0.5) / (this.ds.scale * dpi);
         this.setDirty(true, true);
     };
 


### PR DESCRIPTION
`LGraphCanvas.centerOnNode` is used by various extensions. Currently it does not work when browser is zoomed in/out or DPI is not otherwise 1.

Related: 
- comfyanonymous/ComfyUI@4796e61