### PR TITLE
Snaps for Comfy 🫰

### DIFF
--- a/src/LGraphCanvas.ts
+++ b/src/LGraphCanvas.ts
@@ -3933,7 +3933,6 @@ export class LGraphCanvas {
         const node = this.node_over
         if (!(node && this.connecting_links?.[0])) return
 
-        const transform = ctx.getTransform()
         const { strokeStyle, lineWidth } = ctx
 
         const area = LGraphCanvas.#tmp_area
@@ -3947,7 +3946,6 @@ export class LGraphCanvas {
         const width = area[2] + (gap * 2)
         const height = area[3] + (gap * 2)
 
-        ctx.translate(node.pos[0], node.pos[1])
         ctx.beginPath()
         ctx.roundRect(x, y, width, height, radius)
 
@@ -3956,8 +3954,8 @@ export class LGraphCanvas {
         const inverter = start ? -1 : 1
 
         // Radial highlight centred on highlight pos
-        const hx = highlightPos[0] - node.pos[0]
-        const hy = highlightPos[1] - node.pos[1]
+        const hx = highlightPos[0]
+        const hy = highlightPos[1]
         const gRadius = width < height
             ? width
             : width * Math.max(height / width, 0.5)
@@ -3989,7 +3987,6 @@ export class LGraphCanvas {
         ctx.setLineDash([])
         ctx.lineWidth = lineWidth
         ctx.strokeStyle = strokeStyle
-        ctx.setTransform(transform)
     }
 
     /**
@@ -4770,8 +4767,12 @@ export class LGraphCanvas {
             ? false
             : true
 
+        // Normalised node dimensions
         const area = LGraphCanvas.#tmp_area
         node.measure(area)
+        area[0] -= node.pos[0]
+        area[1] -= node.pos[1]
+        area[2]++
 
         const old_alpha = ctx.globalAlpha
 

--- a/src/LGraphNode.ts
+++ b/src/LGraphNode.ts
@@ -1423,6 +1423,22 @@ export class LGraphNode {
     }
 
     /**
+     * Measures the node for rendering, populating outArea with the results in graph space.
+     * @param out Results (x, y, width, height) are inserted into this array.
+     * @param pad Expands the area by this amount on each side.  Default: 0
+     */
+    measure(out: Rect, pad = 0): void {
+        const titleMode = this.constructor.title_mode
+        const renderTitle = titleMode != LiteGraph.TRANSPARENT_TITLE && titleMode != LiteGraph.NO_TITLE
+        const titleHeight = renderTitle ? LiteGraph.NODE_TITLE_HEIGHT : 0
+
+        out[0] = 0 - pad
+        out[1] = -titleHeight - pad
+        out[2] = this.size[0] + 1 + (2 * pad)
+        out[3] = this.size[1] + titleHeight + (2 * pad)
+    }
+
+    /**
      * returns the bounding of the object, used for rendering purposes
      * @param out {Float32Array[4]?} [optional] a place to store the output, to free garbage
      * @param compute_outer {boolean?} [optional] set to true to include the shadow and connection points in the bounding calculation

--- a/src/LGraphNode.ts
+++ b/src/LGraphNode.ts
@@ -1748,8 +1748,10 @@ export class LGraphNode {
         }
         // connect to the first free input slot if not found a specific type and this output is general
         if (opts.wildcardToTyped && (slotType == 0 || slotType == "*" || slotType == "")) {
-            const find = findInputs ? node.findInputSlotFree : node.findOutputSlotFree
-            const nonEventSlot = find({ typesNotAccepted: [LiteGraph.EVENT] })
+            const opt = { typesNotAccepted: [LiteGraph.EVENT] }
+            const nonEventSlot = findInputs
+                ? node.findInputSlotFree(opt)
+                : node.findOutputSlotFree(opt)
             if (nonEventSlot >= 0) return nonEventSlot
         }
         return null

--- a/src/LGraphNode.ts
+++ b/src/LGraphNode.ts
@@ -24,8 +24,9 @@ export type INodeProperties = Dictionary<unknown> & {
 }
 
 interface IMouseOverData {
-    inputId: number
-    outputId: number
+    inputId: number | null
+    outputId: number | null
+    overWidget: IWidget | null
 }
 
 interface ConnectByTypeOptions {

--- a/src/LiteGraphGlobal.ts
+++ b/src/LiteGraphGlobal.ts
@@ -130,6 +130,7 @@ export class LiteGraphGlobal {
     shift_click_do_break_link_from = false // [false!] prefer false if results too easy to break links - implement with ALT or TODO custom keys
     click_do_break_link_to = false // [false!]prefer false, way too easy to break links
     ctrl_alt_click_do_break_link = true // [true!] who accidentally ctrl-alt-clicks on an in/output? nobody! that's who!
+    snaps_for_comfy = true // [true!] snaps links when dragging connections over valid targets
 
     search_hide_on_mouse_leave = true // [false on mobile] better true if not touch device, TODO add an helper/listener to close if false
     search_filter_enabled = false // [true!] enable filtering slots type in the search widget, !requires auto_load_slot_types or manual set registered_slot_[in/out]_types and slot_types_[in/out]

--- a/src/LiteGraphGlobal.ts
+++ b/src/LiteGraphGlobal.ts
@@ -131,6 +131,7 @@ export class LiteGraphGlobal {
     click_do_break_link_to = false // [false!]prefer false, way too easy to break links
     ctrl_alt_click_do_break_link = true // [true!] who accidentally ctrl-alt-clicks on an in/output? nobody! that's who!
     snaps_for_comfy = true // [true!] snaps links when dragging connections over valid targets
+    snap_highlights_node = true // [true!] renders a partial border to highlight when a dragged link is snapped to a node
 
     search_hide_on_mouse_leave = true // [false on mobile] better true if not touch device, TODO add an helper/listener to close if false
     search_filter_enabled = false // [true!] enable filtering slots type in the search widget, !requires auto_load_slot_types or manual set registered_slot_[in/out]_types and slot_types_[in/out]


### PR DESCRIPTION
### Snaps for Comfy 🫰

Snaps connecting links to the target slot when hovering over nodes.  An edge glow effect indicates that the link has snapped.

https://github.com/user-attachments/assets/f2f2f1da-71f9-4f44-93e5-d2230b5b72a8

- Uses existing hard-coded colours
- Snap border indicator can be disabled
- All features in this PR can be completely disabled via LiteGraph setting
- Does _not_ use animations