### PR TITLE
Add / fix canvas TS strict types, doc

### DIFF
--- a/src/LGraphCanvas.ts
+++ b/src/LGraphCanvas.ts
@@ -251,35 +251,35 @@ export class LGraphCanvas {
     autoresize: boolean
     static active_canvas: LGraphCanvas
     static onMenuNodeOutputs?(entries: IOptionalSlotData<INodeOutputSlot>[]): IOptionalSlotData<INodeOutputSlot>[]
-    frame: number
-    last_draw_time: number
-    render_time: number
-    fps: number
-    selected_nodes: Dictionary<LGraphNode>
+    frame = 0
+    last_draw_time = 0
+    render_time = 0
+    fps = 0
+    selected_nodes: Dictionary<LGraphNode> = {}
     /** @deprecated Temporary implementation only - will be replaced with `selectedItems: Set<Positionable>`. */
-    selectedGroups: Set<LGraphGroup>
-    selected_group: LGraphGroup
-    visible_nodes: LGraphNode[]
+    selectedGroups: Set<LGraphGroup> = new Set()
+    selected_group: LGraphGroup | null = null
+    visible_nodes: LGraphNode[] = []
     node_dragged?: LGraphNode
     node_over?: LGraphNode
     node_capturing_input?: LGraphNode
-    highlighted_links: Dictionary<boolean>
+    highlighted_links: Dictionary<boolean> = {}
     link_over_widget?: IWidget
     link_over_widget_type?: string
 
-    dirty_canvas: boolean
-    dirty_bgcanvas: boolean
+    dirty_canvas: boolean = true
+    dirty_bgcanvas: boolean = true
     /** A map of nodes that require selective-redraw */
     dirty_nodes = new Map<NodeId, LGraphNode>()
     dirty_area?: Rect
     // Unused
     node_in_panel?: LGraphNode
-    last_mouse: Point
-    last_mouseclick: number
-    pointer_is_down: boolean
-    pointer_is_double: boolean
-    graph: LGraph
-    _graph_stack: LGraph[]
+    last_mouse: Point = [0, 0]
+    last_mouseclick: number = 0
+    pointer_is_down: boolean = false
+    pointer_is_double: boolean = false
+    graph!: LGraph
+    _graph_stack: LGraph[] | null = null
     canvas: HTMLCanvasElement
     bgcanvas: HTMLCanvasElement
     ctx?: CanvasRenderingContext2D

--- a/src/LGraphCanvas.ts
+++ b/src/LGraphCanvas.ts
@@ -208,8 +208,8 @@ export class LGraphCanvas {
     allow_reconnect_links: boolean
     align_to_grid: boolean
     drag_mode: boolean
-    dragging_rectangle?: Rect
-    filter?: string
+    dragging_rectangle: Rect | null
+    filter?: string | null
     set_canvas_dirty_on_mouse_event: boolean
     always_render_background: boolean
     render_shadows: boolean
@@ -223,23 +223,30 @@ export class LGraphCanvas {
     render_title_colored: boolean
     render_link_tooltip: boolean
     links_render_mode: number
+    /** mouse in canvas coordinates, where 0,0 is the top-left corner of the blue rectangle */
     mouse: Point
+    /** mouse in graph coordinates, where 0,0 is the top-left corner of the blue rectangle */
     graph_mouse: Point
+    /** @deprecated LEGACY: REMOVE THIS, USE {@link graph_mouse} INSTEAD */
     canvas_mouse: Point
+    /** to personalize the search box */
     onSearchBox?: (helper: Element, str: string, canvas: LGraphCanvas) => any
     onSearchBoxSelection?: (name: any, event: any, canvas: LGraphCanvas) => void
     onMouse?: (e: CanvasMouseEvent) => boolean
+    /** to render background objects (behind nodes and connections) in the canvas affected by transform */
     onDrawBackground?: (ctx: CanvasRenderingContext2D, visible_area: any) => void
+    /** to render foreground objects (above nodes and connections) in the canvas affected by transform */
     onDrawForeground?: (arg0: CanvasRenderingContext2D, arg1: any) => void
     connections_width: number
     round_radius: number
-    current_node: LGraphNode
-    node_widget?: [LGraphNode, IWidget]
-    over_link_center: LLink
+    current_node: LGraphNode | null
+    /** used for widgets */
+    node_widget?: [LGraphNode, IWidget] | null
+    over_link_center: LLink | null
     last_mouse_position: Point
     visible_area?: Rect32
     visible_links?: LLink[]
-    connecting_links: ConnectingLink[]
+    connecting_links: ConnectingLink[] | null
     viewport?: Rect
     autoresize: boolean
     static active_canvas: LGraphCanvas
@@ -312,12 +319,18 @@ export class LGraphCanvas {
     getMenuOptions?(): IContextMenuValue[]
     getExtraMenuOptions?(canvas: LGraphCanvas, options: IContextMenuValue[]): IContextMenuValue[]
     static active_node: LGraphNode
+    /** called before modifying the graph */
     onBeforeChange?(graph: LGraph): void
+    /** called after modifying the graph */
     onAfterChange?(graph: LGraph): void
     onClear?: () => void
+    /** called after moving a node */
     onNodeMoved?: (node_dragged: LGraphNode) => void
+    /** called if the selection changes */
     onSelectionChange?: (selected_nodes: Dictionary<LGraphNode>) => void
+    /** called when rendering a tooltip */
     onDrawLinkTooltip?: (ctx: CanvasRenderingContext2D, link: LLink, canvas?: LGraphCanvas) => boolean
+    /** to render foreground objects not affected by transform (for GUIs) */
     onDrawOverlay?: (ctx: CanvasRenderingContext2D) => void
     onRenderBackground?: (canvas: HTMLCanvasElement, ctx: CanvasRenderingContext2D) => boolean
     onNodeDblClicked?: (n: LGraphNode) => void
@@ -409,9 +422,9 @@ export class LGraphCanvas {
 
         this.links_render_mode = LiteGraph.SPLINE_LINK
 
-        this.mouse = [0, 0] //mouse in canvas coordinates, where 0,0 is the top-left corner of the blue rectangle
-        this.graph_mouse = [0, 0] //mouse in graph coordinates, where 0,0 is the top-left corner of the blue rectangle
-        this.canvas_mouse = this.graph_mouse //LEGACY: REMOVE THIS, USE GRAPH_MOUSE INSTEAD
+        this.mouse = [0, 0]
+        this.graph_mouse = [0, 0]
+        this.canvas_mouse = this.graph_mouse
 
         //to personalize the search box
         this.onSearchBox = null
@@ -419,23 +432,24 @@ export class LGraphCanvas {
 
         //callbacks
         this.onMouse = null
-        this.onDrawBackground = null //to render background objects (behind nodes and connections) in the canvas affected by transform
-        this.onDrawForeground = null //to render foreground objects (above nodes and connections) in the canvas affected by transform
-        this.onDrawOverlay = null //to render foreground objects not affected by transform (for GUIs)
-        this.onDrawLinkTooltip = null //called when rendering a tooltip
-        this.onNodeMoved = null //called after moving a node
-        this.onSelectionChange = null //called if the selection changes
+        this.onDrawBackground = null
+        this.onDrawForeground = null
+        this.onDrawOverlay = null
+        this.onDrawLinkTooltip = null
+        this.onNodeMoved = null
+        this.onSelectionChange = null
         // FIXME: Typo, does nothing
+        //called before any link changes
         // @ts-expect-error
-        this.onConnectingChange = null //called before any link changes
-        this.onBeforeChange = null //called before modifying the graph
-        this.onAfterChange = null //called after modifying the graph
+        this.onConnectingChange = null
+        this.onBeforeChange = null
+        this.onAfterChange = null
 
         this.connections_width = 3
         this.round_radius = 8
 
         this.current_node = null
-        this.node_widget = null //used for widgets
+        this.node_widget = null
         this.over_link_center = null
         this.last_mouse_position = [0, 0]
         this.visible_area = this.ds.visible_area

--- a/src/LGraphCanvas.ts
+++ b/src/LGraphCanvas.ts
@@ -643,8 +643,8 @@ export class LGraphCanvas {
             parentMenu: prev_menu,
         })
 
-        function inner_clicked(value) {
-            LGraphCanvas.alignNodes(LGraphCanvas.active_canvas.selected_nodes, value.toLowerCase())
+        function inner_clicked(value: string) {
+            LGraphCanvas.alignNodes(LGraphCanvas.active_canvas.selected_nodes, (value.toLowerCase() as Direction))
         }
     }
     static createDistributeMenu(value: IContextMenuValue, options: IContextMenuOptions, event: MouseEvent, prev_menu: ContextMenu, node: LGraphNode): void {

--- a/src/LiteGraphGlobal.ts
+++ b/src/LiteGraphGlobal.ts
@@ -6,7 +6,6 @@ import { LGraphCanvas } from "./LGraphCanvas"
 import { ContextMenu } from "./ContextMenu"
 import { CurveEditor } from "./CurveEditor"
 import { LGraphEventMode, LinkDirection, LinkRenderType, NodeSlotType, RenderShape, TitleMode } from "./types/globalEnums"
-import { LiteGraph } from "./litegraph"
 import { LGraphNode } from "./LGraphNode"
 import { SlotShape, SlotDirection, SlotType, LabelPosition } from "./draw"
 import type { Dictionary, ISlotType, Rect } from "./interfaces"
@@ -707,7 +706,7 @@ export class LiteGraphGlobal {
     pointerListenerAdd(oDOM: Node, sEvIn: string, fCall: (e: Event) => boolean | void, capture = false): void {
         if (!oDOM || !oDOM.addEventListener || !sEvIn || typeof fCall !== "function") return
 
-        let sMethod = LiteGraph.pointerevents_method
+        let sMethod = this.pointerevents_method
         let sEvent = sEvIn
 
         // UNDER CONSTRUCTION
@@ -775,16 +774,16 @@ export class LiteGraphGlobal {
             //both pointer and move events
             case "down": case "up": case "move": case "over": case "out": case "enter":
                 {
-                    if (LiteGraph.pointerevents_method == "pointer" || LiteGraph.pointerevents_method == "mouse") {
-                        oDOM.removeEventListener(LiteGraph.pointerevents_method + sEvent, fCall, capture)
+                    if (this.pointerevents_method == "pointer" || this.pointerevents_method == "mouse") {
+                        oDOM.removeEventListener(this.pointerevents_method + sEvent, fCall, capture)
                     }
                 }
             // @ts-expect-error
             // only pointerevents
             case "leave": case "cancel": case "gotpointercapture": case "lostpointercapture":
                 {
-                    if (LiteGraph.pointerevents_method == "pointer") {
-                        return oDOM.removeEventListener(LiteGraph.pointerevents_method + sEvent, fCall, capture)
+                    if (this.pointerevents_method == "pointer") {
+                        return oDOM.removeEventListener(this.pointerevents_method + sEvent, fCall, capture)
                     }
                 }
             // not "pointer" || "mouse"

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -5,6 +5,11 @@ import type { LinkId } from "./LLink"
 
 export type Dictionary<T> = { [key: string]: T }
 
+/** Allows all properties to be null.  The same as `Partial<T>`, but adds null instead of undefined. */
+export type NullableProperties<T> = {
+    [P in keyof T]: T[P] | null
+}
+
 export type CanvasColour = string | CanvasGradient | CanvasPattern
 
 export interface IInputOrOutput {

--- a/src/types/events.ts
+++ b/src/types/events.ts
@@ -58,7 +58,7 @@ export interface GenericEventDetail {
 }
 
 export interface OriginalEvent {
-    originalEvent: CanvasMouseEvent,
+    originalEvent: CanvasPointerEvent,
 }
 
 export interface EmptyReleaseEventDetail extends OriginalEvent {

--- a/src/utils/arrange.ts
+++ b/src/utils/arrange.ts
@@ -1,5 +1,44 @@
+import type { Dictionary, Direction, IBoundaryNodes } from "@/interfaces"
 import type { LGraphNode } from "@/LGraphNode"
 
+/**
+ * Finds the nodes that are farthest in all four directions, representing the boundary of the nodes.
+ * @param nodes The nodes to check the edges of
+ * @returns An object listing the furthest node (edge) in all four directions.  `null` if no nodes were supplied or the first node was falsy.
+ */
+export function getBoundaryNodes(nodes: LGraphNode[]): IBoundaryNodes | null {
+    const valid = nodes?.find(x => x)
+    if (!valid) return null
+
+    let top = valid
+    let right = valid
+    let bottom = valid
+    let left = valid
+
+    for (const node of nodes) {
+        if (!node) continue
+        const [x, y] = node.pos
+        const [width, height] = node.size
+
+        if (y < top.pos[1]) top = node
+        if (x + width > right.pos[0] + right.size[0]) right = node
+        if (y + height > bottom.pos[1] + bottom.size[1]) bottom = node
+        if (x < left.pos[0]) left = node
+    }
+
+    return {
+        top,
+        right,
+        bottom,
+        left
+    }
+}
+
+/**
+ * Distributes nodes evenly along a horizontal or vertical plane.
+ * @param nodes The nodes to distribute
+ * @param horizontal If true, distributes along the horizontal plane.  Otherwise, the vertical plane.
+ */
 export function distributeNodes(nodes: LGraphNode[], horizontal?: boolean): void {
     const nodeCount = nodes?.length
     if (!(nodeCount > 1)) return
@@ -24,5 +63,43 @@ export function distributeNodes(nodes: LGraphNode[], horizontal?: boolean): void
         const node = sorted[i]
         node.pos[index] = startAt + (gap * i)
         startAt += node.size[index]
+    }
+}
+
+/**
+ * Aligns all nodes along the edge of a node.
+ * @param nodes The nodes to align
+ * @param direction The edge to align nodes on
+ * @param align_to The node to align all other nodes to.  If undefined, the farthest node will be used.
+ */
+export function alignNodes(nodes: LGraphNode[], direction: Direction, align_to?: LGraphNode): void {
+    if (!nodes) return
+
+    const boundary = align_to === undefined
+        ? getBoundaryNodes(nodes)
+        : {
+            top: align_to,
+            right: align_to,
+            bottom: align_to,
+            left: align_to
+        }
+
+    if (boundary === null) return
+
+    for (const node of nodes) {
+        switch (direction) {
+            case "right":
+                node.pos[0] = boundary.right.pos[0] + boundary.right.size[0] - node.size[0]
+                break
+            case "left":
+                node.pos[0] = boundary.left.pos[0]
+                break
+            case "top":
+                node.pos[1] = boundary.top.pos[1]
+                break
+            case "bottom":
+                node.pos[1] = boundary.bottom.pos[1] + boundary.bottom.size[1] - node.size[1]
+                break
+        }
     }
 }


### PR DESCRIPTION
Some minor changes in:
- [Fix circular depdency in global](https://github.com/Comfy-Org/litegraph.js/commit/5894e8eeb1f1a43b1547f1ffdeb0ea2298cd40fd)
- [Add TS type guard private function](https://github.com/Comfy-Org/litegraph.js/commit/c7f8589ce61e27cfa61495a2a464f57ff3d98d89)
- [Split node arrange code out to separate file](https://github.com/Comfy-Org/litegraph.js/commit/d369c33b1df5e3cea5848e3f5df56523cb59de05)

The rest is:
- Add / fix TS strict types
- Add property initializers
- Docs