### PR TITLE
Fix drag-select on Mac

### DIFF
--- a/src/LGraphCanvas.ts
+++ b/src/LGraphCanvas.ts
@@ -3176,7 +3176,7 @@ export class LGraphCanvas {
         this.setDirty(true);
     }
     processNodeSelected(node, e) {
-        this.selectNode(node, e && (e.shiftKey || e.ctrlKey || this.multi_select));
+        this.selectNode(node, e && (e.shiftKey || e.metaKey || e.ctrlKey || this.multi_select));
         if (this.onNodeSelected) {
             this.onNodeSelected(node);
         }

--- a/src/LGraphCanvas.ts
+++ b/src/LGraphCanvas.ts
@@ -1608,7 +1608,7 @@ export class LGraphCanvas {
 
         //left button mouse / single finger
         if (e.which == 1 && !this.pointer_is_double) {
-            if (e.ctrlKey && !e.altKey) {
+            if ((e.metaKey || e.ctrlKey) && !e.altKey) {
                 this.dragging_rectangle = new Float32Array(4);
                 this.dragging_rectangle[0] = e.canvasX;
                 this.dragging_rectangle[1] = e.canvasY;


### PR DESCRIPTION
For Mac+Firefox users, allow meta key to be used to drag-select multiple nodes.

Resolves Issues

- https://github.com/Comfy-Org/ComfyUI_frontend/issues/1033
- https://github.com/comfyanonymous/ComfyUI/issues/4984

Also mentioned in:

- https://github.com/Comfy-Org/ComfyUI_frontend/issues/1032
- (Comment) https://github.com/comfyanonymous/ComfyUI/issues/1016#issuecomment-1656755686

Tested with playwright:

![Selection_441](https://github.com/user-attachments/assets/7a24443f-e5b6-4d5b-99f7-822e1763b062)