### PR TITLE
Remove hard-coded modifications to nodes

### DIFF
--- a/src/LGraphCanvas.ts
+++ b/src/LGraphCanvas.ts
@@ -4603,7 +4603,6 @@ export class LGraphCanvas {
         node.measure(area)
         area[0] -= node.pos[0]
         area[1] -= node.pos[1]
-        area[2]++
 
         const old_alpha = ctx.globalAlpha
 
@@ -4679,12 +4678,12 @@ export class LGraphCanvas {
                 //ctx.globalAlpha = 0.5 * old_alpha;
                 ctx.beginPath()
                 if (shape == RenderShape.BOX || low_quality) {
-                    ctx.rect(0, -title_height, size[0] + 1, title_height)
+                    ctx.rect(0, -title_height, size[0], title_height)
                 } else if (shape == RenderShape.ROUND || shape == RenderShape.CARD) {
                     ctx.roundRect(
                         0,
                         -title_height,
-                        size[0] + 1,
+                        size[0],
                         title_height,
                         node.flags.collapsed ? [this.round_radius] : [this.round_radius, this.round_radius, 0, 0]
                     )

--- a/src/LGraphCanvas.ts
+++ b/src/LGraphCanvas.ts
@@ -1701,7 +1701,7 @@ export class LGraphCanvas {
 
         if (!is_inside) return
 
-        let node = this.graph.getNodeOnPos(e.canvasX, e.canvasY, this.visible_nodes, 5)
+        let node = this.graph.getNodeOnPos(e.canvasX, e.canvasY, this.visible_nodes)
         let skip_action = false
         const now = LiteGraph.getTime()
         const is_primary = (e.isPrimary === undefined || !e.isPrimary)


### PR DESCRIPTION
- Removes the arbitrary 5 graph unit margin in the node hitbox for pointer events and other tests
- Removes arbitrary +1 graph unit width to nodes (have not been able to find a reason for this - likely historic)

These can still be added, but the choice is now up to the consumer instead of being hard-coded into the lib.