### PR TITLE
Positionable: Common interface for canvas items

### DIFF
--- a/src/LGraph.ts
+++ b/src/LGraph.ts
@@ -847,19 +847,17 @@ export class LGraph {
      * Returns the top-most node in this position of the canvas
      * @param {number} x the x coordinate in canvas space
      * @param {number} y the y coordinate in canvas space
-     * @param {Array} nodes_list a list with all the nodes to search from, by default is all the nodes in the graph
+     * @param {Array} nodeList a list with all the nodes to search from, by default is all the nodes in the graph
      * @return {LGraphNode} the node at this position or null
      */
-    getNodeOnPos(x: number, y: number, nodes_list?: LGraphNode[], margin?: number): LGraphNode | null {
-        nodes_list = nodes_list || this._nodes
-        const nRet = null
-        for (let i = nodes_list.length - 1; i >= 0; i--) {
-            const n = nodes_list[i]
-            const skip_title = n.constructor.title_mode == TitleMode.NO_TITLE
-            if (n.isPointInside(x, y, margin, skip_title))
-                return n
+    getNodeOnPos(x: number, y: number, nodeList?: LGraphNode[]): LGraphNode | null {
+        const nodes = nodeList || this._nodes
+        let i = nodes.length
+        while (--i >= 0) {
+            const node = nodes[i]
+            if (node.isPointInside(x, y)) return node
         }
-        return nRet
+        return null
     }
     /**
      * Returns the top-most group in that position
@@ -867,8 +865,8 @@ export class LGraph {
      * @param y The y coordinate in canvas space
      * @return The group or null
      */
-    getGroupOnPos(x: number, y: number, { margin = 2 } = {}): LGraphGroup | undefined {
-        return this._groups.toReversed().find(g => g.isPointInside(x, y, margin, true))
+    getGroupOnPos(x: number, y: number): LGraphGroup | undefined {
+        return this._groups.toReversed().find(g => g.isPointInside(x, y))
     }
 
     /**

--- a/src/LGraph.ts
+++ b/src/LGraph.ts
@@ -55,6 +55,7 @@ export class LGraph {
     last_link_id: number
     /** The largest ID created by this graph */
     last_reroute_id: number
+    lastGroupId: number = -1
     _nodes: LGraphNode[]
     _nodes_by_id: Record<NodeId, LGraphNode>
     _nodes_in_order: LGraphNode[]
@@ -647,6 +648,10 @@ export class LGraph {
         // LEGACY: This was changed from constructor === LGraphGroup
         //groups
         if (node instanceof LGraphGroup) {
+            // Assign group ID
+            if (node.id == null || node.id === -1) node.id = ++this.lastGroupId
+            if (node.id > this.lastGroupId) this.lastGroupId = node.id
+
             this._groups.push(node)
             this.setDirtyCanvas(true)
             this.change()

--- a/src/LGraphCanvas.ts
+++ b/src/LGraphCanvas.ts
@@ -2002,7 +2002,7 @@ export class LGraphCanvas {
                             this.isDragging = true
                         }
                         // Account for shift + click + drag
-                        if (!(e.shiftKey && !e.ctrlKey && !e.altKey) || !node.is_selected) {
+                        if (!(e.shiftKey && !e.ctrlKey && !e.altKey) || !node.selected) {
                             this.processNodeSelected(node, e)
                         }
                     } else { // double-click
@@ -2010,7 +2010,7 @@ export class LGraphCanvas {
                          * Don't call the function if the block is already selected.
                          * Otherwise, it could cause the block to be unselected while its panel is open.
                          */
-                        if (!node.is_selected) this.processNodeSelected(node, e)
+                        if (!node.selected) this.processNodeSelected(node, e)
                     }
 
                     this.dirty_canvas = true
@@ -2455,7 +2455,7 @@ export class LGraphCanvas {
                      * Don't call the function if the block is already selected.
                      * Otherwise, it could cause the block to be unselected while dragging.
                      */
-                    if (!n.is_selected) this.processNodeSelected(n, e)
+                    if (!n.selected) this.processNodeSelected(n, e)
 
                 }
 
@@ -3248,15 +3248,15 @@ export class LGraphCanvas {
         if (typeof nodes == "string") nodes = [nodes]
         for (const i in nodes) {
             const node: LGraphNode = nodes[i]
-            if (node.is_selected) {
+            if (node.selected) {
                 this.deselectNode(node)
                 continue
             }
 
-            if (!node.is_selected) {
+            if (!node.selected) {
                 node.onSelected?.()
             }
-            node.is_selected = true
+            node.selected = true
             this.selected_nodes[node.id] = node
 
             if (node.inputs) {
@@ -3284,9 +3284,9 @@ export class LGraphCanvas {
      * removes a node from the current selection
      **/
     deselectNode(node: LGraphNode): void {
-        if (!node.is_selected) return
+        if (!node.selected) return
         node.onDeselected?.()
-        node.is_selected = false
+        node.selected = false
         delete this.selected_nodes[node.id]
 
         this.onNodeDeselected?.(node)
@@ -3316,11 +3316,11 @@ export class LGraphCanvas {
         const nodes = this.graph._nodes
         for (let i = 0, l = nodes.length; i < l; ++i) {
             const node = nodes[i]
-            if (!node.is_selected) {
+            if (!node.selected) {
                 continue
             }
             node.onDeselected?.()
-            node.is_selected = false
+            node.selected = false
             this.onNodeDeselected?.(node)
         }
         this.selected_nodes = {}
@@ -4313,7 +4313,7 @@ export class LGraphCanvas {
             size,
             color,
             bgcolor,
-            node.is_selected
+            node.selected
         )
 
         if (!low_quality) {
@@ -4590,7 +4590,7 @@ export class LGraphCanvas {
      * @param size Size of the background to draw, in graph units.  Differs from node size if collapsed, etc.
      * @param fgcolor Foreground colour - used for text
      * @param bgcolor Background colour of the node
-     * @param selected Whether to render the node as selected.  Likely to be removed in future, as current usage is simply the is_selected property of the node.
+     * @param selected Whether to render the node as selected.  Likely to be removed in future, as current usage is simply the selected property of the node.
      * @param mouse_over Deprecated
      */
     drawNodeShape(

--- a/src/LGraphCanvas.ts
+++ b/src/LGraphCanvas.ts
@@ -1719,7 +1719,7 @@ export class LGraphCanvas {
 
         if (!is_inside) return
 
-        let node = this.graph.getNodeOnPos(e.canvasX, e.canvasY, this.visible_nodes, 5)
+        let node = this.graph.getNodeOnPos(e.canvasX, e.canvasY, this.visible_nodes)
         let skip_action = false
         const now = LiteGraph.getTime()
         const is_primary = (e.isPrimary === undefined || !e.isPrimary)

--- a/src/LGraphCanvas.ts
+++ b/src/LGraphCanvas.ts
@@ -2451,12 +2451,6 @@ export class LGraphCanvas {
                     nodes.add(n)
                     n.pos[0] += delta[0] / this.ds.scale
                     n.pos[1] += delta[1] / this.ds.scale
-                    /*
-                     * Don't call the function if the block is already selected.
-                     * Otherwise, it could cause the block to be unselected while dragging.
-                     */
-                    if (!n.selected) this.processNodeSelected(n, e)
-
                 }
 
                 if (this.selectedGroups) {

--- a/src/LGraphGroup.ts
+++ b/src/LGraphGroup.ts
@@ -54,6 +54,10 @@ export class LGraphGroup implements Positionable {
         this._size[1] = Math.max(80, v[1])
     }
 
+    get boundingRect() {
+        return this._bounding
+    }
+
     get nodes() {
         return this._nodes
     }
@@ -181,10 +185,9 @@ export class LGraphGroup implements Positionable {
      */
     resizeTo(objects: Iterable<Positionable>, padding: number = 10): void {
         const bounds = new Float32Array([Infinity, Infinity, -Infinity, -Infinity])
-        const rect = new Float32Array(4)
 
         for (const obj of objects) {
-            obj.measure(rect)
+            const rect = obj.boundingRect
             bounds[0] = Math.min(bounds[0], rect[0])
             bounds[1] = Math.min(bounds[1], rect[1])
             bounds[2] = Math.max(bounds[2], rect[0] + rect[2])

--- a/src/LGraphGroup.ts
+++ b/src/LGraphGroup.ts
@@ -12,6 +12,7 @@ export interface IGraphGroupFlags extends Record<string, unknown> {
 }
 
 export class LGraphGroup implements Positionable {
+    id: number
     color: string
     title: string
     font?: string
@@ -25,7 +26,9 @@ export class LGraphGroup implements Positionable {
     flags: IGraphGroupFlags = {}
     selected?: boolean
 
-    constructor(title?: string) {
+    constructor(title?: string, id?: number) {
+        // TODO: Object instantiation pattern requires too much boilerplate and null checking.  ID should be passed in via constructor.
+        this.id = id ?? -1
         this.title = title || "Group"
         this.color = LGraphCanvas.node_colors.pale_blue
             ? LGraphCanvas.node_colors.pale_blue.groupcolor
@@ -79,6 +82,7 @@ export class LGraphGroup implements Positionable {
     }
 
     configure(o: ISerialisedGroup): void {
+        this.id = o.id
         this.title = o.title
         this._bounding.set(o.bounding)
         this.color = o.color
@@ -89,6 +93,7 @@ export class LGraphGroup implements Positionable {
     serialize(): ISerialisedGroup {
         const b = this._bounding
         return {
+            id: this.id,
             title: this.title,
             bounding: [
                 Math.round(b[0]),

--- a/src/LGraphGroup.ts
+++ b/src/LGraphGroup.ts
@@ -175,6 +175,30 @@ export class LGraphGroup implements Positionable {
     }
 
     /**
+     * Resizes and moves the group to neatly fit all given {@link objects}.
+     * @param objects All objects that should be inside the group
+     * @param padding Value in graph units to add to all sides of the group.  Default: 10
+     */
+    resizeTo(objects: Iterable<Positionable>, padding: number = 10): void {
+        const bounds = new Float32Array([Infinity, Infinity, -Infinity, -Infinity])
+        const rect = new Float32Array(4)
+
+        for (const obj of objects) {
+            obj.measure(rect)
+            bounds[0] = Math.min(bounds[0], rect[0])
+            bounds[1] = Math.min(bounds[1], rect[1])
+            bounds[2] = Math.max(bounds[2], rect[0] + rect[2])
+            bounds[3] = Math.max(bounds[3], rect[1] + rect[3])
+        }
+        if (!bounds.every(x => isFinite(x))) return
+
+        this.pos[0] = bounds[0] - padding
+        this.pos[1] = bounds[1] - padding - this.titleHeight
+        this.size[0] = bounds[2] - bounds[0] + (2 * padding)
+        this.size[1] = bounds[3] - bounds[1] + (2 * padding) + this.titleHeight
+    }
+
+    /**
      * Add nodes to the group and adjust the group's position and size accordingly
      * @param {LGraphNode[]} nodes - The nodes to add to the group
      * @param {number} [padding=10] - The padding around the group
@@ -182,36 +206,7 @@ export class LGraphGroup implements Positionable {
      */
     addNodes(nodes: LGraphNode[], padding: number = 10): void {
         if (!this._nodes && nodes.length === 0) return
-
-        const allNodes = [...(this._nodes || []), ...nodes]
-
-        const bounds = allNodes.reduce((acc, node) => {
-            const [x, y] = node.pos
-            const [width, height] = node.size
-            const isReroute = node.type === "Reroute"
-            const isCollapsed = node.flags?.collapsed
-
-            const top = y - (isReroute ? 0 : LiteGraph.NODE_TITLE_HEIGHT)
-            const bottom = isCollapsed ? top + LiteGraph.NODE_TITLE_HEIGHT : y + height
-            const right = isCollapsed && node._collapsed_width ? x + Math.round(node._collapsed_width) : x + width
-
-            return {
-                left: Math.min(acc.left, x),
-                top: Math.min(acc.top, top),
-                right: Math.max(acc.right, right),
-                bottom: Math.max(acc.bottom, bottom)
-            }
-        }, { left: Infinity, top: Infinity, right: -Infinity, bottom: -Infinity })
-
-        this.pos = [
-            bounds.left - padding,
-            bounds.top - padding - this.titleHeight
-        ]
-
-        this.size = [
-            bounds.right - bounds.left + padding * 2,
-            bounds.bottom - bounds.top + padding * 2 + this.titleHeight
-        ]
+        this.resizeTo([...this._nodes, ...nodes], padding)
     }
 
     getMenuOptions(): IContextMenuValue[] {

--- a/src/LGraphNode.ts
+++ b/src/LGraphNode.ts
@@ -1,4 +1,4 @@
-import type { Dictionary, IContextMenuValue, IFoundSlot, INodeFlags, INodeInputSlot, INodeOutputSlot, IOptionalSlotData, ISlotType, Point, Rect, Size } from "./interfaces"
+import type { Dictionary, IContextMenuValue, IFoundSlot, INodeFlags, INodeInputSlot, INodeOutputSlot, IOptionalSlotData, ISlotType, Point, Positionable, Rect, Size } from "./interfaces"
 import type { LGraph } from "./LGraph"
 import type { IWidget, TWidgetValue } from "./types/widgets"
 import type { ISerialisedNode } from "./types/serialisation"
@@ -111,7 +111,7 @@ export interface LGraphNode {
  * Base Class for all the node type classes
  * @param {String} name a name for the node
  */
-export class LGraphNode {
+export class LGraphNode implements Positionable {
     // Static properties used by dynamic child classes
     static title?: string
     static MAX_CONSOLE?: number
@@ -166,7 +166,6 @@ export class LGraphNode {
     subgraph?: LGraph
     skip_subgraph_button?: boolean
     mouseOver?: IMouseOverData
-    is_selected?: boolean
     redraw_on_mouse?: boolean
     // Appears unused
     optional_inputs?
@@ -180,6 +179,7 @@ export class LGraphNode {
     has_errors?: boolean
     removable?: boolean
     block_delete?: boolean
+    selected?: boolean
     showAdvanced?: boolean
 
     _pos: Point = new Float32Array([10, 10])
@@ -216,6 +216,13 @@ export class LGraphNode {
             default:
                 this._shape = v
         }
+    }
+
+    public get is_selected(): boolean {
+        return this.selected
+    }
+    public set is_selected(value: boolean) {
+        this.selected = value
     }
 
     // Used in group node
@@ -1391,6 +1398,11 @@ export class LGraphNode {
         this.widgets ||= []
         this.widgets.push(custom_widget)
         return custom_widget
+    }
+
+    move(deltaX: number, deltaY: number): void {
+        this.pos[0] += deltaX
+        this.pos[1] += deltaY
     }
 
     /**

--- a/src/LGraphNode.ts
+++ b/src/LGraphNode.ts
@@ -8,7 +8,7 @@ import type { DragAndScale } from "./DragAndScale"
 import { LGraphEventMode, NodeSlotType, TitleMode, RenderShape } from "./types/globalEnums"
 import { BadgePosition, LGraphBadge } from "./LGraphBadge"
 import { type LGraphNodeConstructor, LiteGraph } from "./litegraph"
-import { isInsideRectangle } from "./measure"
+import { isInsideRectangle, isXyInRectangle } from "./measure"
 import { LLink } from "./LLink"
 
 export type NodeId = number | string
@@ -1509,33 +1509,8 @@ export class LGraphNode implements Positionable {
      * @param {number} y
      * @return {boolean}
      */
-    isPointInside(x: number, y: number, margin?: number, skip_title?: boolean): boolean {
-        margin ||= 0
-
-        const margin_top = skip_title || this.graph?.isLive()
-            ? 0
-            : LiteGraph.NODE_TITLE_HEIGHT
-
-        if (this.flags.collapsed) {
-            //if ( distance([x,y], [this.pos[0] + this.size[0]*0.5, this.pos[1] + this.size[1]*0.5]) < LiteGraph.NODE_COLLAPSED_RADIUS)
-            if (isInsideRectangle(
-                x,
-                y,
-                this.pos[0] - margin,
-                this.pos[1] - LiteGraph.NODE_TITLE_HEIGHT - margin,
-                (this._collapsed_width || LiteGraph.NODE_COLLAPSED_WIDTH) +
-                2 * margin,
-                LiteGraph.NODE_TITLE_HEIGHT + 2 * margin
-            )) {
-                return true
-            }
-        } else if (this.pos[0] - 4 - margin < x &&
-            this.pos[0] + this.size[0] + 4 + margin > x &&
-            this.pos[1] - margin_top - margin < y &&
-            this.pos[1] + this.size[1] + margin > y) {
-            return true
-        }
-        return false
+    isPointInside(x: number, y: number): boolean {
+        return isXyInRectangle(x, y, this.boundingRect)
     }
 
     /**

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -1,5 +1,5 @@
 import type { ContextMenu } from "./ContextMenu"
-import type { LGraphNode } from "./LGraphNode"
+import type { LGraphNode, NodeId } from "./LGraphNode"
 import type { LinkDirection, RenderShape } from "./types/globalEnums"
 import type { LinkId } from "./LLink"
 
@@ -13,6 +13,7 @@ export type NullableProperties<T> = {
 export type CanvasColour = string | CanvasGradient | CanvasPattern
 
 export interface Positionable {
+    id: NodeId | number
     /** Position in graph coordinates.  Default: 0,0 */
     pos: Point
     /** true if this object is part of the selection, otherwise false. */

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -18,6 +18,8 @@ export interface Positionable {
     /** true if this object is part of the selection, otherwise false. */
     selected?: boolean
 
+    readonly children?: ReadonlySet<Positionable>
+
     /**
      * Adds a delta to the current position.
      * @param deltaX X value to add to current position
@@ -25,6 +27,17 @@ export interface Positionable {
      * @param skipChildren If true, any child objects like group contents will not be moved
      */
     move(deltaX: number, deltaY: number, skipChildren?: boolean): void
+
+    /**
+     * Cached position & size as `x, y, width, height`.
+     * @readonly See {@link move}
+     */
+    readonly boundingRect: ReadOnlyRect
+
+    /** Called whenever the item is selected */
+    onSelected?(): void
+    /** Called whenever the item is deselected */
+    onDeselected?(): void
 }
 
 export interface IInputOrOutput {

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -12,6 +12,21 @@ export type NullableProperties<T> = {
 
 export type CanvasColour = string | CanvasGradient | CanvasPattern
 
+export interface Positionable {
+    /** Position in graph coordinates.  Default: 0,0 */
+    pos: Point
+    /** true if this object is part of the selection, otherwise false. */
+    selected?: boolean
+
+    /**
+     * Adds a delta to the current position.
+     * @param deltaX X value to add to current position
+     * @param deltaY Y value to add to current position
+     * @param skipChildren If true, any child objects like group contents will not be moved
+     */
+    move(deltaX: number, deltaY: number, skipChildren?: boolean): void
+}
+
 export interface IInputOrOutput {
     // If an input, this will be defined
     input?: INodeInputSlot

--- a/src/measure.ts
+++ b/src/measure.ts
@@ -109,7 +109,7 @@ export function overlapBounding(a: ReadOnlyRect, b: ReadOnlyRect): boolean {
 export function containsCentre(a: ReadOnlyRect, b: ReadOnlyRect): boolean {
     const centreX = b[0] + (b[2] * 0.5)
     const centreY = b[1] + (b[3] * 0.5)
-    return isInsideRectangle(centreX, centreY, a[0], a[1], a[2], a[3])
+    return isXyInRectangle(centreX, centreY, a)
 }
 
 /**

--- a/src/measure.ts
+++ b/src/measure.ts
@@ -39,6 +39,20 @@ export function isPointInRectangle(point: ReadOnlyPoint, rect: ReadOnlyRect): bo
 
 /**
  * Determines whether a point is inside a rectangle.
+ * @param x X co-ordinate of the point to check
+ * @param y Y co-ordinate of the point to check
+ * @param rect The rectangle, as `x, y, width, height`
+ * @returns `true` if the point is inside the rect, otherwise `false`
+ */
+export function isXyInRectangle(x: number, y: number, rect: ReadOnlyRect): boolean {
+    return rect[0] <= x
+        && rect[0] + rect[2] > x
+        && rect[1] <= y
+        && rect[1] + rect[3] > y
+}
+
+/**
+ * Determines whether a point is inside a rectangle.
  * @param x Point x
  * @param y Point y
  * @param left Rect x

--- a/src/measure.ts
+++ b/src/measure.ts
@@ -31,9 +31,9 @@ export function dist2(a: ReadOnlyPoint, b: ReadOnlyPoint): number {
  * @returns `true` if the point is inside the rect, otherwise `false`
  */
 export function isPointInRectangle(point: ReadOnlyPoint, rect: ReadOnlyRect): boolean {
-    return rect[0] < point[0]
+    return rect[0] <= point[0]
         && rect[0] + rect[2] > point[0]
-        && rect[1] < point[1]
+        && rect[1] <= point[1]
         && rect[1] + rect[3] > point[1]
 }
 

--- a/src/types/serialisation.ts
+++ b/src/types/serialisation.ts
@@ -59,6 +59,7 @@ export type ISerialisedGraph<
 
 /** Serialised LGraphGroup */
 export interface ISerialisedGroup {
+    id: number
     title: string
     bounding: number[]
     color: string


### PR DESCRIPTION
Allows user-positionable canvas objects (groups, nodes, future-types) to share common features such as selection, arranging, and movement.  Enables a more intuitive and natural UX.

### Nodes
- Node `size` is now a getter/setter backed by a `Rect`; array ref can no longer be overwritten (in line with `pos` and groups)
- Node `is_selected` is now a legacy accessor for `Positionable.selected`
- Adds `renderArea` - calculated once per frame, replacing repeat calls to getBounding (and onBounding callback)

### Groups
- Adds `id` to groups

-----
- Removes unused margin checks from `get_X_OnPos` functions
- Some test failures are expected; there are minor differences in node resize
- The arbitrary +1 width added to nodes during render is still present on this branch
