### PR TITLE
Convert Links to ES6 Map & LLink Serialisation

### DIFF
--- a/src/LGraphCanvas.ts
+++ b/src/LGraphCanvas.ts
@@ -1794,7 +1794,7 @@ export class LGraphCanvas {
 
                                             this.connecting_links = []
                                             for (const linkId of output.links) {
-                                                const link = this.graph.links[linkId]
+                                                const link = this.graph._links.get(linkId)
                                                 const slot = link.target_slot
                                                 const linked_node = this.graph._nodes_by_id[link.target_id]
                                                 const input = linked_node.inputs[slot]
@@ -1869,7 +1869,7 @@ export class LGraphCanvas {
 
                                     if (input.link !== null) {
                                         //before disconnecting
-                                        const link_info = this.graph.links[input.link]
+                                        const link_info = this.graph._links.get(input.link)
                                         const slot = link_info.origin_slot
                                         const linked_node = this.graph._nodes_by_id[link_info.origin_id]
                                         if (LiteGraph.click_do_break_link_to || (LiteGraph.ctrl_alt_click_do_break_link && e.ctrlKey && e.altKey && !e.shiftKey)) {
@@ -3002,7 +3002,7 @@ export class LGraphCanvas {
                     const input = node.inputs[j]
                     if (!input || input.link == null) continue
 
-                    const link_info = this.graph.links[input.link]
+                    const link_info = this.graph._links.get(input.link)
                     if (!link_info) continue
 
                     const target_node = this.graph.getNodeById(link_info.origin_id)
@@ -3336,8 +3336,8 @@ export class LGraphCanvas {
 
             //autoconnect when possible (very basic, only takes into account first input-output)
             if (node.inputs?.length && node.outputs && node.outputs.length && LiteGraph.isValidConnection(node.inputs[0].type, node.outputs[0].type) && node.inputs[0].link && node.outputs[0].links && node.outputs[0].links.length) {
-                const input_link = node.graph.links[node.inputs[0].link]
-                const output_link = node.graph.links[node.outputs[0].links[0]]
+                const input_link = node.graph._links.get(node.inputs[0].link)
+                const output_link = node.graph._links.get(node.outputs[0].links[0])
                 const input_node = node.getInputNode(0)
                 const output_node = node.getOutputNodes(0)[0]
                 if (input_node && output_node)
@@ -4941,7 +4941,7 @@ export class LGraphCanvas {
                 if (!input || input.link == null) continue
 
                 const link_id = input.link
-                const link = this.graph.links[link_id]
+                const link = this.graph._links.get(link_id)
                 if (!link) continue
 
                 //find link info

--- a/src/LGraphNode.ts
+++ b/src/LGraphNode.ts
@@ -1996,7 +1996,7 @@ export class LGraphNode {
 
                     //remove the link from the links pool
                     graph._links.delete(link_id)
-                    if (graph) graph._version++
+                    graph._version++
 
                     //link_info hasn't been modified so its ok
                     target_node.onConnectionsChange?.(
@@ -2014,10 +2014,8 @@ export class LGraphNode {
                         output
                     )
 
-                    // FIXME: Called twice.
-                    graph?.onNodeConnectionChange?.(NodeSlotType.OUTPUT, this, slot)
-                    graph?.onNodeConnectionChange?.(NodeSlotType.OUTPUT, this, slot)
-                    graph?.onNodeConnectionChange?.(NodeSlotType.INPUT, target_node, link_info.target_slot)
+                    graph.onNodeConnectionChange?.(NodeSlotType.OUTPUT, this, slot)
+                    graph.onNodeConnectionChange?.(NodeSlotType.INPUT, target_node, link_info.target_slot)
                     break
                 }
             }
@@ -2030,7 +2028,7 @@ export class LGraphNode {
                 if (!link_info) continue
 
                 target_node = graph.getNodeById(link_info.target_id)
-                if (graph) graph._version++
+                graph._version++
 
                 if (target_node) {
                     const input = target_node.inputs[link_info.target_slot]
@@ -2045,8 +2043,6 @@ export class LGraphNode {
                         link_info,
                         input
                     )
-                    // FIXME: Called twice.
-                    graph?.onNodeConnectionChange?.(NodeSlotType.INPUT, target_node, link_info.target_slot)
                 }
                 //remove the link from the links pool
                 graph._links.delete(link_id)
@@ -2058,8 +2054,8 @@ export class LGraphNode {
                     link_info,
                     output
                 )
-                graph?.onNodeConnectionChange?.(NodeSlotType.OUTPUT, this, slot)
-                graph?.onNodeConnectionChange?.(NodeSlotType.INPUT, target_node, link_info.target_slot)
+                graph.onNodeConnectionChange?.(NodeSlotType.OUTPUT, this, slot)
+                graph.onNodeConnectionChange?.(NodeSlotType.INPUT, target_node, link_info.target_slot)
             }
             output.links = null
         }
@@ -2090,9 +2086,7 @@ export class LGraphNode {
         }
 
         const input = this.inputs[slot]
-        if (!input) {
-            return false
-        }
+        if (!input) return false
 
         const link_id = this.inputs[slot].link
         if (link_id != null) {
@@ -2102,14 +2096,10 @@ export class LGraphNode {
             const link_info = this.graph._links.get(link_id)
             if (link_info) {
                 const target_node = this.graph.getNodeById(link_info.origin_id)
-                if (!target_node) {
-                    return false
-                }
+                if (!target_node) return false
 
                 const output = target_node.outputs[link_info.origin_slot]
-                if (!(output?.links?.length > 0)) {
-                    return false
-                }
+                if (!(output?.links?.length > 0)) return false
 
                 //search in the inputs list for this link
                 let i = 0

--- a/src/LLink.ts
+++ b/src/LLink.ts
@@ -1,12 +1,13 @@
 import type { CanvasColour, ISlotType } from "./interfaces"
 import type { NodeId } from "./LGraphNode"
+import type { Serialisable, SerialisableLLink } from "./types/serialisation"
 
 export type LinkId = number | string
 
 export type SerialisedLLinkArray = [LinkId, NodeId, number, NodeId, number, ISlotType]
 
 //this is the class in charge of storing link information
-export class LLink {
+export class LLink implements Serialisable<SerialisableLLink> {
     /** Link ID */
     id: LinkId
     type: ISlotType
@@ -46,8 +47,18 @@ export class LLink {
         this._pos = new Float32Array(2) //center
     }
 
+    /** @deprecated Use {@link LLink.create} */
     static createFromArray(data: SerialisedLLinkArray): LLink {
         return new LLink(data[0], data[5], data[1], data[2], data[3], data[4])
+    }
+
+    /**
+     * LLink static factory: creates a new LLink from the provided data.
+     * @param data Serialised LLink data to create the link from
+     * @returns A new LLink
+     */
+    static create(data: SerialisableLLink): LLink {
+        return new LLink(data.id, data.type, data.origin_id, data.origin_slot, data.target_id, data.target_slot)
     }
 
     configure(o: LLink | SerialisedLLinkArray) {
@@ -68,6 +79,10 @@ export class LLink {
         }
     }
 
+    /**
+     * @deprecated Prefer {@link LLink.asSerialisable} (returns an object, not an array)
+     * @returns An array representing this LLink
+     */
     serialize(): SerialisedLLinkArray {
         return [
             this.id,
@@ -77,5 +92,17 @@ export class LLink {
             this.target_slot,
             this.type
         ]
+    }
+
+    asSerialisable(): SerialisableLLink {
+        const copy: SerialisableLLink = {
+            id: this.id,
+            origin_id: this.origin_id,
+            origin_slot: this.origin_slot,
+            target_id: this.target_id,
+            target_slot: this.target_slot,
+            type: this.type
+        }
+        return copy
     }
 }

--- a/src/LLink.ts
+++ b/src/LLink.ts
@@ -8,16 +8,16 @@ export type SerialisedLLinkArray = [LinkId, NodeId, number, NodeId, number, ISlo
 //this is the class in charge of storing link information
 export class LLink {
     /** Link ID */
-    id?: LinkId
-    type?: ISlotType
+    id: LinkId
+    type: ISlotType
     /** Output node ID */
-    origin_id?: NodeId
+    origin_id: NodeId
     /** Output slot index */
-    origin_slot?: number
+    origin_slot: number
     /** Input node ID */
-    target_id?: NodeId
+    target_id: NodeId
     /** Input slot index */
-    target_slot?: number
+    target_slot: number
     data?: number | string | boolean | { toToolTip?(): string }
     _data?: unknown
     /** Centre point of the link, calculated during render only - can be inaccurate */
@@ -44,6 +44,10 @@ export class LLink {
 
         this._data = null
         this._pos = new Float32Array(2) //center
+    }
+
+    static createFromArray(data: SerialisedLLinkArray): LLink {
+        return new LLink(data[0], data[5], data[1], data[2], data[3], data[4])
     }
 
     configure(o: LLink | SerialisedLLinkArray) {

--- a/src/MapProxyHandler.ts
+++ b/src/MapProxyHandler.ts
@@ -1,0 +1,55 @@
+/** Temporary workaround until downstream consumers migrate to Map.  A brittle wrapper with many flaws, but should be fine for simple maps using int indexes. */
+export class MapProxyHandler<V> implements ProxyHandler<Map<number | string, V>> {
+    getOwnPropertyDescriptor(target: Map<number | string, V>, p: string | symbol): PropertyDescriptor | undefined {
+        const value = this.get(target, p)
+        if (value) return {
+            configurable: true,
+            enumerable: true,
+            value
+        }
+    }
+
+    has(target: Map<number | string, V>, p: string | symbol): boolean {
+        if (typeof p === "symbol") return false
+
+        const int = parseInt(p, 10)
+        return target.has(!isNaN(int) ? int : p)
+    }
+
+    ownKeys(target: Map<number | string, V>): ArrayLike<string | symbol> {
+        return [...target.keys()].map(x => String(x))
+    }
+
+    get(target: Map<number | string, V>, p: string | symbol): any {
+        // Workaround does not support link IDs of "values", "entries", "constructor", etc.
+        if (p in target) return Reflect.get(target, p, target)
+        if (typeof p === "symbol") return
+
+        const int = parseInt(p, 10)
+        return target.get(!isNaN(int) ? int : p)
+    }
+
+    set(target: Map<number | string, V>, p: string | symbol, newValue: any): boolean {
+        if (typeof p === "symbol") return false
+
+        const int = parseInt(p, 10)
+        target.set(!isNaN(int) ? int : p, newValue)
+        return true
+    }
+
+    deleteProperty(target: Map<number | string, V>, p: string | symbol): boolean {
+        return target.delete(p as number | string)
+    }
+
+    static bindAllMethods(map: Map<any, any>): void {
+        map.clear = map.clear.bind(map)
+        map.delete = map.delete.bind(map)
+        map.forEach = map.forEach.bind(map)
+        map.get = map.get.bind(map)
+        map.has = map.has.bind(map)
+        map.set = map.set.bind(map)
+        map.entries = map.entries.bind(map)
+        map.keys = map.keys.bind(map)
+        map.values = map.values.bind(map)
+    }
+}

--- a/src/types/serialisation.ts
+++ b/src/types/serialisation.ts
@@ -1,4 +1,4 @@
-import type { Dictionary, INodeFlags, INodeInputSlot, INodeOutputSlot, Point, Rect, Size } from "@/interfaces"
+import type { ISlotType, Dictionary, INodeFlags, INodeInputSlot, INodeOutputSlot, Point, Rect, Size } from "@/interfaces"
 import type { LGraph } from "@/LGraph"
 import type { IGraphGroupFlags, LGraphGroup } from "@/LGraphGroup"
 import type { LGraphNode, NodeId } from "@/LGraphNode"
@@ -6,6 +6,18 @@ import type { LiteGraph } from "@/litegraph"
 import type { LinkId, LLink } from "@/LLink"
 import type { TWidgetValue } from "@/types/widgets"
 import { RenderShape } from "./globalEnums"
+
+/**
+ * An object that implements custom pre-serialization logic via {@link Serialisable.asSerialisable}.
+ */
+export interface Serialisable<SerialisableObject> {
+    /**
+     * Prepares this object for serialization.
+     * Creates a partial shallow copy of itself, with only the properties that should be serialised.
+     * @returns An object that can immediately be serialized to JSON.
+     */
+    asSerialisable(): SerialisableObject
+}
 
 /** Serialised LGraphNode */
 export interface ISerialisedNode {
@@ -59,4 +71,18 @@ export type TClipboardLink = [targetRelativeIndex: number, originSlot: number, n
 export interface IClipboardContents {
     nodes?: ISerialisedNode[]
     links?: TClipboardLink[]
+}
+export interface SerialisableLLink {
+    /** Link ID */
+    id: LinkId
+    /** Output node ID */
+    origin_id: NodeId
+    /** Output slot index */
+    origin_slot: number
+    /** Input node ID */
+    target_id: NodeId
+    /** Input slot index */
+    target_slot: number
+    /** Data type of the link */
+    type: ISlotType
 }

--- a/src/types/serialisation.ts
+++ b/src/types/serialisation.ts
@@ -37,7 +37,7 @@ export type ISerialisedGraph<
     last_link_id: LGraph["last_link_id"]
     last_reroute_id?: LGraph["last_reroute_id"]
     nodes: TNode[]
-    links: TLink[] | LLink[]
+    links: TLink[]
     groups: TGroup[]
     config: LGraph["config"]
     version: typeof LiteGraph.VERSION


### PR DESCRIPTION
Graph `links` updated to use `Map`.  Public interface now supports both object and `Map`-style access via `Proxy`.

Direct access to the `Map` object is via `_links`, if the temporary Proxy is not suitable.

Adds new `asSerialisable` interface, allowing LLink to be migrated away from being an object serialiased as an array.  The current `serialize` method used throughout Litegraph is a bit counter-intuititve; it doesn't actually serialize anything.