### PR TITLE
Fix truncating non-string combo widgets

### DIFF
--- a/src/litegraph.js
+++ b/src/litegraph.js
@@ -9937,6 +9937,7 @@ LGraphNode.prototype.executeAction = function(action)
                                 if (availableWidth <= ellipsisWidth) {
                                     v = "\u2024"; // One dot leader
                                 } else {
+                                    v = `${v}`
                                     const overflowWidth = (textWidth + ellipsisWidth) - availableWidth;
                                     // Only first 3 characters need to be measured precisely
                                     if ( overflowWidth + charWidthAvg * 3 > availableWidth) {


### PR DESCRIPTION
Text truncate in combo widgets was not converting to string before attempting to truncate. If there were combos of numbers or objects and they exceeded the available space, it tried to call `substr` and the entire graph breaks.

After fix it works with all types:


https://github.com/user-attachments/assets/b18b4e47-0a71-4195-92e8-30297c1f903c

