### PR TITLE
Canvas refactors - standardising

### DIFF
--- a/src/LGraph.ts
+++ b/src/LGraph.ts
@@ -830,7 +830,6 @@ export class LGraph {
         const nRet = null
         for (let i = nodes_list.length - 1; i >= 0; i--) {
             const n = nodes_list[i]
-            // @ts-expect-error ctor props
             const skip_title = n.constructor.title_mode == LiteGraph.NO_TITLE
             if (n.isPointInside(x, y, margin, skip_title)) {
                 // check for lesser interest nodes (TODO check for overlapping, use the top)

--- a/src/LGraphCanvas.ts
+++ b/src/LGraphCanvas.ts
@@ -4563,12 +4563,9 @@ export class LGraphCanvas {
         const shape = node._shape || node.constructor.shape || LiteGraph.ROUND_SHAPE
         const title_mode = node.constructor.title_mode
 
-        let render_title = true
-        if (title_mode == LiteGraph.TRANSPARENT_TITLE || title_mode == LiteGraph.NO_TITLE) {
-            render_title = false
-        } else if (title_mode == LiteGraph.AUTOHIDE_TITLE && mouse_over) {
-            render_title = true
-        }
+        const render_title = title_mode == LiteGraph.TRANSPARENT_TITLE || title_mode == LiteGraph.NO_TITLE
+            ? false
+            : true
 
         const area = LGraphCanvas.#tmp_area
         area[0] = 0 //x

--- a/src/LGraphCanvas.ts
+++ b/src/LGraphCanvas.ts
@@ -1793,15 +1793,17 @@ export class LGraphCanvas {
 
             // clone node ALT dragging
             if (LiteGraph.alt_drag_do_clone_nodes && e.altKey && !e.ctrlKey && node && this.allow_interaction && !skip_action && !this.read_only) {
-                const cloned = node.clone()
+                const node_data = node.clone()?.serialize()
+                const cloned = LiteGraph.createNode(node_data.type)
                 if (cloned) {
+                    cloned.configure(node_data)
                     cloned.pos[0] += 5
                     cloned.pos[1] += 5
+
                     // @ts-expect-error Not impl. - harmless
                     this.graph.add(cloned, false, { doCalcSize: false })
                     node = cloned
                     skip_action = true
-
                     if (this.allow_dragnodes) {
                         this.graph.beforeChange()
                         this.node_dragged = node

--- a/src/LGraphCanvas.ts
+++ b/src/LGraphCanvas.ts
@@ -4214,9 +4214,7 @@ export class LGraphCanvas {
     drawNode(node: LGraphNode, ctx: CanvasRenderingContext2D): void {
         this.current_node = node
 
-        // @ts-expect-error ctor props
         const color = node.color || node.constructor.color || LiteGraph.NODE_DEFAULT_COLOR
-        // @ts-expect-error ctor props
         let bgcolor = node.bgcolor || node.constructor.bgcolor || LiteGraph.NODE_DEFAULT_BGCOLOR
 
         const low_quality = this.ds.scale < 0.6 //zoomed out
@@ -4583,10 +4581,7 @@ export class LGraphCanvas {
         const low_quality = this.ds.scale < 0.5
 
         //render node area depending on shape
-        // @ts-expect-error ctor props
         const shape = node._shape || node.constructor.shape || LiteGraph.ROUND_SHAPE
-
-        // @ts-expect-error ctor props
         const title_mode = node.constructor.title_mode
 
         let render_title = true
@@ -4646,10 +4641,10 @@ export class LGraphCanvas {
             //title bar
             if (node.onDrawTitleBar) {
                 node.onDrawTitleBar(ctx, title_height, size, this.ds.scale, fgcolor)
-            } else if (title_mode != LiteGraph.TRANSPARENT_TITLE &&
-                // @ts-expect-error ctor props
-                (node.constructor.title_color || this.render_title_colored)) {
-                // @ts-expect-error ctor props
+            } else if (
+                title_mode != LiteGraph.TRANSPARENT_TITLE &&
+                (node.constructor.title_color || this.render_title_colored)
+            ) {
                 const title_color = node.constructor.title_color || fgcolor
 
                 if (node.flags.collapsed) {
@@ -4658,10 +4653,14 @@ export class LGraphCanvas {
 
                 //* gradient test
                 if (this.use_gradients) {
+                    // TODO: This feature may not have been completed.  Could finish or remove.
+                    // Original impl. may cause CanvasColour to be used as index key.  Also, colour requires validation before blindly passing on.
+                    // @ts-expect-error Fix or remove gradient feature
                     let grad = LGraphCanvas.gradients[title_color]
                     if (!grad) {
+                        // @ts-expect-error Fix or remove gradient feature
                         grad = LGraphCanvas.gradients[title_color] = ctx.createLinearGradient(0, 0, 400, 0)
-                        grad.addColorStop(0, title_color) // TODO refactor: validate color !! prevent DOMException
+                        grad.addColorStop(0, title_color)
                         grad.addColorStop(1, "#000")
                     }
                     ctx.fillStyle = grad
@@ -4770,7 +4769,6 @@ export class LGraphCanvas {
                         ctx.fillStyle = LiteGraph.NODE_SELECTED_TITLE_COLOR
                     } else {
                         ctx.fillStyle =
-                            // @ts-expect-error ctor props
                             node.constructor.title_text_color || this.node_title_color
                     }
                     if (node.flags.collapsed) {

--- a/src/LGraphCanvas.ts
+++ b/src/LGraphCanvas.ts
@@ -13,6 +13,7 @@ import { drawSlot, LabelPosition } from "./draw"
 import { DragAndScale } from "./DragAndScale"
 import { LiteGraph, clamp } from "./litegraph"
 import { stringOrNull } from "./strings"
+import { distributeNodes } from "./utils/arrange"
 
 interface IShowSearchOptions {
     node_to?: LGraphNode
@@ -608,6 +609,19 @@ export class LGraphCanvas {
 
         function inner_clicked(value) {
             LGraphCanvas.alignNodes(LGraphCanvas.active_canvas.selected_nodes, value.toLowerCase())
+        }
+    }
+    static createDistributeMenu(value: IContextMenuValue, options: IContextMenuOptions, event: MouseEvent, prev_menu: ContextMenu, node: LGraphNode): void {
+        new LiteGraph.ContextMenu(["Vertically", "Horizontally"], {
+            event,
+            callback: inner_clicked,
+            parentMenu: prev_menu,
+        })
+
+        function inner_clicked(value: string) {
+            const canvas = LGraphCanvas.active_canvas
+            distributeNodes(Object.values(canvas.selected_nodes), value === "Horizontally")
+            canvas.setDirty(true, true)
         }
     }
     static onMenuAdd(node: LGraphNode, options: IContextMenuOptions, e: MouseEvent, prev_menu: ContextMenu, callback?: (node: LGraphNode) => void): boolean {
@@ -7882,6 +7896,11 @@ export class LGraphCanvas {
                 content: "Align Selected To",
                 has_submenu: true,
                 callback: LGraphCanvas.onNodeAlign,
+            })
+            options.push({
+                content: "Distribute Nodes",
+                has_submenu: true,
+                callback: LGraphCanvas.createDistributeMenu,
             })
         }
 

--- a/src/LGraphCanvas.ts
+++ b/src/LGraphCanvas.ts
@@ -4159,16 +4159,6 @@ export class LGraphCanvas {
             }
 
             this.onDrawBackground?.(ctx, this.visible_area)
-            // TODO: Just delete this...
-            // @ts-expect-error
-            if (this.onBackgroundRender) {
-                //LEGACY
-                console.error(
-                    "WARNING! onBackgroundRender deprecated, now is named onDrawBackground "
-                )
-                // @ts-expect-error
-                this.onBackgroundRender = null
-            }
 
             //DEBUG: show clipping area
             //ctx.fillStyle = "red";

--- a/src/LGraphCanvas.ts
+++ b/src/LGraphCanvas.ts
@@ -12,7 +12,7 @@ import { isInsideRectangle, distance, overlapBounding, isPointInRectangle } from
 import { drawSlot, LabelPosition } from "./draw"
 import { DragAndScale } from "./DragAndScale"
 import { LinkReleaseContextExtended, LiteGraph, clamp } from "./litegraph"
-import { stringOrNull } from "./strings"
+import { stringOrEmpty, stringOrNull } from "./strings"
 import { distributeNodes } from "./utils/arrange"
 
 interface IShowSearchOptions {
@@ -1800,8 +1800,7 @@ export class LGraphCanvas {
                     cloned.pos[0] += 5
                     cloned.pos[1] += 5
 
-                    // @ts-expect-error Not impl. - harmless
-                    this.graph.add(cloned, false, { doCalcSize: false })
+                    this.graph.add(cloned, false)
                     node = cloned
                     skip_action = true
                     if (this.allow_dragnodes) {
@@ -3129,8 +3128,7 @@ export class LGraphCanvas {
                 node.pos[0] += this.graph_mouse[0] - posMin[0] //+= 5;
                 node.pos[1] += this.graph_mouse[1] - posMin[1] //+= 5;
 
-                // @ts-expect-error This can be changed to just "true", given the functionality of .add() - but the param should be removed
-                this.graph.add(node, { doProcessChange: false })
+                this.graph.add(node, true)
 
                 nodes.push(node)
             }
@@ -5387,8 +5385,7 @@ export class LGraphCanvas {
             }
             ctx.fillStyle = "#FFF"
             ctx.fillText(
-                // @ts-expect-error type coercion
-                node.order,
+                stringOrEmpty(node.order),
                 node.pos[0] + LiteGraph.NODE_TITLE_HEIGHT * -0.5,
                 node.pos[1] - 6
             )
@@ -6999,7 +6996,7 @@ export class LGraphCanvas {
             options
         )
 
-        let input: boolean | HTMLElement = false
+        let input: HTMLInputElement | HTMLSelectElement
         if ((type == "enum" || type == "combo") && info.values) {
             input = dialog.querySelector("select")
             // FIXME: No optional chaining
@@ -7053,7 +7050,6 @@ export class LGraphCanvas {
         button.addEventListener("click", inner)
 
         function inner() {
-            // @ts-expect-error
             setValue(input.value)
         }
 
@@ -7143,7 +7139,7 @@ export class LGraphCanvas {
         }
 
         let dialogCloseTimer = null
-        let prevent_timeout = false
+        let prevent_timeout = 0
         dialog.addEventListener("mouseleave", function () {
             if (prevent_timeout)
                 return
@@ -7157,11 +7153,8 @@ export class LGraphCanvas {
         const selInDia = dialog.querySelectorAll("select")
         // if filtering, check focus changed to comboboxes and prevent closing
         selInDia?.forEach(function (selIn) {
-            // @ts-expect-error
             selIn.addEventListener("click", function () { prevent_timeout++ })
-            // @ts-expect-error
             selIn.addEventListener("blur", function () { prevent_timeout = 0 })
-            // @ts-expect-error
             selIn.addEventListener("change", function () { prevent_timeout = -1 })
         })
 

--- a/src/LGraphCanvas.ts
+++ b/src/LGraphCanvas.ts
@@ -5,9 +5,9 @@ import type { CanvasDragEvent, CanvasMouseEvent, CanvasWheelEvent, CanvasEventDe
 import type { LinkDirection, RenderShape, TitleMode } from "./types/globalEnums"
 import type { IClipboardContents } from "./types/serialisation"
 import type { LLink } from "./LLink"
-import type { LGraphGroup } from "./LGraphGroup"
 import type { LGraph } from "./LGraph"
 import type { ContextMenu } from "./ContextMenu"
+import { LGraphGroup } from "./LGraphGroup"
 import { isInsideRectangle, distance, overlapBounding, isPointInRectangle } from "./measure"
 import { drawSlot, LabelPosition } from "./draw"
 import { DragAndScale } from "./DragAndScale"
@@ -323,7 +323,7 @@ export class LGraphCanvas {
         //	throw ("No graph assigned");
         this.background_image = LGraphCanvas.DEFAULT_BACKGROUND_IMAGE
 
-        if (canvas && canvas.constructor === String) {
+        if (canvas && typeof canvas === "string") {
             canvas = document.querySelector(canvas)
         }
 
@@ -867,7 +867,7 @@ export class LGraphCanvas {
             const value = v.value[1]
 
             if (value &&
-                (value.constructor === Object || value.constructor === Array)) {
+                (typeof value === "object" || Array.isArray(value))) {
                 //submenu why?
                 const entries = []
                 for (const i in value) {
@@ -1068,11 +1068,11 @@ export class LGraphCanvas {
         if (!values)
             return String(value)
 
-        if (values.constructor === Array) {
+        if (Array.isArray(values)) {
             return String(value)
         }
 
-        if (values.constructor === Object) {
+        if (typeof values === "object") {
             let desc_value = ""
             for (const k in values) {
                 if (values[k] != value)
@@ -1174,7 +1174,7 @@ export class LGraphCanvas {
 
             const fApplyColor = function (node: LGraphNode) {
                 if (color) {
-                    if (node.constructor === LiteGraph.LGraphGroup) {
+                    if (node instanceof LGraphGroup) {
                         node.color = color.groupcolor
                     } else {
                         node.color = color.color
@@ -1441,7 +1441,7 @@ export class LGraphCanvas {
      */
     setCanvas(canvas?: string | HTMLCanvasElement, skip_events?: boolean) {
         // TODO: Remove input mutation
-        if (canvas?.constructor === String) {
+        if (typeof canvas === "string") {
             // @ts-expect-error
             canvas = document.getElementById(canvas)
             if (!canvas) {
@@ -5549,10 +5549,10 @@ export class LGraphCanvas {
                             let v = typeof w.value === "number" ? String(w.value) : w.value
                             if (w.options.values) {
                                 let values = w.options.values
-                                if (values.constructor === Function)
+                                if (typeof values === "function")
                                     // @ts-expect-error
                                     values = values()
-                                if (values && values.constructor !== Array)
+                                if (values && !Array.isArray(values))
                                     v = values[w.value]
                             }
                             const labelWidth = ctx.measureText(w.label || w.name).width + margin * 2
@@ -5710,14 +5710,14 @@ export class LGraphCanvas {
                         }
                     } else if (event.type == LiteGraph.pointerevents_method + "down") {
                         values = w.options.values
-                        if (values && values.constructor === Function) {
+                        if (typeof values === "function") {
                             // @ts-expect-error
                             values = w.options.values(w, node)
                         }
                         values_list = null
 
                         if (w.type != "number")
-                            values_list = values.constructor === Array ? values : Object.keys(values)
+                            values_list = Array.isArray(values) ? values : Object.keys(values)
 
                         delta = x < 40 ? -1 : x > widget_width - 40 ? 1 : 0
                         if (w.type == "number") {
@@ -5731,14 +5731,14 @@ export class LGraphCanvas {
                         } else if (delta) { //clicked in arrow, used for combos 
                             let index = -1
                             this.last_mouseclick = 0 //avoids dobl click event
-                            index = values.constructor === Object
+                            index = typeof values === "object"
                                 ? values_list.indexOf(String(w.value)) + delta
                                 : values_list.indexOf(w.value) + delta
 
                             if (index >= values_list.length) index = values_list.length - 1
                             if (index < 0) index = 0
 
-                            w.value = values.constructor === Array
+                            w.value = Array.isArray(values)
                                 ? values[index]
                                 : index
                         } else { //combo clicked 
@@ -6948,7 +6948,7 @@ export class LGraphCanvas {
         } else if ((type == "enum" || type == "combo") && info.values) {
             input_html = "<select autofocus type='text' class='value'>"
             for (const i in info.values) {
-                const v = info.values.constructor === Array
+                const v = Array.isArray(info.values)
                     ? info.values[i]
                     : i
 
@@ -7036,7 +7036,7 @@ export class LGraphCanvas {
 
         function setValue(value: string | number) {
 
-            if (info?.values && info.values.constructor === Object && info.values[value] != undefined)
+            if (info?.values && typeof info.values === "object" && info.values[value] != undefined)
                 value = info.values[value]
 
             if (typeof node.properties[property] == "number") {
@@ -7152,9 +7152,9 @@ export class LGraphCanvas {
         root.header = root.querySelector(".dialog-header")
 
         if (options.width)
-            root.style.width = options.width + (options.width.constructor === Number ? "px" : "")
+            root.style.width = options.width + (typeof options.width === "number" ? "px" : "")
         if (options.height)
-            root.style.height = options.height + (options.height.constructor === Number ? "px" : "")
+            root.style.height = options.height + (typeof options.height === "number" ? "px" : "")
         if (options.closable) {
             const close = document.createElement("span")
             close.innerHTML = "&#10005;"

--- a/src/LGraphCanvas.ts
+++ b/src/LGraphCanvas.ts
@@ -7290,8 +7290,6 @@ export class LGraphCanvas {
                 if (value)
                     elem.classList.add("bool-on")
                 elem.addEventListener("click", function () {
-                    //var v = node.properties[this.dataset["property"]]; 
-                    //node.setProperty(this.dataset["property"],!v); this.innerText = v ? "true" : "false"; 
                     const propname = this.dataset["property"]
                     this.value = !this.value
                     this.classList.toggle("bool-on")
@@ -7361,103 +7359,6 @@ export class LGraphCanvas {
         document.querySelector("#node-panel")?.close()
         // @ts-expect-error
         document.querySelector("#option-panel")?.close()
-    }
-    showShowGraphOptionsPanel(refOpts, obEv) {
-        let graphcanvas
-        if (this.constructor && this.constructor.name == "HTMLDivElement") {
-            // assume coming from the menu event click
-            if (!obEv || !obEv.event || !obEv.event.target || !obEv.event.target.lgraphcanvas) {
-                console.warn("Canvas not found") // need a ref to canvas obj
-
-                /*console.debug(event);
-                console.debug(event.target);*/
-                return
-            }
-            graphcanvas = obEv.event.target.lgraphcanvas
-        } else {
-            // assume called internally
-            graphcanvas = this
-        }
-        graphcanvas.closePanels()
-        const ref_window = graphcanvas.getCanvasWindow()
-        // @ts-expect-error
-        panel = graphcanvas.createPanel("Options", {
-            closable: true,
-            window: ref_window,
-            onOpen: function () {
-                graphcanvas.OPTIONPANEL_IS_OPEN = true
-            },
-            onClose: function () {
-                graphcanvas.OPTIONPANEL_IS_OPEN = false
-                graphcanvas.options_panel = null
-            }
-        })
-        // @ts-expect-error
-        graphcanvas.options_panel = panel
-        // @ts-expect-error
-        panel.id = "option-panel"
-        // @ts-expect-error
-        panel.classList.add("settings")
-
-        function inner_refresh() {
-
-            // @ts-expect-error
-            panel.content.innerHTML = "" //clear
-
-            const fUpdate = function (name, value, options) {
-                switch (name) {
-                    /*case "Render mode":
-                        // Case ""..
-                        if (options.values && options.key){
-                            var kV = Object.values(options.values).indexOf(value);
-                            if (kV>=0 && options.values[kV]){
-                                console.debug("update graph options: "+options.key+": "+kV);
-                                graphcanvas[options.key] = kV;
-                                //console.debug(graphcanvas);
-                                break;
-                            }
-                        }
-                        console.warn("unexpected options");
-                        console.debug(options);
-                        break;*/
-                    default:
-                        //console.debug("want to update graph options: "+name+": "+value);
-                        if (options?.key) {
-                            name = options.key
-                        }
-                        if (options.values) {
-                            value = Object.values(options.values).indexOf(value)
-                        }
-                        //console.debug("update graph option: "+name+": "+value);
-                        graphcanvas[name] = value
-                        break
-                }
-            }
-
-            // panel.addWidget( "string", "Graph name", "", {}, fUpdate); // implement
-            // @ts-expect-error Doesn't exist.  Check for downstream consumers then remove.
-            const aProps = LiteGraph.availableCanvasOptions
-            aProps.sort()
-            for (const pI in aProps) {
-                const pX = aProps[pI]
-                // @ts-expect-error
-                panel.addWidget("boolean", pX, graphcanvas[pX], { key: pX, on: "True", off: "False" }, fUpdate)
-            }
-
-            // @ts-expect-error
-            panel.addWidget("combo", "Render mode", LiteGraph.LINK_RENDER_MODES[graphcanvas.links_render_mode], { key: "links_render_mode", values: LiteGraph.LINK_RENDER_MODES }, fUpdate)
-
-            // @ts-expect-error
-            panel.addSeparator()
-
-            // @ts-expect-error
-            panel.footer.innerHTML = "" // clear
-
-        }
-        inner_refresh()
-        // @ts-expect-error
-
-        graphcanvas.canvas.parentNode.appendChild(panel)
     }
     showShowNodePanel(node: LGraphNode): void {
         this.SELECTED_NODE = node
@@ -7558,21 +7459,10 @@ export class LGraphCanvas {
             panel.classList.remove("settings")
             panel.classList.add("centered")
 
-            /*if(window.CodeFlask) //disabled for now
-            {
-                panel.content.innerHTML = "<div class='code'></div>";
-                var flask = new CodeFlask( "div.code", { language: 'js' });
-                flask.updateCode(node.properties[propname]);
-                flask.onUpdate( function(code) {
-                    node.setProperty(propname, code);
-                });
-            }
-            else
-            {*/
             panel.alt_content.innerHTML = "<textarea class='code'></textarea>"
             const textarea = panel.alt_content.querySelector("textarea")
             const fDoneWith = function () {
-                panel.toggleAltContent(false) //if(node_prop_div) node_prop_div.style.display = "block"; // panel.close();
+                panel.toggleAltContent(false)
                 panel.toggleFooterVisibility(true)
                 textarea.parentNode.removeChild(textarea)
                 panel.classList.add("settings")
@@ -7589,15 +7479,15 @@ export class LGraphCanvas {
             panel.toggleAltContent(true)
             panel.toggleFooterVisibility(false)
             textarea.style.height = "calc(100% - 40px)"
-            /*}*/
+
             const assign = panel.addButton("Assign", function () {
                 node.setProperty(propname, textarea.value)
                 fDoneWith()
             })
-            panel.alt_content.appendChild(assign) //panel.content.appendChild(assign);
+            panel.alt_content.appendChild(assign)
             const button = panel.addButton("Close", fDoneWith)
             button.style.float = "right"
-            panel.alt_content.appendChild(button) // panel.content.appendChild(button);
+            panel.alt_content.appendChild(button)
         }
 
         inner_refresh()
@@ -7746,9 +7636,6 @@ export class LGraphCanvas {
                 //{ content: "Arrange", callback: that.graph.arrange },
                 //{content:"Collapse All", callback: LGraphCanvas.onMenuCollapseAll }
             ]
-            /*if (LiteGraph.showCanvasOptions){
-                options.push({ content: "Options", callback: that.showShowGraphOptionsPanel });
-            }*/
             if (Object.keys(this.selected_nodes).length > 1) {
                 options.push({
                     content: "Align",

--- a/src/litegraph.ts
+++ b/src/litegraph.ts
@@ -3,6 +3,7 @@ import type { INodeSlot, INodeInputSlot, INodeOutputSlot, CanvasColour, Directio
 import type { SlotShape, LabelPosition, SlotDirection, SlotType } from "./draw"
 import type { IWidget } from "./types/widgets"
 import type { TitleMode } from "./types/globalEnums"
+import type { CanvasEventDetail } from "./types/events"
 import { LiteGraphGlobal } from "./LiteGraphGlobal"
 import { loadPolyfills } from "./polyfills"
 
@@ -71,14 +72,10 @@ export interface LinkReleaseContextExtended {
     links: ConnectingLink[]
 }
 
+/** @deprecated Confirm no downstream consumers, then remove. */
 export type LiteGraphCanvasEventType = "empty-release" | "empty-double-click" | "group-double-click"
 
-export interface LiteGraphCanvasEvent extends CustomEvent<{
-    subType: string
-    originalEvent: Event
-    linkReleaseContext?: LinkReleaseContextExtended
-    group?: LGraphGroup
-}> { }
+export interface LiteGraphCanvasEvent extends CustomEvent<CanvasEventDetail> { }
 
 export interface LiteGraphCanvasGroupEvent extends CustomEvent<{
     subType: "group-double-click"

--- a/src/litegraph.ts
+++ b/src/litegraph.ts
@@ -2,7 +2,7 @@ import type { Point, ConnectingLink } from "./interfaces"
 import type { INodeSlot, INodeInputSlot, INodeOutputSlot, CanvasColour, Direction, IBoundaryNodes, IContextMenuOptions, IContextMenuValue, IFoundSlot, IInputOrOutput, INodeFlags, IOptionalInputsData, ISlotType, KeysOfType, MethodNames, PickByType, Rect, Rect32, Size } from "./interfaces"
 import type { SlotShape, LabelPosition, SlotDirection, SlotType } from "./draw"
 import type { IWidget } from "./types/widgets"
-import type { TitleMode } from "./types/globalEnums"
+import type { RenderShape, TitleMode } from "./types/globalEnums"
 import type { CanvasEventDetail } from "./types/events"
 import { LiteGraphGlobal } from "./LiteGraphGlobal"
 import { loadPolyfills } from "./polyfills"
@@ -93,6 +93,12 @@ export interface LGraphNodeConstructor<T extends LGraphNode = LGraphNode> {
     slot_start_y?: number
     widgets_info?: any
     collapsable?: boolean
+    color?: string
+    bgcolor?: string
+    shape?: RenderShape
+    title_mode?: TitleMode
+    title_color?: string
+    title_text_color?: string
     nodeData: any
     new(): T
 }

--- a/src/types/events.ts
+++ b/src/types/events.ts
@@ -2,6 +2,11 @@
  * Event interfaces for event extension
  */
 
+import type { ConnectingLink, LinkReleaseContextExtended } from "@/litegraph"
+import type { IWidget } from "@/types/widgets"
+import type { LGraphNode } from "@/LGraphNode"
+import type { LGraphGroup } from "@/LGraphGroup"
+
 /** For Canvas*Event - adds graph space co-ordinates (property names are shipped) */
 export interface ICanvasPosition {
     /** X co-ordinate of the event, in graph space (NOT canvas space) */
@@ -38,3 +43,51 @@ export interface CanvasDragEvent extends DragEvent, ICanvasPosition, IDeltaPosit
 
 /** TouchEvent with canvasX/Y and deltaX/Y properties */
 export interface CanvasTouchEvent extends TouchEvent, ICanvasPosition, IDeltaPosition { }
+
+export type CanvasEventDetail =
+    GenericEventDetail
+    | DragggingCanvasEventDetail
+    | ReadOnlyEventDetail
+    | GroupDoubleClickEventDetail
+    | EmptyDoubleClickEventDetail
+    | ConnectingWidgetLinkEventDetail
+    | EmptyReleaseEventDetail
+
+export interface GenericEventDetail {
+    subType: "before-change" | "after-change"
+}
+
+export interface OriginalEvent {
+    originalEvent: CanvasMouseEvent,
+}
+
+export interface EmptyReleaseEventDetail extends OriginalEvent {
+    subType: "empty-release",
+    linkReleaseContext: LinkReleaseContextExtended,
+}
+
+export interface ConnectingWidgetLinkEventDetail {
+    subType: "connectingWidgetLink"
+    link: ConnectingLink
+    node: LGraphNode
+    widget: IWidget
+}
+
+export interface EmptyDoubleClickEventDetail extends OriginalEvent {
+    subType: "empty-double-click"
+}
+
+export interface GroupDoubleClickEventDetail extends OriginalEvent {
+    subType: "group-double-click"
+    group: LGraphGroup
+}
+
+export interface DragggingCanvasEventDetail {
+    subType: "dragging-canvas"
+    draggingCanvas: boolean
+}
+
+export interface ReadOnlyEventDetail {
+    subType: "read-only"
+    readOnly: boolean
+}

--- a/src/utils/arrange.ts
+++ b/src/utils/arrange.ts
@@ -1,0 +1,28 @@
+import type { LGraphNode } from "@/LGraphNode"
+
+export function distributeNodes(nodes: LGraphNode[], horizontal?: boolean): void {
+    const nodeCount = nodes?.length
+    if (!(nodeCount > 1)) return
+
+    const index = horizontal ? 0 : 1
+
+    let total = 0
+    let highest = -Infinity
+
+    for (const node of nodes) {
+        total += node.size[index]
+
+        const high = node.pos[index] + node.size[index]
+        if (high > highest) highest = high
+    }
+    const sorted = [...nodes].sort((a, b) => a.pos[index] - b.pos[index])
+    const lowest = sorted[0].pos[index]
+
+    const gap = ((highest - lowest) - total) / (nodeCount - 1)
+    let startAt = lowest
+    for (let i = 0; i < nodeCount; i++) {
+        const node = sorted[i]
+        node.pos[index] = startAt + (gap * i)
+        startAt += node.size[index]
+    }
+}


### PR DESCRIPTION
Based on #220

- Changes the way alt + drag node works under the hood (now same as copy & paste) - fixes minor inconsistencies with downstream customisation
- Changes type checks to `typeof` / `instanceof` / `isArray`
- Removes unused (broken) code

Refactors:
- Standardises event emit calls
- TS types