### PR TITLE
Add basic tests

### DIFF
--- a/test/LGraph.test.ts
+++ b/test/LGraph.test.ts
@@ -1,26 +1,45 @@
-import {
-  LGraph,
-  LiteGraph,
-} from "../dist/litegraph.es.js";
+import { LGraph, LGraphGroup, LGraphNode, LiteGraph } from "../src/litegraph"
+import { LiteGraphGlobal } from "../src/LiteGraphGlobal"
 
-describe("LegacyLGraph Compatibility Layer", () => {
-  test("LGraph can be instantiated", () => {
-    const graph = new LGraph({extra: "TestGraph"});
-    expect(graph).toBeInstanceOf(LGraph);
-    expect(graph.extra).toBe("TestGraph");
-  });
+function makeGraph() {
+  const LiteGraph = new LiteGraphGlobal()
+  LiteGraph.registerNodeType("TestNode", LGraphNode)
+  LiteGraph.registerNodeType("OtherNode", LGraphNode)
+  LiteGraph.registerNodeType("", LGraphNode)
+  return new LGraph()
+}
 
-  test("LGraph can be extended via prototype", () => {
-    const graph = new LGraph();
+describe("LGraph", () => {
+  it("can be instantiated", () => {
+    // @ts-ignore TODO: Remove once relative imports fix goes in.
+    const graph = new LGraph({ extra: "TestGraph" })
+    expect(graph).toBeInstanceOf(LGraph)
+    expect(graph.extra).toBe("TestGraph")
+  })
+})
+
+describe("Legacy LGraph Compatibility Layer", () => {
+  it("can be extended via prototype", () => {
+    const graph = new LGraph()
     // @ts-expect-error Should always be an error.
     LGraph.prototype.newMethod = function () {
-      return "New method added via prototype";
-    };
+      return "New method added via prototype"
+    }
     // @ts-expect-error Should always be an error.
-    expect(graph.newMethod()).toBe("New method added via prototype");
-  });
+    expect(graph.newMethod()).toBe("New method added via prototype")
+  })
 
-  test("LegacyLGraph is correctly assigned to LiteGraph", () => {
-    expect(LiteGraph.LGraph).toBe(LGraph);
-  });
-});
+  it("is correctly assigned to LiteGraph", () => {
+    expect(LiteGraph.LGraph).toBe(LGraph)
+  })
+})
+
+describe("LGraph Serialisation", () => {
+  it("should serialise", () => {
+    const graph = new LGraph()
+    graph.add(new LGraphNode("Test Node"))
+    graph.add(new LGraphGroup("Test Group"))
+    expect(graph.nodes.length).toBe(1)
+    expect(graph.groups.length).toBe(1)
+  })
+})

--- a/test/LGraphNode.test.ts
+++ b/test/LGraphNode.test.ts
@@ -1,12 +1,13 @@
 import {
   LGraphNode,
-} from "../dist/litegraph.es.js";
+} from "../src/litegraph"
 
 describe("LGraphNode", () => {
   it("should serialize position correctly", () => {
-    const node = new LGraphNode("TestNode");
-    node.pos = [10, 10];
-    expect(node.pos).toEqual(new Float32Array([10, 10]));
-    expect(node.serialize().pos).toEqual(new Float32Array([10, 10]));
-  });
-});
+    const node = new LGraphNode("TestNode")
+    node.pos = [10, 10]
+    expect(node.pos).toEqual(new Float32Array([10, 10]))
+    expect(node.serialize().pos).toEqual(new Float32Array([10, 10]))
+  })
+
+})


### PR DESCRIPTION
- Adds some simple tests
- Replaces import of `../dist/*.js` with imports of the typescript source

The tests are written in typescript, and will fail to compile even basic tests due to only getting basic inference.

If it is preferred to test against `dist` (which is understandable), `js` tests for this could be added.