### PR TITLE
Add multi-group select & drag

### DIFF
--- a/src/LGraphGroup.ts
+++ b/src/LGraphGroup.ts
@@ -27,6 +27,7 @@ export class LGraphGroup {
     _nodes: LGraphNode[]
     graph?: LGraph
     flags: IGraphGroupFlags
+    selected?: boolean
 
     constructor(title?: string) {
         this._ctor(title)
@@ -74,10 +75,6 @@ export class LGraphGroup {
 
     get titleHeight() {
         return this.font_size * 1.4
-    }
-
-    get selected() {
-        return !!this.graph?.list_of_graphcanvas?.some(c => c.selected_group === this)
     }
 
     get pinned() {

--- a/src/LiteGraphGlobal.ts
+++ b/src/LiteGraphGlobal.ts
@@ -164,7 +164,7 @@ export class LiteGraphGlobal {
     use_uuids = false
 
     // Whether to highlight the bounding box of selected groups
-    highlight_selected_group = false
+    highlight_selected_group = true
 
     // TODO: Remove legacy accessors
     LGraph = LGraph


### PR DESCRIPTION
Adds basic multi-group selection & drag to move.

- Selection combines with nodes, e.g. select any node, then shift + click + drag an unrelated group to move both
- Selecting groups using a drag rectangle requires the group be wholly contained inside it.

https://github.com/user-attachments/assets/e6230a94-411e-4fba-90cb-6c694200adaa

Note: Some of this PR I've already rewritten, but it happens here on my timeline, and is pretty solid.