### PR TITLE
Avoid sort nodes in place

### DIFF
--- a/src/litegraph.js
+++ b/src/litegraph.js
@@ -2044,7 +2044,7 @@ const globalExport = {};
              */
         serialize() {
             var nodes_info = [];
-            nodes_info = this._nodes.sort((a, b) => a.id - b.id).map(node => node.serialize());
+            nodes_info = [...this._nodes].sort((a, b) => a.id - b.id).map(node => node.serialize());
 
             //pack link info into a non-verbose format
             var links = [];


### PR DESCRIPTION
JavaScript's sort function sorts nodes in place, which causes a side effect on the graph when calling `serialize`. This PR prevents this side effect.