### PR TITLE
Fix adding node to selection with Ctrl+Click on Mac

### DIFF
--- a/src/LGraphCanvas.ts
+++ b/src/LGraphCanvas.ts
@@ -2552,7 +2552,7 @@ export class LGraphCanvas {
                         }
                     } else {
                         // will select of update selection
-                        this.selectNodes([node], e.shiftKey || e.ctrlKey); // add to selection add to selection with ctrlKey or shiftKey
+                        this.selectNodes([node], e.shiftKey || e.ctrlKey || e.metaKey); // add to selection add to selection with ctrlKey or shiftKey
                     }
 
                 }


### PR DESCRIPTION
Allow Meta+Click to add node to current selection on Mac, mirroring behavior of Ctrl+Click on other OS.

Playwright test case for future reference:

```typescript
    test('Can select multiple nodes with Meta+Click (mac)', async ({
      comfyPage
    }) => {
      const clipNodes = await comfyPage.getNodeRefsByType('CLIPTextEncode')
      for (const node of clipNodes) {
        await node.click('title', { modifiers: ['Meta'] })
      }
      const selectedNodeCount = await comfyPage.getSelectedGraphNodesCount()
      expect(selectedNodeCount).toBe(clipNodes.length)
    })
```