### PR TITLE
Allow shift+click on input to create new link from origin node

### DIFF
--- a/src/litegraph.js
+++ b/src/litegraph.js
@@ -7046,16 +7046,24 @@ const globalExport = {};
 
                                         if (input.link !== null) {
                                             var link_info = this.graph.links[input.link]; //before disconnecting
+                                            const slot = link_info.origin_slot;
+                                            const linked_node = this.graph._nodes_by_id[link_info.origin_id];
                                             if (LiteGraph.click_do_break_link_to || (LiteGraph.ctrl_alt_click_do_break_link && e.ctrlKey && e.altKey && !e.shiftKey)) {
                                                 node.disconnectInput(i);
-                                            } else if (this.allow_reconnect_links ||
-                                                //this.move_destination_link_without_shift ||
-                                                e.shiftKey) {
+                                            } else if (e.shiftKey) {
+                                                this.connecting_links = [{
+                                                    node: linked_node,
+                                                    slot,
+                                                    output: linked_node.outputs[slot],
+                                                    pos: linked_node.getConnectionPos(false, slot),
+                                                }]
+
+                                                this.dirty_bgcanvas = true;
+                                                skip_action = true;
+                                            } else if (this.allow_reconnect_links) {
                                                 if (!LiteGraph.click_do_break_link_to) {
                                                     node.disconnectInput(i);
                                                 }
-                                                const linked_node = this.graph._nodes_by_id[link_info.origin_id];
-                                                const slot = link_info.origin_slot;
                                                 this.connecting_links = [
                                                     {
                                                         node: linked_node,


### PR DESCRIPTION
Supports shift+click on the input slot to create a new link from the origin node