### PR TITLE
Fix blurry links on HiDPI screen

### DIFF
--- a/src/litegraph.js
+++ b/src/litegraph.js
@@ -8666,7 +8666,8 @@ const globalExport = {};
             if (this.bgcanvas == this.canvas) {
                 this.drawBackCanvas();
             } else {
-                ctx.drawImage(this.bgcanvas, 0, 0);
+                let scale = window.devicePixelRatio;
+                ctx.drawImage(this.bgcanvas, 0, 0, this.bgcanvas.width / scale, this.bgcanvas.height / scale);
             }
 
             //rendering
@@ -9172,8 +9173,9 @@ const globalExport = {};
 
             //reset in case of error
             if (!this.viewport) {
+                let scale = window.devicePixelRatio;
                 ctx.restore();
-                ctx.setTransform(1, 0, 0, 1, 0, 0);
+                ctx.setTransform(scale, 0, 0, scale, 0, 0);
             }
             this.visible_links.length = 0;
 


### PR DESCRIPTION
Close: #123 

This bug is because we only scale the foreground canvas, but not the background canvas.

**Before** ![image](https://github.com/user-attachments/assets/06f9afb6-fa1a-4ab4-9da2-dadfe216f75b) **After**![image](https://github.com/user-attachments/assets/bb1d799c-c129-4f9e-8f94-ef2d5f8679f6)