### PR TITLE
Remove unnecessary compatibility layer

### DIFF
--- a/src/litegraph.js
+++ b/src/litegraph.js
@@ -2226,14 +2226,7 @@ const globalExport = {};
             //TODO
         }
     }
-    // Backward Compatibility for extending the functionality via prototype.
-    function LegacyLGraph(...args) {
-        return new LGraph(...args);
-    }
-    LegacyLGraph.prototype = LGraph.prototype;
-
-    globalThis.LGraph = LGraph;
-    globalThis.LegacyLGraph = LiteGraph.LGraph = LegacyLGraph;
+    globalThis.LGraph = LiteGraph.LGraph = LGraph;
 
     //this is the class in charge of storing link information
     function LLink(id, type, origin_id, origin_slot, target_id, target_slot) {
@@ -14455,8 +14448,7 @@ LGraphNode.prototype.executeAction = function(action)
 })(globalExport)
 
 export const LiteGraph = globalExport.LiteGraph;
-export const LGraphES6 = globalExport.LGraph;
-export const LGraph = globalExport.LegacyLGraph;
+export const LGraph = globalExport.LGraph;
 export const LLink = globalExport.LLink;
 export const LGraphNode = globalExport.LGraphNode;
 export const LGraphGroup = globalExport.LGraphGroup;

--- a/test/LGraph.test.ts
+++ b/test/LGraph.test.ts
@@ -1,39 +1,24 @@
 import {
-  LGraphES6 as LGraph,
-  LGraph as LegacyLGraph,
+  LGraph,
   LiteGraph,
 } from "../dist/litegraph.es.js";
 
 describe("LegacyLGraph Compatibility Layer", () => {
-  test("LegacyLGraph can be instantiated", () => {
-    const graph = new LegacyLGraph({extra: "TestGraph"});
+  test("LGraph can be instantiated", () => {
+    const graph = new LGraph({extra: "TestGraph"});
     expect(graph).toBeInstanceOf(LGraph);
-    expect(graph).toBeInstanceOf(LegacyLGraph);
     expect(graph.extra).toBe("TestGraph");
   });
 
-  test("LegacyLGraph can be extended via prototype", () => {
-    LegacyLGraph.prototype.newMethod = function () {
+  test("LGraph can be extended via prototype", () => {
+    const graph = new LGraph();
+    LGraph.prototype.newMethod = function () {
       return "New method added via prototype";
     };
-
-    const graph = new LegacyLGraph();
     expect(graph.newMethod()).toBe("New method added via prototype");
   });
 
-  test("Extensions to LegacyLGraph affect LGraph instances", () => {
-    LegacyLGraph.prototype.anotherMethod = function () {
-      return "Another method";
-    };
-
-    const legacyGraph = new LegacyLGraph();
-    const normalGraph = new LGraph();
-
-    expect(legacyGraph.anotherMethod()).toBe("Another method");
-    expect(normalGraph.anotherMethod()).toBe("Another method");
-  });
-
   test("LegacyLGraph is correctly assigned to LiteGraph", () => {
-    expect(LiteGraph.LGraph).toBe(LegacyLGraph);
+    expect(LiteGraph.LGraph).toBe(LGraph);
   });
 });


### PR DESCRIPTION
It seems like if we are not in strict mode, directly write class's prototype is fine. Note: ComfyUI_frontend is no where close to turning on strict mode.