### PR TITLE
ES2022 Output & whitespace-only minification

### DIFF
--- a/test/LGraph.test.ts
+++ b/test/LGraph.test.ts
@@ -21,7 +21,6 @@ describe("LegacyLGraph Compatibility Layer", () => {
   });
 
   test("LegacyLGraph is correctly assigned to LiteGraph", () => {
-    // @ts-expect-error Fixed later in the TS conversion process.
     expect(LiteGraph.LGraph).toBe(LGraph);
   });
 });

--- a/test/LGraphNode.test.ts
+++ b/test/LGraphNode.test.ts
@@ -5,9 +5,7 @@ import {
 describe("LGraphNode", () => {
   it("should serialize position correctly", () => {
     const node = new LGraphNode("TestNode");
-    // @ts-expect-error Expected - not a TS class yet.
     node.pos = [10, 10];
-    // @ts-expect-error JS tests in TS format
     expect(node.pos).toEqual(new Float32Array([10, 10]));
     expect(node.serialize().pos).toEqual(new Float32Array([10, 10]));
   });

--- a/vite.config.mts
+++ b/vite.config.mts
@@ -10,9 +10,13 @@ export default defineConfig({
       fileName: (format) => `litegraph.${format}.js`,
       formats: ['es', 'umd']
     },
-    minify: false,
+    // minify: false,
     sourcemap: true,
     target: ['es2022'],
+  },
+  esbuild: {
+    minifyIdentifiers: false,
+    minifySyntax: false,
   },
   plugins: [
     dts({

--- a/vite.config.mts
+++ b/vite.config.mts
@@ -12,6 +12,7 @@ export default defineConfig({
     },
     minify: false,
     sourcemap: true,
+    target: ['es2022'],
   },
   plugins: [
     dts({

--- a/vite.config.mts
+++ b/vite.config.mts
@@ -10,7 +10,6 @@ export default defineConfig({
       fileName: (format) => `litegraph.${format}.js`,
       formats: ['es', 'umd']
     },
-    // minify: false,
     sourcemap: true,
     target: ['es2022'],
   },


### PR DESCRIPTION
Saves a little over 150K on the `.umd.js` output file.  Only whitespace / comments are altered.  Names, map, etc are not impacted.  Easily reformats using e.g. prettier.

Does not work for .es.js output - limitation of vite.  Workaround for .es.js involves adding `terser` & a plugin.