### PR TITLE
Close prompt dialog popup on outer canvas click

### DIFF
--- a/src/litegraph.js
+++ b/src/litegraph.js
@@ -11431,6 +11431,15 @@ LGraphNode.prototype.executeAction = function(action)
 
         setTimeout(function() {
             input.focus();
+            function handleOutsideClick(e) {
+                if (e.target === canvas) {
+                    dialog.close();
+                    canvas.parentNode.removeEventListener("click", handleOutsideClick);
+                    canvas.parentNode.removeEventListener("touchend", handleOutsideClick);
+                }
+            }
+            canvas.parentNode.addEventListener("click", handleOutsideClick);
+            canvas.parentNode.addEventListener("touchend", handleOutsideClick);
         }, 10);
 
         return dialog;


### PR DESCRIPTION
Close prompt dialogs by clicking elsewhere on canvas, consistent with how the litegraph context menus work. Currrently you have to click the `OK` button. Escape/Enter also work, but not if the element loses focus. 

Resolves an issue on touch devices in which the `OK` button is rendered offscreen and the dialog is seemingly impossible to dismiss. 

Touch device:

https://github.com/user-attachments/assets/4851a5ea-bf55-4a40-b38f-42eb70781553

Chrome and Firefox:


https://github.com/user-attachments/assets/dc6472e0-774e-4ab2-8972-c24830e8e21c

Related:

- comfyanonymous/ComfyUI#90
