### PR TITLE
Multi-link drag keeps links bundled properly

### DIFF
--- a/src/LGraphCanvas.ts
+++ b/src/LGraphCanvas.ts
@@ -2,11 +2,11 @@ import type { CanvasColour, Dictionary, Direction, IBoundaryNodes, IContextMenuO
 import type { IWidget, TWidgetValue } from "./types/widgets"
 import type { LGraphNode, NodeId } from "./LGraphNode"
 import type { CanvasDragEvent, CanvasMouseEvent, CanvasWheelEvent, CanvasEventDetail, CanvasPointerEvent } from "./types/events"
-import type { LinkDirection, RenderShape, TitleMode } from "./types/globalEnums"
 import type { IClipboardContents } from "./types/serialisation"
 import type { LLink } from "./LLink"
 import type { LGraph } from "./LGraph"
 import type { ContextMenu } from "./ContextMenu"
+import { LinkDirection, RenderShape, TitleMode } from "./types/globalEnums"
 import { LGraphGroup } from "./LGraphGroup"
 import { isInsideRectangle, distance, overlapBounding, isPointInRectangle } from "./measure"
 import { drawSlot, LabelPosition } from "./draw"
@@ -1855,6 +1855,7 @@ export class LGraphCanvas {
                                                     input: input,
                                                     output: null,
                                                     pos: pos,
+                                                    direction: node.horizontal !== true ? LinkDirection.RIGHT : LinkDirection.CENTER,
                                                 })
                                             }
 
@@ -3672,7 +3673,7 @@ export class LGraphCanvas {
                         null,
                         link_color,
                         connDir,
-                        LiteGraph.CENTER
+                        link.direction ?? LinkDirection.CENTER
                     )
 
                     ctx.beginPath()


### PR DESCRIPTION
Links keep their default curves when dragging multiple outputs.  Behaviour unchanged for "vertical" nodes.

Old behaviour:
![image](https://github.com/user-attachments/assets/34bd78cf-7a4c-4e19-a643-44e0b78ec364)

New behaviour:
![image](https://github.com/user-attachments/assets/9ed39a11-939b-411a-9b61-9342c0237272)