### PR TITLE
Fix canvas zoom centre not centred on pointer

### DIFF
--- a/src/DragAndScale.ts
+++ b/src/DragAndScale.ts
@@ -222,6 +222,8 @@ export class DragAndScale {
     if (!rect) return
 
     zooming_center = zooming_center || [rect.width * 0.5, rect.height * 0.5]
+    zooming_center[0] -= rect.x
+    zooming_center[1] -= rect.y
     const center = this.convertCanvasToOffset(zooming_center)
     this.scale = value
     if (Math.abs(this.scale - 1) < 0.01) this.scale = 1


### PR DESCRIPTION
Current behaviour impacts any canvas where canvas element top,left != client area 0,0

Zoom bad:

https://github.com/user-attachments/assets/7b82ba41-1d8f-4ec3-ae75-e103ff10bec6

Zoom good:

https://github.com/user-attachments/assets/25c7e598-20a7-4e8e-8238-d50d5db0d1ad