### PR TITLE
Add default group colour option

### DIFF
--- a/src/LGraphGroup.ts
+++ b/src/LGraphGroup.ts
@@ -121,8 +121,8 @@ export class LGraphGroup {
     draw(graphCanvas: LGraphCanvas, ctx: CanvasRenderingContext2D): void {
         const padding = 4
 
-        ctx.fillStyle = this.color
-        ctx.strokeStyle = this.color
+        ctx.fillStyle = this.color ?? LiteGraph.DEFAULT_GROUP_COLOR
+        ctx.strokeStyle = this.color ?? LiteGraph.DEFAULT_GROUP_COLOR
         const [x, y] = this._pos
         const [width, height] = this._size
         ctx.globalAlpha = 0.25 * graphCanvas.editor_alpha

--- a/src/LiteGraphGlobal.ts
+++ b/src/LiteGraphGlobal.ts
@@ -48,6 +48,7 @@ export class LiteGraphGlobal {
     DEFAULT_SHADOW_COLOR = "rgba(0,0,0,0.5)"
     DEFAULT_GROUP_FONT = 24
     DEFAULT_GROUP_FONT_SIZE?: any
+    DEFAULT_GROUP_COLOR?: string
 
     WIDGET_BGCOLOR = "#222"
     WIDGET_OUTLINE_COLOR = "#666"


### PR DESCRIPTION
Resolves #234 

.. More or less.

For this change to change anything, `LiteGraph.DEFAULT_GROUP_COLOR` must be configured, which can be done directly, or as part of a Comfy theme.