### PR TITLE
Make node id serialization optional

### DIFF
--- a/public/litegraph.d.ts
+++ b/public/litegraph.d.ts
@@ -584,7 +584,7 @@ export declare class LGraph {
     /** Destroys a link */
     removeLink(link_id: number): void;
     /** Creates a Object containing all the info about this graph, it can be serialized */
-    serialize<T extends serializedLGraph>(): T;
+    serialize<T extends serializedLGraph>(option?: { sortNodes: boolean }): T;
     /**
      * Configure a graph from a JSON string
      * @param data configure a graph from a JSON string

--- a/src/litegraph.js
+++ b/src/litegraph.js
@@ -2042,9 +2042,13 @@ const globalExport = {};
              * @method serialize
              * @return {Object} value of the node
              */
-        serialize() {
+        serialize(option = { sortNodes: false }) {
             var nodes_info = [];
-            nodes_info = [...this._nodes].sort((a, b) => a.id - b.id).map(node => node.serialize());
+            nodes_info = (
+                option?.sortNodes ?
+                [...this._nodes].sort((a, b) => a.id - b.id) :
+                this._nodes
+            ).map(node => node.serialize());
 
             //pack link info into a non-verbose format
             var links = [];


### PR DESCRIPTION
Related issue: https://github.com/Comfy-Org/ComfyUI_frontend/issues/438

Some users specifically want a certain node order on serialization because the node order defines which node is displayed in front of which when 2 or more nodes overlay with each other. This PR makes sort optional and not sort by default.