### PR TITLE
Don't draw badges when zoomed out

### DIFF
--- a/src/LGraphCanvas.ts
+++ b/src/LGraphCanvas.ts
@@ -4376,7 +4376,10 @@ export class LGraphCanvas {
             node.is_selected,
             node.mouseOver
         );
-        node.drawBadges(ctx);
+
+        if (!low_quality) {
+            node.drawBadges(ctx);
+        }
 
         ctx.shadowColor = "transparent";
 


### PR DESCRIPTION
Don't draw node badges when zoomed out enough.