### PR TITLE
Fix legacy searchbox autofocus on Firefox

### DIFF
--- a/src/litegraph.js
+++ b/src/litegraph.js
@@ -11928,7 +11928,9 @@ const globalExport = {};
             }
             canvas.parentNode.appendChild(dialog);
             */
-            input.focus();
+            requestAnimationFrame(function () {
+              input.focus();
+            });
             if (options.show_all_on_open) refreshHelper();
 
             function select(name) {


### PR DESCRIPTION
Fixes Comfy-Org/ComfyUI_frontend#751

Using the new frontend on Firefox, the legacy searchbox's input cannot be focused immediately. It is fixed by delaying the focus.