### PR TITLE
Fix deselect delete

### DIFF
--- a/src/litegraph.js
+++ b/src/litegraph.js
@@ -7517,6 +7517,7 @@ LGraphNode.prototype.executeAction = function(action)
             node.onDeselected();
         }
         node.is_selected = false;
+        delete this.selected_nodes[node.id]
 
         if (this.onNodeDeselected) {
             this.onNodeDeselected(node);

--- a/src/litegraph.js
+++ b/src/litegraph.js
@@ -6175,7 +6175,10 @@ LGraphNode.prototype.executeAction = function(action)
 							this.graph.beforeChange();
                             this.node_dragged = node;
                         }
-                        this.processNodeSelected(node, e);
+                        // Account for shift + click + drag
+                        if (!(e.shiftKey && !e.ctrlKey && !e.altKey) || !node.is_selected) {
+                            this.processNodeSelected(node, e);
+                        }
                     } else { // double-click
                         /**
                          * Don't call the function if the block is already selected.


### PR DESCRIPTION
Fixes issue: **de**selecting nodes (`shift + click` or `ctrl + click`) only deselects them visually.  The nodes are still selected.  Example:
- Select 3 nodes
- Deselect two nodes using `ctrl + click`
- Press `Delete`
- Three nodes are deleted

https://github.com/user-attachments/assets/a589ba35-facf-4120-a36f-8b8d8d1334ac

