### PR TITLE
Serialize to node pos/size to plain array

### DIFF
--- a/src/LGraphNode.ts
+++ b/src/LGraphNode.ts
@@ -426,8 +426,8 @@ export class LGraphNode implements Positionable {
         const o: ISerialisedNode = {
             id: this.id,
             type: this.type,
-            pos: this.pos,
-            size: this.size,
+            pos: [this.pos[0], this.pos[1]],
+            size: [this.size[0], this.size[1]],
             flags: LiteGraph.cloneObject(this.flags),
             order: this.order,
             mode: this.mode,

--- a/test/LGraphNode.test.ts
+++ b/test/LGraphNode.test.ts
@@ -3,11 +3,14 @@ import {
 } from "../src/litegraph"
 
 describe("LGraphNode", () => {
-  it("should serialize position correctly", () => {
+  it("should serialize position/size correctly", () => {
     const node = new LGraphNode("TestNode")
     node.pos = [10, 10]
     expect(node.pos).toEqual(new Float32Array([10, 10]))
-    expect(node.serialize().pos).toEqual(new Float32Array([10, 10]))
-  })
+    expect(node.serialize().pos).toEqual([10, 10])
 
+    node.size = [100, 100]
+    expect(node.size).toEqual(new Float32Array([100, 100]))
+    expect(node.serialize().size).toEqual([100, 100])
+  })
 })


### PR DESCRIPTION
Serialize node pos/size to plain js array to avoid change detection issue in the frontend. `Float32Array` behaves differently on `_.isEqual`.