### PR TITLE
Add / improve Node interfaces: Find slots & before connect callback

### DIFF
--- a/src/LGraphCanvas.ts
+++ b/src/LGraphCanvas.ts
@@ -1,4 +1,4 @@
-import type { CanvasColour, Dictionary, Direction, IBoundaryNodes, IContextMenuOptions, INodeSlot, INodeInputSlot, INodeOutputSlot, IOptionalInputsData, Point, Rect, Rect32, Size, IContextMenuValue, ISlotType, ConnectingLink } from "./interfaces"
+import type { CanvasColour, Dictionary, Direction, IBoundaryNodes, IContextMenuOptions, INodeSlot, INodeInputSlot, INodeOutputSlot, IOptionalSlotData, Point, Rect, Rect32, Size, IContextMenuValue, ISlotType, ConnectingLink } from "./interfaces"
 import type { IWidget, TWidgetValue } from "./types/widgets"
 import type { LGraphNode, NodeId } from "./LGraphNode"
 import type { CanvasDragEvent, CanvasMouseEvent, CanvasWheelEvent, CanvasEventDetail, CanvasPointerEvent } from "./types/events"
@@ -230,7 +230,7 @@ export class LGraphCanvas {
     viewport?: Rect
     autoresize: boolean
     static active_canvas: LGraphCanvas
-    static onMenuNodeOutputs?(entries: IOptionalInputsData[]): IOptionalInputsData[]
+    static onMenuNodeOutputs?(entries: IOptionalSlotData<INodeOutputSlot>[]): IOptionalSlotData<INodeOutputSlot>[]
     frame: number
     last_draw_time: number
     render_time: number
@@ -718,7 +718,7 @@ export class LGraphCanvas {
             ? node.onGetInputs()
             : node.optional_inputs
 
-        let entries: IOptionalInputsData[] = []
+        let entries: IOptionalSlotData<INodeInputSlot>[] = []
         if (options) {
             for (let i = 0; i < options.length; i++) {
                 const entry = options[i]
@@ -734,7 +734,7 @@ export class LGraphCanvas {
                 }
 
                 entry[2].removable = true
-                const data: IOptionalInputsData = { content: label, value: entry }
+                const data: IOptionalSlotData<INodeInputSlot> = { content: label, value: entry }
                 if (entry[1] == LiteGraph.ACTION) {
                     data.className = "event"
                 }
@@ -795,7 +795,7 @@ export class LGraphCanvas {
             ? node.onGetOutputs()
             : node.optional_outputs
 
-        let entries: IOptionalInputsData[] = []
+        let entries: IOptionalSlotData<INodeOutputSlot>[] = []
         if (options) {
             for (let i = 0; i < options.length; i++) {
                 const entry = options[i]
@@ -816,7 +816,7 @@ export class LGraphCanvas {
                     label = entry[2].label
                 }
                 entry[2].removable = true
-                const data: IOptionalInputsData = { content: label, value: entry }
+                const data: IOptionalSlotData<INodeOutputSlot> = { content: label, value: entry }
                 if (entry[1] == LiteGraph.EVENT) {
                     data.className = "event"
                 }
@@ -827,6 +827,7 @@ export class LGraphCanvas {
         if (this.onMenuNodeOutputs) entries = this.onMenuNodeOutputs(entries)
         if (LiteGraph.do_add_triggers_slots) { //canvas.allow_addOutSlot_onExecuted
             if (node.findOutputSlot("onExecuted") == -1) {
+                // @ts-expect-error Events
                 entries.push({ content: "On Executed", value: ["onExecuted", LiteGraph.EVENT, { nameLocked: true }], className: "event" }) //, opts: {}
             }
         }

--- a/src/LGraphNode.ts
+++ b/src/LGraphNode.ts
@@ -1,4 +1,4 @@
-import type { Dictionary, IContextMenuValue, IFoundSlot, INodeFlags, INodeInputSlot, INodeOutputSlot, IOptionalInputsData, ISlotType, Point, Rect, Size } from "./interfaces"
+import type { Dictionary, IContextMenuValue, IFoundSlot, INodeFlags, INodeInputSlot, INodeOutputSlot, IOptionalSlotData, ISlotType, Point, Rect, Size } from "./interfaces"
 import type { LGraph } from "./LGraph"
 import type { IWidget, TWidgetValue } from "./types/widgets"
 import type { ISerialisedNode } from "./types/serialisation"
@@ -244,7 +244,7 @@ export class LGraphNode {
     onDrawCollapsed?(this: LGraphNode, ctx: CanvasRenderingContext2D, cavnas: LGraphCanvas): boolean
     onDrawForeground?(this: LGraphNode, ctx: CanvasRenderingContext2D, canvas: LGraphCanvas, canvasElement: HTMLCanvasElement): void
     onMouseLeave?(this: LGraphNode, e: CanvasMouseEvent): void
-    getSlotMenuOptions?(this: LGraphNode, slot: any): IOptionalInputsData[]
+    getSlotMenuOptions?(this: LGraphNode, slot: IFoundSlot): IContextMenuValue[]
     // FIXME: Re-typing
     onDropItem?(this: LGraphNode, event: Event): boolean
     onDropData?(this: LGraphNode, data: string | ArrayBuffer, filename: any, file: any): void
@@ -257,8 +257,8 @@ export class LGraphNode {
     onGetPropertyInfo?(this: LGraphNode, property: string): any
     onNodeOutputAdd?(this: LGraphNode, value): void
     onNodeInputAdd?(this: LGraphNode, value): void
-    onMenuNodeInputs?(this: LGraphNode, entries: IOptionalInputsData[]): IOptionalInputsData[]
-    onMenuNodeOutputs?(this: LGraphNode, entries: IOptionalInputsData[]): IOptionalInputsData[]
+    onMenuNodeInputs?(this: LGraphNode, entries: IOptionalSlotData<INodeInputSlot>[]): IOptionalSlotData<INodeInputSlot>[]
+    onMenuNodeOutputs?(this: LGraphNode, entries: IOptionalSlotData<INodeOutputSlot>[]): IOptionalSlotData<INodeOutputSlot>[]
     onGetInputs?(this: LGraphNode): INodeInputSlot[]
     onGetOutputs?(this: LGraphNode): INodeOutputSlot[]
     onMouseUp?(this: LGraphNode, e: CanvasMouseEvent, pos: Point): void

--- a/src/LGraphNode.ts
+++ b/src/LGraphNode.ts
@@ -1592,8 +1592,7 @@ export class LGraphNode {
 
     /**
      * Finds the next free slot
-     * @param isInput If true, search for an input.  Otherwise, search for an output.
-     * @param slots The slots to search, i.e. this.inputs or this.outputs.  Must match provided value in isInput.
+     * @param slots The slots to search, i.e. this.inputs or this.outputs
      * @param options Options
      */
     #findFreeSlot<TSlot extends INodeInputSlot | INodeOutputSlot>(slots: TSlot[], options?: FindFreeSlotOptions): TSlot | number {
@@ -1754,11 +1753,11 @@ export class LGraphNode {
     /**
      * connect this node output to the input of another node BY TYPE
      * @param {number} slot (could be the number of the slot or the string with the name of the slot)
-     * @param {LGraphNode} node the target node
-     * @param {string} target_type the input slot type of the target node
+     * @param {LGraphNode} target_node the target node
+     * @param {string} target_slotType the input slot type of the target node
      * @return {Object} the link_info is created, otherwise null
      */
-    connectByType(slot: number, target_node: LGraphNode, target_slotType: ISlotType, optsIn?: ConnectByTypeOptions): LLink | null {
+    connectByType(slot: number | string, target_node: LGraphNode, target_slotType: ISlotType, optsIn?: ConnectByTypeOptions): LLink | null {
         const slotIndex = this.findConnectByTypeSlot(true, target_node, target_slotType, optsIn)
         if (slotIndex !== null) return this.connect(slot, target_node, slotIndex)
         return null
@@ -1767,12 +1766,12 @@ export class LGraphNode {
     /**
      * connect this node input to the output of another node BY TYPE
      * @method connectByType
-     * @param {number_or_string} slot (could be the number of the slot or the string with the name of the slot)
+     * @param {number | string} slot (could be the number of the slot or the string with the name of the slot)
      * @param {LGraphNode} source_node the target node
      * @param {string} source_slotType the output slot type of the target node
      * @return {Object} the link_info is created, otherwise null
      */
-    connectByTypeOutput(slot: number, source_node: LGraphNode, source_slotType: ISlotType, optsIn?: ConnectByTypeOptions): LLink | null {
+    connectByTypeOutput(slot: number | string, source_node: LGraphNode, source_slotType: ISlotType, optsIn?: ConnectByTypeOptions): LLink | null {
         // LEGACY: Old options names
         if (typeof optsIn === "object") {
             if ("firstFreeIfInputGeneralInCase" in optsIn) optsIn.wildcardToTyped = !!optsIn.firstFreeIfInputGeneralInCase
@@ -1790,7 +1789,7 @@ export class LGraphNode {
      * @param {number_or_string} target_slot the input slot of the target node (could be the number of the slot or the string with the name of the slot, or -1 to connect a trigger)
      * @return {Object} the link_info is created, otherwise null
      */
-    connect(slot: number, target_node: LGraphNode, target_slot: ISlotType | false): LLink | null {
+    connect(slot: number | string, target_node: LGraphNode, target_slot: ISlotType | false): LLink | null {
         target_slot = target_slot || 0
 
         if (!this.graph) {

--- a/src/LGraphNode.ts
+++ b/src/LGraphNode.ts
@@ -103,7 +103,7 @@ supported callbacks:
 */
 
 export interface LGraphNode {
-    constructor?: LGraphNodeConstructor
+    constructor: LGraphNodeConstructor
 }
 
 /**
@@ -1088,7 +1088,7 @@ export class LGraphNode {
     addOutputs(array: [string, ISlotType, Record<string, unknown>][]): void {
         for (let i = 0; i < array.length; ++i) {
             const info = array[i]
-            const o = { name: info[0], type: info[1], link: null }
+            const o = { name: info[0], type: info[1], links: null }
             if (array[2]) {
                 for (const j in info[2]) {
                     o[j] = info[2][j]

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -54,10 +54,9 @@ export interface IBoundaryNodes {
 
 export type Direction = "top" | "bottom" | "left" | "right"
 
-// TODO: Rename IOptionalSlotsData
-export interface IOptionalInputsData {
+export interface IOptionalSlotData<TSlot extends INodeInputSlot | INodeOutputSlot> {
     content: string
-    value?
+    value: TSlot
     className?: string
 }
 

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -87,12 +87,12 @@ export interface INodeFlags {
 }
 
 export interface INodeInputSlot extends INodeSlot {
-    link?: LinkId
+    link: LinkId | null
     not_subgraph_input?: boolean
 }
 
 export interface INodeOutputSlot extends INodeSlot {
-    links?: LinkId[]
+    links: LinkId[] | null
     _data?: unknown
     slot_index?: number
     not_subgraph_output?: boolean

--- a/src/litegraph.ts
+++ b/src/litegraph.ts
@@ -1,5 +1,5 @@
 import type { Point, ConnectingLink } from "./interfaces"
-import type { INodeSlot, INodeInputSlot, INodeOutputSlot, CanvasColour, Direction, IBoundaryNodes, IContextMenuOptions, IContextMenuValue, IFoundSlot, IInputOrOutput, INodeFlags, IOptionalInputsData, ISlotType, KeysOfType, MethodNames, PickByType, Rect, Rect32, Size } from "./interfaces"
+import type { INodeSlot, INodeInputSlot, INodeOutputSlot, CanvasColour, Direction, IBoundaryNodes, IContextMenuOptions, IContextMenuValue, IFoundSlot, IInputOrOutput, INodeFlags, IOptionalSlotData, ISlotType, KeysOfType, MethodNames, PickByType, Rect, Rect32, Size } from "./interfaces"
 import type { SlotShape, LabelPosition, SlotDirection, SlotType } from "./draw"
 import type { IWidget } from "./types/widgets"
 import type { RenderShape, TitleMode } from "./types/globalEnums"
@@ -19,7 +19,7 @@ import { LGraphBadge, BadgePosition } from "./LGraphBadge"
 
 export const LiteGraph = new LiteGraphGlobal()
 export { LGraph, LGraphCanvas, DragAndScale, LGraphNode, LGraphGroup, LLink, ContextMenu, CurveEditor }
-export { INodeSlot, INodeInputSlot, INodeOutputSlot, ConnectingLink, CanvasColour, Direction, IBoundaryNodes, IContextMenuOptions, IContextMenuValue, IFoundSlot, IInputOrOutput, INodeFlags, IOptionalInputsData, ISlotType, KeysOfType, MethodNames, PickByType, Rect, Rect32, Size }
+export { INodeSlot, INodeInputSlot, INodeOutputSlot, ConnectingLink, CanvasColour, Direction, IBoundaryNodes, IContextMenuOptions, IContextMenuValue, IFoundSlot, IInputOrOutput, INodeFlags, IOptionalSlotData, ISlotType, KeysOfType, MethodNames, PickByType, Rect, Rect32, Size }
 export { IWidget }
 export { LGraphBadge, BadgePosition }
 export { SlotShape, LabelPosition, SlotDirection, SlotType }


### PR DESCRIPTION
- Backwards compatible
- Moves slot find logic out from `connectByType` functions to new find functions, so links don't need to be backed up, created, deleted, and restored just to get a slot index
- Extend node before-connect callback: can now determine if connection is to a specific input, or just trying to connect any valid slot on the node
- Refactored input/output duplication to generics