### PR TITLE
Create link from link by shift+clicking

### DIFF
--- a/src/litegraph.js
+++ b/src/litegraph.js
@@ -6123,49 +6123,49 @@ LGraphNode.prototype.executeAction = function(action)
             else {
 				if (!skip_action){
 					//search for link connector
-                    if (!this.read_only) {
-                        // Set the width of the line for isPointInStroke checks
-                        const lineWidth = this.ctx.lineWidth;
-                        this.ctx.lineWidth = this.connections_width + 7;
+					if (!this.read_only) {
+						// Set the width of the line for isPointInStroke checks
+						const lineWidth = this.ctx.lineWidth;
+						this.ctx.lineWidth = this.connections_width + 7;
 
 						for (var i = 0; i < this.visible_links.length; ++i) {
 							var link = this.visible_links[i];
-                            var center = link._pos;
-                            let overLink = null;
+							var center = link._pos;
+							let overLink = null;
 							if (
 								!center ||
 								e.canvasX < center[0] - 4 ||
 								e.canvasX > center[0] + 4 ||
 								e.canvasY < center[1] - 4 ||
 								e.canvasY > center[1] + 4
-                            ) {
-                                // If we shift click on a link then start a link from that input
-                                if (e.shiftKey && link.path && this.ctx.isPointInStroke(link.path, e.canvasX, e.canvasY)) {
-                                    overLink = link;
-                                } else {
-                                    continue;
-                                }
-                            }
-                            
-                            if (overLink) {
-                                const slot = overLink.origin_slot;
-                                const originNode = this.graph._nodes_by_id[overLink.origin_id];
+							) {
+								// If we shift click on a link then start a link from that input
+								if (e.shiftKey && link.path && this.ctx.isPointInStroke(link.path, e.canvasX, e.canvasY)) {
+									overLink = link;
+								} else {
+									continue;
+								}
+							}
+							
+							if (overLink) {
+								const slot = overLink.origin_slot;
+								const originNode = this.graph._nodes_by_id[overLink.origin_id];
 
-                                if (!this.connecting_links) this.connecting_links = []
-                                this.connecting_links.push({
-                                    node: originNode,
-                                    slot,
-                                    output: originNode.outputs[slot],
-                                    pos: originNode.getConnectionPos(false, slot),
-                                });
-                                skip_action = true;
-                            } else {
-                                //link clicked
-                                this.showLinkMenu(link, e);
-                                this.over_link_center = null; //clear tooltip
-                            }
+								if (!this.connecting_links) this.connecting_links = []
+								this.connecting_links.push({
+									node: originNode,
+									slot,
+									output: originNode.outputs[slot],
+									pos: originNode.getConnectionPos(false, slot),
+								});
+								skip_action = true;
+							} else {
+								//link clicked
+								this.showLinkMenu(link, e);
+								this.over_link_center = null; //clear tooltip
+							}
 							break;
-                        }
+						}
                         
                         // Restore line width
                         this.ctx.lineWidth = lineWidth;

--- a/src/litegraph.js
+++ b/src/litegraph.js
@@ -6123,24 +6123,52 @@ LGraphNode.prototype.executeAction = function(action)
             else {
 				if (!skip_action){
 					//search for link connector
-					if(!this.read_only) {
+                    if (!this.read_only) {
+                        // Set the width of the line for isPointInStroke checks
+                        const lineWidth = this.ctx.lineWidth;
+                        this.ctx.lineWidth = this.connections_width + 7;
+
 						for (var i = 0; i < this.visible_links.length; ++i) {
 							var link = this.visible_links[i];
-							var center = link._pos;
+                            var center = link._pos;
+                            let overLink = null;
 							if (
 								!center ||
 								e.canvasX < center[0] - 4 ||
 								e.canvasX > center[0] + 4 ||
 								e.canvasY < center[1] - 4 ||
 								e.canvasY > center[1] + 4
-							) {
-								continue;
-							}
-							//link clicked
-							this.showLinkMenu(link, e);
-							this.over_link_center = null; //clear tooltip
+                            ) {
+                                // If we shift click on a link then start a link from that input
+                                if (e.shiftKey && link.path && this.ctx.isPointInStroke(link.path, e.canvasX, e.canvasY)) {
+                                    overLink = link;
+                                } else {
+                                    continue;
+                                }
+                            }
+                            
+                            if (overLink) {
+                                const slot = overLink.origin_slot;
+                                const originNode = this.graph._nodes_by_id[overLink.origin_id];
+
+                                if (!this.connecting_links) this.connecting_links = []
+                                this.connecting_links.push({
+                                    node: originNode,
+                                    slot,
+                                    output: originNode.outputs[slot],
+                                    pos: originNode.getConnectionPos(false, slot),
+                                });
+                                skip_action = true;
+                            } else {
+                                //link clicked
+                                this.showLinkMenu(link, e);
+                                this.over_link_center = null; //clear tooltip
+                            }
 							break;
-						}
+                        }
+                        
+                        // Restore line width
+                        this.ctx.lineWidth = lineWidth;
 					}
 
 					this.selected_group = this.graph.getGroupOnPos( e.canvasX, e.canvasY );
@@ -9432,12 +9460,17 @@ LGraphNode.prototype.executeAction = function(action)
         }
 
         //begin line shape
-        ctx.beginPath();
+        const path = new Path2D();
+        if (link) {
+            // Store the path on the link for hittests
+            link.path = path;
+        }
+
         for (var i = 0; i < num_sublines; i += 1) {
             var offsety = (i - (num_sublines - 1) * 0.5) * 5;
 
             if (this.links_render_mode == LiteGraph.SPLINE_LINK) {
-                ctx.moveTo(a[0], a[1] + offsety);
+                path.moveTo(a[0], a[1] + offsety);
                 var start_offset_x = 0;
                 var start_offset_y = 0;
                 var end_offset_x = 0;
@@ -9470,7 +9503,7 @@ LGraphNode.prototype.executeAction = function(action)
                         end_offset_y = dist * 0.25;
                         break;
                 }
-                ctx.bezierCurveTo(
+                path.bezierCurveTo(
                     a[0] + start_offset_x,
                     a[1] + start_offset_y + offsety,
                     b[0] + end_offset_x,
@@ -9479,7 +9512,7 @@ LGraphNode.prototype.executeAction = function(action)
                     b[1] + offsety
                 );
             } else if (this.links_render_mode == LiteGraph.LINEAR_LINK) {
-                ctx.moveTo(a[0], a[1] + offsety);
+                path.moveTo(a[0], a[1] + offsety);
                 var start_offset_x = 0;
                 var start_offset_y = 0;
                 var end_offset_x = 0;
@@ -9513,17 +9546,17 @@ LGraphNode.prototype.executeAction = function(action)
                         break;
                 }
                 var l = 15;
-                ctx.lineTo(
+                path.lineTo(
                     a[0] + start_offset_x * l,
                     a[1] + start_offset_y * l + offsety
                 );
-                ctx.lineTo(
+                path.lineTo(
                     b[0] + end_offset_x * l,
                     b[1] + end_offset_y * l + offsety
                 );
-                ctx.lineTo(b[0], b[1] + offsety);
+                path.lineTo(b[0], b[1] + offsety);
             } else if (this.links_render_mode == LiteGraph.STRAIGHT_LINK) {
-                ctx.moveTo(a[0], a[1]);
+                path.moveTo(a[0], a[1]);
                 var start_x = a[0];
                 var start_y = a[1];
                 var end_x = b[0];
@@ -9538,11 +9571,11 @@ LGraphNode.prototype.executeAction = function(action)
                 } else {
                     end_y -= 10;
                 }
-                ctx.lineTo(start_x, start_y);
-                ctx.lineTo((start_x + end_x) * 0.5, start_y);
-                ctx.lineTo((start_x + end_x) * 0.5, end_y);
-                ctx.lineTo(end_x, end_y);
-                ctx.lineTo(b[0], b[1]);
+                path.lineTo(start_x, start_y);
+                path.lineTo((start_x + end_x) * 0.5, start_y);
+                path.lineTo((start_x + end_x) * 0.5, end_y);
+                path.lineTo(end_x, end_y);
+                path.lineTo(b[0], b[1]);
             } else {
                 return;
             } //unknown
@@ -9555,12 +9588,12 @@ LGraphNode.prototype.executeAction = function(action)
             !skip_border
         ) {
             ctx.strokeStyle = "rgba(0,0,0,0.5)";
-            ctx.stroke();
+            ctx.stroke(path);
         }
 
         ctx.lineWidth = this.connections_width;
         ctx.fillStyle = ctx.strokeStyle = color;
-        ctx.stroke();
+        ctx.stroke(path);
         //end line shape
 
         var pos = this.computeConnectionPoint(a, b, 0.5, start_dir, end_dir);

--- a/src/litegraph.js
+++ b/src/litegraph.js
@@ -6167,8 +6167,8 @@ LGraphNode.prototype.executeAction = function(action)
 							break;
 						}
                         
-                        // Restore line width
-                        this.ctx.lineWidth = lineWidth;
+						// Restore line width
+						this.ctx.lineWidth = lineWidth;
 					}
 
 					this.selected_group = this.graph.getGroupOnPos( e.canvasX, e.canvasY );


### PR DESCRIPTION
Allows dragging new links from existing ones, useful when the origin node is a long way away.
Requires shift+click as it requires extra hit tests and didn't want to annoy people who are used to being able to click there to pan the canvas.

[rec.webm](https://github.com/user-attachments/assets/7e73aaf9-79e2-4c3c-a26a-911cba3b85e4)
