### PR TITLE
let node label field for node panel translation

### DIFF
--- a/src/litegraph.js
+++ b/src/litegraph.js
@@ -9195,7 +9195,7 @@ LGraphNode.prototype.executeAction = function(action)
             }
             if (!low_quality) {
                 ctx.font = this.title_text_font;
-                var title = String(node.getTitle());
+                var title = String(node.label || node.getTitle());
                 if (title) {
                     if (selected) {
                         ctx.fillStyle = LiteGraph.NODE_SELECTED_TITLE_COLOR;


### PR DESCRIPTION
Due to the fact that many third-party custom_nodes use getTitle() to implement predetermined logic, we cannot use the title field for node panel translation. Therefore, we have added the label as a translation field here.
See this problem we encountered:
https://github.com/AIGODLIKE/AIGODLIKE-ComfyUI-Translation/issues/255