### PR TITLE
Typescript LGraphGroup

### DIFF
--- a/src/LGraphGroup.ts
+++ b/src/LGraphGroup.ts
@@ -1,4 +1,4 @@
-import type { Point, Size } from "./interfaces"
+import type { IContextMenuValue, Point, Size } from "./interfaces"
 import type { LGraph } from "./LGraph"
 import type { ISerialisedGroup } from "./types/serialisation"
 import { LiteGraph } from "./litegraph"
@@ -48,26 +48,26 @@ export class LGraphGroup {
         this.flags = {}
 
         Object.defineProperty(this, "pos", {
-            set: function (v) {
+            set(this: LGraphGroup, v: Point) {
                 if (!v || v.length < 2) return
 
                 this._pos[0] = v[0]
                 this._pos[1] = v[1]
             },
-            get: function () {
+            get(this: LGraphGroup): Point {
                 return this._pos
             },
             enumerable: true
         })
 
         Object.defineProperty(this, "size", {
-            set: function (v) {
+            set(this: LGraphGroup, v) {
                 if (!v || v.length < 2) return
 
                 this._size[0] = Math.max(140, v[0])
                 this._size[1] = Math.max(80, v[1])
             },
-            get: function () {
+            get(this: LGraphGroup): Size {
                 return this._size
             },
             enumerable: true
@@ -90,15 +90,15 @@ export class LGraphGroup {
         return !!this.flags.pinned
     }
 
-    pin() {
+    pin(): void {
         this.flags.pinned = true
     }
 
-    unpin() {
+    unpin(): void {
         delete this.flags.pinned
     }
 
-    configure(o) {
+    configure(o: ISerialisedGroup): void {
         this.title = o.title
         this._bounding.set(o.bounding)
         this.color = o.color
@@ -106,7 +106,7 @@ export class LGraphGroup {
         if (o.font_size) this.font_size = o.font_size
     }
 
-    serialize() {
+    serialize(): ISerialisedGroup {
         const b = this._bounding
         return {
             title: this.title,
@@ -127,7 +127,7 @@ export class LGraphGroup {
      * @param {LGraphCanvas} graphCanvas
      * @param {CanvasRenderingContext2D} ctx
      */
-    draw(graphCanvas, ctx) {
+    draw(graphCanvas: LGraphCanvas, ctx: CanvasRenderingContext2D): void {
         const padding = 4
 
         ctx.fillStyle = this.color
@@ -163,14 +163,14 @@ export class LGraphGroup {
         }
     }
 
-    resize(width, height) {
+    resize(width: number, height: number): void {
         if (this.pinned) return
 
         this._size[0] = width
         this._size[1] = height
     }
 
-    move(deltax, deltay, ignore_nodes) {
+    move(deltax: number, deltay: number, ignore_nodes: boolean): void {
         if (this.pinned) return
 
         this._pos[0] += deltax
@@ -184,7 +184,7 @@ export class LGraphGroup {
         }
     }
 
-    recomputeInsideNodes() {
+    recomputeInsideNodes(): void {
         this._nodes.length = 0
         const nodes = this.graph._nodes
         const node_bounding = new Float32Array(4)
@@ -206,7 +206,7 @@ export class LGraphGroup {
      * @param {number} [padding=10] - The padding around the group
      * @returns {void}
      */
-    addNodes(nodes, padding = 10) {
+    addNodes(nodes: LGraphNode[], padding: number = 10): void {
         if (!this._nodes && nodes.length === 0) return
 
         const allNodes = [...(this._nodes || []), ...nodes]
@@ -240,7 +240,7 @@ export class LGraphGroup {
         ]
     }
 
-    getMenuOptions() {
+    getMenuOptions(): IContextMenuValue[] {
         return [
             {
                 content: this.pinned ? "Unpin" : "Pin",

--- a/src/LGraphGroup.ts
+++ b/src/LGraphGroup.ts
@@ -164,7 +164,7 @@ export class LGraphGroup {
         this._size[1] = height
     }
 
-    move(deltax: number, deltay: number, ignore_nodes: boolean): void {
+    move(deltax: number, deltay: number, ignore_nodes = false): void {
         if (this.pinned) return
 
         this._pos[0] += deltax

--- a/src/LGraphGroup.ts
+++ b/src/LGraphGroup.ts
@@ -1,6 +1,6 @@
-// @ts-nocheck
 import type { Point, Size } from "./interfaces"
 import type { LGraph } from "./LGraph"
+import type { ISerialisedGroup } from "./types/serialisation"
 import { LiteGraph } from "./litegraph"
 import { LGraphCanvas } from "./LGraphCanvas"
 import { overlapBounding } from "./measure"
@@ -34,7 +34,7 @@ export class LGraphGroup {
         this._ctor(title)
     }
 
-    _ctor(title?: string) {
+    _ctor(title?: string): void {
         this.title = title || "Group"
         this.font_size = LiteGraph.DEFAULT_GROUP_FONT || 24
         this.color = LGraphCanvas.node_colors.pale_blue
@@ -49,9 +49,8 @@ export class LGraphGroup {
 
         Object.defineProperty(this, "pos", {
             set: function (v) {
-                if (!v || v.length < 2) {
-                    return
-                }
+                if (!v || v.length < 2) return
+
                 this._pos[0] = v[0]
                 this._pos[1] = v[1]
             },
@@ -63,9 +62,8 @@ export class LGraphGroup {
 
         Object.defineProperty(this, "size", {
             set: function (v) {
-                if (!v || v.length < 2) {
-                    return
-                }
+                if (!v || v.length < 2) return
+
                 this._size[0] = Math.max(140, v[0])
                 this._size[1] = Math.max(80, v[1])
             },
@@ -105,9 +103,7 @@ export class LGraphGroup {
         this._bounding.set(o.bounding)
         this.color = o.color
         this.flags = o.flags || this.flags
-        if (o.font_size) {
-            this.font_size = o.font_size
-        }
+        if (o.font_size) this.font_size = o.font_size
     }
 
     serialize() {
@@ -168,22 +164,19 @@ export class LGraphGroup {
     }
 
     resize(width, height) {
-        if (this.pinned) {
-            return
-        }
+        if (this.pinned) return
+
         this._size[0] = width
         this._size[1] = height
     }
 
     move(deltax, deltay, ignore_nodes) {
-        if (this.pinned) {
-            return
-        }
+        if (this.pinned) return
+
         this._pos[0] += deltax
         this._pos[1] += deltay
-        if (ignore_nodes) {
-            return
-        }
+        if (ignore_nodes) return
+
         for (let i = 0; i < this._nodes.length; ++i) {
             const node = this._nodes[i]
             node.pos[0] += deltax
@@ -199,9 +192,10 @@ export class LGraphGroup {
         for (let i = 0; i < nodes.length; ++i) {
             const node = nodes[i]
             node.getBounding(node_bounding)
-            if (!overlapBounding(this._bounding, node_bounding)) {
+            //out of the visible area
+            if (!overlapBounding(this._bounding, node_bounding))
                 continue
-            } //out of the visible area
+
             this._nodes.push(node)
         }
     }
@@ -251,7 +245,8 @@ export class LGraphGroup {
             {
                 content: this.pinned ? "Unpin" : "Pin",
                 callback: () => {
-                    this.pinned ? this.unpin() : this.pin()
+                    if (this.pinned) this.unpin()
+                    else this.pin()
                     this.setDirtyCanvas(false, true)
                 },
             },

--- a/src/LGraphGroup.ts
+++ b/src/LGraphGroup.ts
@@ -111,7 +111,7 @@ export class LGraphGroup {
     }
 
     serialize() {
-        var b = this._bounding
+        const b = this._bounding
         return {
             title: this.title,
             bounding: [
@@ -184,8 +184,8 @@ export class LGraphGroup {
         if (ignore_nodes) {
             return
         }
-        for (var i = 0; i < this._nodes.length; ++i) {
-            var node = this._nodes[i]
+        for (let i = 0; i < this._nodes.length; ++i) {
+            const node = this._nodes[i]
             node.pos[0] += deltax
             node.pos[1] += deltay
         }
@@ -193,11 +193,11 @@ export class LGraphGroup {
 
     recomputeInsideNodes() {
         this._nodes.length = 0
-        var nodes = this.graph._nodes
-        var node_bounding = new Float32Array(4)
+        const nodes = this.graph._nodes
+        const node_bounding = new Float32Array(4)
 
-        for (var i = 0; i < nodes.length; ++i) {
-            var node = nodes[i]
+        for (let i = 0; i < nodes.length; ++i) {
+            const node = nodes[i]
             node.getBounding(node_bounding)
             if (!overlapBounding(this._bounding, node_bounding)) {
                 continue

--- a/src/LGraphGroup.ts
+++ b/src/LGraphGroup.ts
@@ -17,7 +17,6 @@ export interface IGraphGroupFlags extends Record<string, unknown> {
 }
 
 export class LGraphGroup {
-    pos: Point
     color: string
     title: string
     font?: string
@@ -28,7 +27,6 @@ export class LGraphGroup {
     _nodes: LGraphNode[]
     graph?: LGraph
     flags: IGraphGroupFlags
-    size?: Size
 
     constructor(title?: string) {
         this._ctor(title)
@@ -46,32 +44,28 @@ export class LGraphGroup {
         this._nodes = []
         this.graph = null
         this.flags = {}
+    }
 
-        Object.defineProperty(this, "pos", {
-            set(this: LGraphGroup, v: Point) {
-                if (!v || v.length < 2) return
+    /** Position of the group, as x,y co-ordinates in graph space */
+    get pos() {
+        return this._pos
+    }
+    set pos(v) {
+        if (!v || v.length < 2) return
 
-                this._pos[0] = v[0]
-                this._pos[1] = v[1]
-            },
-            get(this: LGraphGroup): Point {
-                return this._pos
-            },
-            enumerable: true
-        })
+        this._pos[0] = v[0]
+        this._pos[1] = v[1]
+    }
 
-        Object.defineProperty(this, "size", {
-            set(this: LGraphGroup, v) {
-                if (!v || v.length < 2) return
+    /** Size of the group, as width,height in graph units */
+    get size() {
+        return this._size
+    }
+    set size(v) {
+        if (!v || v.length < 2) return
 
-                this._size[0] = Math.max(140, v[0])
-                this._size[1] = Math.max(80, v[1])
-            },
-            get(this: LGraphGroup): Size {
-                return this._size
-            },
-            enumerable: true
-        })
+        this._size[0] = Math.max(140, v[0])
+        this._size[1] = Math.max(80, v[1])
     }
 
     get nodes() {

--- a/src/LGraphGroup.ts
+++ b/src/LGraphGroup.ts
@@ -1,10 +1,10 @@
 // @ts-nocheck
 import type { Point, Size } from "./interfaces"
 import type { LGraph } from "./LGraph"
-import { LiteGraph } from "./litegraph";
-import { LGraphCanvas } from "./LGraphCanvas";
-import { overlapBounding } from "./measure";
-import { LGraphNode } from "./LGraphNode";
+import { LiteGraph } from "./litegraph"
+import { LGraphCanvas } from "./LGraphCanvas"
+import { overlapBounding } from "./measure"
+import { LGraphNode } from "./LGraphNode"
 
 export interface IGraphGroup {
     _pos: Point
@@ -31,87 +31,87 @@ export class LGraphGroup {
     size?: Size
 
     constructor(title?: string) {
-        this._ctor(title);
+        this._ctor(title)
     }
 
     _ctor(title?: string) {
-        this.title = title || "Group";
-        this.font_size = LiteGraph.DEFAULT_GROUP_FONT || 24;
+        this.title = title || "Group"
+        this.font_size = LiteGraph.DEFAULT_GROUP_FONT || 24
         this.color = LGraphCanvas.node_colors.pale_blue
             ? LGraphCanvas.node_colors.pale_blue.groupcolor
-            : "#AAA";
-        this._bounding = new Float32Array([10, 10, 140, 80]);
-        this._pos = this._bounding.subarray(0, 2);
-        this._size = this._bounding.subarray(2, 4);
-        this._nodes = [];
-        this.graph = null;
-        this.flags = {};
+            : "#AAA"
+        this._bounding = new Float32Array([10, 10, 140, 80])
+        this._pos = this._bounding.subarray(0, 2)
+        this._size = this._bounding.subarray(2, 4)
+        this._nodes = []
+        this.graph = null
+        this.flags = {}
 
         Object.defineProperty(this, "pos", {
             set: function (v) {
                 if (!v || v.length < 2) {
-                    return;
+                    return
                 }
-                this._pos[0] = v[0];
-                this._pos[1] = v[1];
+                this._pos[0] = v[0]
+                this._pos[1] = v[1]
             },
             get: function () {
-                return this._pos;
+                return this._pos
             },
             enumerable: true
-        });
+        })
 
         Object.defineProperty(this, "size", {
             set: function (v) {
                 if (!v || v.length < 2) {
-                    return;
+                    return
                 }
-                this._size[0] = Math.max(140, v[0]);
-                this._size[1] = Math.max(80, v[1]);
+                this._size[0] = Math.max(140, v[0])
+                this._size[1] = Math.max(80, v[1])
             },
             get: function () {
-                return this._size;
+                return this._size
             },
             enumerable: true
-        });
+        })
     }
 
     get nodes() {
-        return this._nodes;
+        return this._nodes
     }
 
     get titleHeight() {
-        return this.font_size * 1.4;
+        return this.font_size * 1.4
     }
 
     get selected() {
-        return !!this.graph?.list_of_graphcanvas?.some(c => c.selected_group === this);
+        return !!this.graph?.list_of_graphcanvas?.some(c => c.selected_group === this)
     }
 
     get pinned() {
-        return !!this.flags.pinned;
+        return !!this.flags.pinned
     }
 
     pin() {
-        this.flags.pinned = true;
+        this.flags.pinned = true
     }
 
     unpin() {
-        delete this.flags.pinned;
+        delete this.flags.pinned
     }
 
     configure(o) {
-        this.title = o.title;
-        this._bounding.set(o.bounding);
-        this.color = o.color;
-        this.flags = o.flags || this.flags;
+        this.title = o.title
+        this._bounding.set(o.bounding)
+        this.color = o.color
+        this.flags = o.flags || this.flags
         if (o.font_size) {
-            this.font_size = o.font_size;
+            this.font_size = o.font_size
         }
     }
 
     serialize() {
-        var b = this._bounding;
+        var b = this._bounding
         return {
             title: this.title,
             bounding: [
@@ -123,7 +123,7 @@ export class LGraphGroup {
             color: this.color,
             font_size: this.font_size,
             flags: this.flags,
-        };
+        }
     }
 
     /**
@@ -132,29 +132,29 @@ export class LGraphGroup {
      * @param {CanvasRenderingContext2D} ctx
      */
     draw(graphCanvas, ctx) {
-        const padding = 4;
+        const padding = 4
 
-        ctx.fillStyle = this.color;
-        ctx.strokeStyle = this.color;
-        const [x, y] = this._pos;
-        const [width, height] = this._size;
-        ctx.globalAlpha = 0.25 * graphCanvas.editor_alpha;
-        ctx.beginPath();
-        ctx.rect(x + 0.5, y + 0.5, width, height);
-        ctx.fill();
-        ctx.globalAlpha = graphCanvas.editor_alpha;
-        ctx.stroke();
+        ctx.fillStyle = this.color
+        ctx.strokeStyle = this.color
+        const [x, y] = this._pos
+        const [width, height] = this._size
+        ctx.globalAlpha = 0.25 * graphCanvas.editor_alpha
+        ctx.beginPath()
+        ctx.rect(x + 0.5, y + 0.5, width, height)
+        ctx.fill()
+        ctx.globalAlpha = graphCanvas.editor_alpha
+        ctx.stroke()
 
-        ctx.beginPath();
-        ctx.moveTo(x + width, y + height);
-        ctx.lineTo(x + width - 10, y + height);
-        ctx.lineTo(x + width, y + height - 10);
-        ctx.fill();
+        ctx.beginPath()
+        ctx.moveTo(x + width, y + height)
+        ctx.lineTo(x + width - 10, y + height)
+        ctx.lineTo(x + width, y + height - 10)
+        ctx.fill()
 
-        const font_size = this.font_size || LiteGraph.DEFAULT_GROUP_FONT_SIZE;
-        ctx.font = font_size + "px Arial";
-        ctx.textAlign = "left";
-        ctx.fillText(this.title + (this.pinned ? "📌" : ""), x + padding, y + font_size);
+        const font_size = this.font_size || LiteGraph.DEFAULT_GROUP_FONT_SIZE
+        ctx.font = font_size + "px Arial"
+        ctx.textAlign = "left"
+        ctx.fillText(this.title + (this.pinned ? "📌" : ""), x + padding, y + font_size)
 
         if (LiteGraph.highlight_selected_group && this.selected) {
             graphCanvas.drawSelectionBounding(ctx, this._bounding, {
@@ -163,46 +163,46 @@ export class LGraphGroup {
                 title_mode: LiteGraph.NORMAL_TITLE,
                 fgcolor: this.color,
                 padding,
-            });
+            })
         }
     }
 
     resize(width, height) {
         if (this.pinned) {
-            return;
+            return
         }
-        this._size[0] = width;
-        this._size[1] = height;
+        this._size[0] = width
+        this._size[1] = height
     }
 
     move(deltax, deltay, ignore_nodes) {
         if (this.pinned) {
-            return;
+            return
         }
-        this._pos[0] += deltax;
-        this._pos[1] += deltay;
+        this._pos[0] += deltax
+        this._pos[1] += deltay
         if (ignore_nodes) {
-            return;
+            return
         }
         for (var i = 0; i < this._nodes.length; ++i) {
-            var node = this._nodes[i];
-            node.pos[0] += deltax;
-            node.pos[1] += deltay;
+            var node = this._nodes[i]
+            node.pos[0] += deltax
+            node.pos[1] += deltay
         }
     }
 
     recomputeInsideNodes() {
-        this._nodes.length = 0;
-        var nodes = this.graph._nodes;
-        var node_bounding = new Float32Array(4);
+        this._nodes.length = 0
+        var nodes = this.graph._nodes
+        var node_bounding = new Float32Array(4)
 
         for (var i = 0; i < nodes.length; ++i) {
-            var node = nodes[i];
-            node.getBounding(node_bounding);
+            var node = nodes[i]
+            node.getBounding(node_bounding)
             if (!overlapBounding(this._bounding, node_bounding)) {
-                continue;
+                continue
             } //out of the visible area
-            this._nodes.push(node);
+            this._nodes.push(node)
         }
     }
 
@@ -213,37 +213,37 @@ export class LGraphGroup {
      * @returns {void}
      */
     addNodes(nodes, padding = 10) {
-        if (!this._nodes && nodes.length === 0) return;
+        if (!this._nodes && nodes.length === 0) return
 
-        const allNodes = [...(this._nodes || []), ...nodes];
+        const allNodes = [...(this._nodes || []), ...nodes]
 
         const bounds = allNodes.reduce((acc, node) => {
-            const [x, y] = node.pos;
-            const [width, height] = node.size;
-            const isReroute = node.type === "Reroute";
-            const isCollapsed = node.flags?.collapsed;
+            const [x, y] = node.pos
+            const [width, height] = node.size
+            const isReroute = node.type === "Reroute"
+            const isCollapsed = node.flags?.collapsed
 
-            const top = y - (isReroute ? 0 : LiteGraph.NODE_TITLE_HEIGHT);
-            const bottom = isCollapsed ? top + LiteGraph.NODE_TITLE_HEIGHT : y + height;
-            const right = isCollapsed && node._collapsed_width ? x + Math.round(node._collapsed_width) : x + width;
+            const top = y - (isReroute ? 0 : LiteGraph.NODE_TITLE_HEIGHT)
+            const bottom = isCollapsed ? top + LiteGraph.NODE_TITLE_HEIGHT : y + height
+            const right = isCollapsed && node._collapsed_width ? x + Math.round(node._collapsed_width) : x + width
 
             return {
                 left: Math.min(acc.left, x),
                 top: Math.min(acc.top, top),
                 right: Math.max(acc.right, right),
                 bottom: Math.max(acc.bottom, bottom)
-            };
-        }, { left: Infinity, top: Infinity, right: -Infinity, bottom: -Infinity });
+            }
+        }, { left: Infinity, top: Infinity, right: -Infinity, bottom: -Infinity })
 
         this.pos = [
             bounds.left - padding,
             bounds.top - padding - this.titleHeight
-        ];
+        ]
 
         this.size = [
             bounds.right - bounds.left + padding * 2,
             bounds.bottom - bounds.top + padding * 2 + this.titleHeight
-        ];
+        ]
     }
 
     getMenuOptions() {
@@ -251,8 +251,8 @@ export class LGraphGroup {
             {
                 content: this.pinned ? "Unpin" : "Pin",
                 callback: () => {
-                    this.pinned ? this.unpin() : this.pin();
-                    this.setDirtyCanvas(false, true);
+                    this.pinned ? this.unpin() : this.pin()
+                    this.setDirtyCanvas(false, true)
                 },
             },
             null,
@@ -270,7 +270,7 @@ export class LGraphGroup {
             },
             null,
             { content: "Remove", callback: LGraphCanvas.onMenuNodeRemove }
-        ];
+        ]
     }
 
     isPointInside = LGraphNode.prototype.isPointInside


### PR DESCRIPTION
Mercifully minor PR.  Changes:
- Moves `pos`/`size` getter/setter to class definitions (from dynamic assign in ctor)
- Makes `move()` nodes param optional with original behaviour as default