### PR TITLE
Add getters to LGraph private fields

### DIFF
--- a/public/litegraph.d.ts
+++ b/public/litegraph.d.ts
@@ -435,6 +435,13 @@ export declare class LGraph {
     private _nodes_in_order: LGraphNode[];
     private _version: number;
 
+    get nodes(): LGraphNode[];
+    get groups(): LGraphGroup[];
+    get nodes_by_id(): Record<number, LGraphNode>;
+    get nodes_executable(): (LGraphNode & { onExecute: NonNullable<LGraphNode["onExecute"]> }[] | null);
+    get nodes_in_order(): LGraphNode[];
+    get version(): number;
+
     getSupportedTypes(): string[];
     /** Removes all nodes from this graph */
     clear(): void;

--- a/src/litegraph.js
+++ b/src/litegraph.js
@@ -868,6 +868,31 @@ const globalExport = {};
 
             this.sendActionToCanvas("clear");
         }
+
+        get nodes() {
+            return this._nodes;
+        }
+
+        get groups() {
+            return this._groups;
+        }
+
+        get nodes_by_id() {
+            return this._nodes_by_id;
+        }
+
+        get nodes_executable() {
+            return this._nodes_executable;
+        }
+
+        get nodes_in_order() {
+            return this._nodes_in_order;
+        }
+
+        get version() {
+            return this._version;
+        }
+
         /**
              * Attach Canvas to this graph
              * @method attachCanvas


### PR DESCRIPTION
Expose LGraph's internals private fields with getters so that they becomes observable from outside. Avoid ts-ignore in ComfyUI frontend.