### PR TITLE
Graph serialisation update - Links & Reroutes

### DIFF
--- a/src/LGraph.ts
+++ b/src/LGraph.ts
@@ -1,6 +1,6 @@
 import type { Dictionary, IContextMenuValue, ISlotType, MethodNames, Point } from "./interfaces"
 import type { ISerialisedGraph } from "./types/serialisation"
-import { LGraphEventMode, TitleMode } from "./types/globalEnums"
+import { LGraphEventMode } from "./types/globalEnums"
 import { LiteGraph } from "./litegraph"
 import { LGraphCanvas } from "./LGraphCanvas"
 import { LGraphGroup } from "./LGraphGroup"

--- a/src/LGraph.ts
+++ b/src/LGraph.ts
@@ -1295,6 +1295,15 @@ export class LGraph implements Serialisable<SerialisableGraph> {
         } else {
             // New schema - one version so far, no check required.
 
+            // State
+            if (data.state) {
+                const { state: { lastGroupId, lastLinkId, lastNodeId, lastRerouteId } } = data
+                if (lastGroupId != null) this.state.lastGroupId = lastGroupId
+                if (lastLinkId != null) this.state.lastLinkId = lastLinkId
+                if (lastNodeId != null) this.state.lastNodeId = lastNodeId
+                if (lastRerouteId != null) this.state.lastRerouteId = lastRerouteId
+            }
+
             // Links
             if (Array.isArray(data.links)) {
                 for (const linkData of data.links) {
@@ -1309,7 +1318,7 @@ export class LGraph implements Serialisable<SerialisableGraph> {
         //copy all stored fields
         for (const i in data) {
             //links must be accepted
-            if (i == "nodes" || i == "groups" || i == "links")
+            if (i == "nodes" || i == "groups" || i == "links" || i === "state")
                 continue
             this[i] = data[i]
         }

--- a/src/LGraphNode.ts
+++ b/src/LGraphNode.ts
@@ -1927,8 +1927,8 @@ export class LGraphNode implements Positionable, IPinnable {
         }
 
         // UUID: LinkIds
-        // const nextId = LiteGraph.use_uuids ? LiteGraph.uuidv4() : ++graph.last_link_id
-        const nextId = ++graph.last_link_id
+        // const nextId = LiteGraph.use_uuids ? LiteGraph.uuidv4() : ++graph.state.lastLinkId
+        const nextId = ++graph.state.lastLinkId
 
         //create link class
         link_info = new LLink(

--- a/src/LiteGraphGlobal.ts
+++ b/src/LiteGraphGlobal.ts
@@ -21,7 +21,8 @@ export class LiteGraphGlobal {
     SlotType = SlotType
     LabelPosition = LabelPosition
 
-    VERSION = 0.4
+    /** Used in serialised graphs at one point. */
+    VERSION = 0.4 as const
 
     CANVAS_GRID_SIZE = 10
 

--- a/src/litegraph.ts
+++ b/src/litegraph.ts
@@ -24,6 +24,7 @@ export { IWidget }
 export { LGraphBadge, BadgePosition }
 export { SlotShape, LabelPosition, SlotDirection, SlotType }
 export { EaseFunction } from "./types/globalEnums"
+export type { SerialisableGraph, SerialisableLLink } from "./types/serialisation"
 
 export function clamp(v: number, a: number, b: number): number {
     return a > v ? a : b < v ? b : v

--- a/src/types/serialisation.ts
+++ b/src/types/serialisation.ts
@@ -48,7 +48,6 @@ export type ISerialisedGraph<
 > = {
     last_node_id: LGraph["last_node_id"]
     last_link_id: LGraph["last_link_id"]
-    last_reroute_id?: LGraph["last_reroute_id"]
     nodes: TNode[]
     links: TLink[]
     groups: TGroup[]

--- a/src/types/serialisation.ts
+++ b/src/types/serialisation.ts
@@ -1,5 +1,5 @@
 import type { ISlotType, Dictionary, INodeFlags, INodeInputSlot, INodeOutputSlot, Point, Rect, Size } from "../interfaces"
-import type { LGraph } from "../LGraph"
+import type { LGraph, LGraphState } from "../LGraph"
 import type { IGraphGroupFlags, LGraphGroup } from "../LGraphGroup"
 import type { LGraphNode, NodeId } from "../LGraphNode"
 import type { LiteGraph } from "../litegraph"
@@ -17,6 +17,17 @@ export interface Serialisable<SerialisableObject> {
      * @returns An object that can immediately be serialized to JSON.
      */
     asSerialisable(): SerialisableObject
+}
+
+export interface SerialisableGraph {
+    /** Schema version.  @remarks Version bump should add to const union, which is used to narrow type during deserialise. */
+    version: 0 | 1
+    config: LGraph["config"]
+    state: LGraphState
+    groups?: ISerialisedGroup[]
+    nodes?: ISerialisedNode[]
+    links?: SerialisableLLink[]
+    extra?: Record<any, any>
 }
 
 /** Serialised LGraphNode */
@@ -40,14 +51,17 @@ export interface ISerialisedNode {
     widgets_values?: TWidgetValue[]
 }
 
-/** Contains serialised graph elements */
+/**
+ * Original implementation from static litegraph.d.ts
+ * Maintained for backwards compat
+ */
 export type ISerialisedGraph<
     TNode = ReturnType<LGraphNode["serialize"]>,
     TLink = ReturnType<LLink["serialize"]>,
     TGroup = ReturnType<LGraphGroup["serialize"]>
 > = {
-    last_node_id: LGraph["last_node_id"]
-    last_link_id: LGraph["last_link_id"]
+    last_node_id: NodeId
+    last_link_id: number
     nodes: TNode[]
     links: TLink[]
     groups: TGroup[]


### PR DESCRIPTION
### Module
- Adds module exports: `SerialisableGraph`, `SerialisableLLink`

### Schema
- Adds new schema version - identified as `1`
- Adds `LGraph.asSerialisable` as preferred prep-for serialisation method
- Deprecates `LGraph.serialize`

### LLink / Reroute
- Has all the elements required to add reroutes
- Serialises `LLink` as object instead of array
- Ensures stale links are not kept when clearing graph
- Moves `last_link_id` & `last_node_id` to settings plain object `LGraph.state`