### PR TITLE
Fix types not resolving through '@/imports' (.d.ts only)

### DIFF
--- a/vite.config.mts
+++ b/vite.config.mts
@@ -23,6 +23,7 @@ export default defineConfig({
       insertTypesEntry: true,
       include: ['src/**/*.ts'],
       outDir: 'dist',
+      aliasesExclude: ['@'],
     }),
   ],
   resolve: {


### PR DESCRIPTION
Fixes broken relative imports generated by `vite-plugin-dts`.  e.g. in `dist/types/serialisation.d.ts`:

Old:
`import { LGraph } from '../../../../../../../src/LGraph';`

New:
`import { LGraph } from '../LGraph';`