### PR TITLE
Increase timeout on prompt dialog dismiss

### DIFF
--- a/.github/workflows/test-comfyui-frontend.yml
+++ b/.github/workflows/test-comfyui-frontend.yml
@@ -35,6 +35,12 @@ jobs:
         repository: "Comfy-Org/ComfyUI_frontend"
         path: "ComfyUI_frontend"
 
+    - name: Checkout ComfyUI_devtools
+      uses: actions/checkout@v4
+      with:
+        repository: "Comfy-Org/ComfyUI_devtools"
+        path: "ComfyUI/custom_nodes/ComfyUI_devtools"
+
     - name: Checkout ComfyUI_examples
       uses: actions/checkout@v4
       with:

--- a/src/litegraph.js
+++ b/src/litegraph.js
@@ -11432,8 +11432,9 @@ LGraphNode.prototype.executeAction = function(action)
 
         setTimeout(function() {
             input.focus();
+            const clickTime = Date.now();
             function handleOutsideClick(e) {
-                if (e.target === canvas) {
+                if (e.target === canvas && Date.now() - clickTime > 256) {
                     dialog.close();
                     canvas.parentNode.removeEventListener("click", handleOutsideClick);
                     canvas.parentNode.removeEventListener("touchend", handleOutsideClick);


### PR DESCRIPTION
Occasionally the click event that opened the prompt dialog will be caught by the close click handler and the dialog will be dismissed immediately, making it unusable.

It was not caught by tests because it only seems to happen when the input type is `STRING`.