### PR TITLE
Fix LGraphNode.pos serialization

### DIFF
--- a/src/litegraph.js
+++ b/src/litegraph.js
@@ -2348,8 +2348,8 @@ const globalExport = {};
             this.title = title || "Unnamed";
             this.size = [LiteGraph.NODE_WIDTH, 60];
             this.graph = null;
-
-            this._pos = new Float32Array(10, 10);
+            // Initialize _pos with a Float32Array of length 2, default value [10, 10]
+            this._pos = new Float32Array([10, 10]);
 
             Object.defineProperty(this, "pos", {
                 set: function (v) {

--- a/test/LGraphNode.test.ts
+++ b/test/LGraphNode.test.ts
@@ -1,0 +1,12 @@
+import {
+  LGraphNode,
+} from "../dist/litegraph.es.js";
+
+describe("LGraphNode", () => {
+  it("should serialize position correctly", () => {
+    const node = new LGraphNode("TestNode");
+    node.pos = [10, 10];
+    expect(node.pos).toEqual(new Float32Array([10, 10]));
+    expect(node.serialize().pos).toEqual(new Float32Array([10, 10]));
+  });
+});


### PR DESCRIPTION
Related issue: https://github.com/Comfy-Org/ComfyUI_frontend/issues/710

The issue has been there for a long while, only surfaced by the previous refactor on node construction in #98. The code in question is creating a float array of length 10, while the real intention should be create a float array that initializes to [10, 10].