### PR TITLE
Keep links connected when deleting nodes

### DIFF
--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -145,6 +145,8 @@ export interface INodeFlags {
     allow_interaction?: boolean
     pinned?: boolean
     collapsed?: boolean
+    /** Configuration setting for {@link LGraphNode.connectInputToOutput} */
+    keepAllLinksOnBypass?: boolean
 }
 
 export interface INodeInputSlot extends INodeSlot {

--- a/src/litegraph.ts
+++ b/src/litegraph.ts
@@ -101,6 +101,7 @@ export interface LGraphNodeConstructor<T extends LGraphNode = LGraphNode> {
     title_mode?: TitleMode
     title_color?: string
     title_text_color?: string
+    keepAllLinksOnBypass: boolean
     nodeData: any
     new(): T
 }


### PR DESCRIPTION
### Default behaviour change
- Currently, when deleting a node, a bypass link is created only for the first input <-> first output
- New default is that this same behaviour is now applied to every input & output pair (e.g. input 3 <-> output 3)

https://github.com/user-attachments/assets/0e5c3c3b-bbc4-499b-8cfa-28eba4a98072

### Optional match-any mode
- Configurable per-node, this mode will first try the default behaviour, then try to bypass each input to the first matching output
- Per-node: `flags.keepAllLinksOnBypass`
- Global default: `LGraphNode.keepAllLinksOnBypass`

https://github.com/user-attachments/assets/397d7bcc-ffa7-4fa2-bec0-213d8c108704

### Future improvements
Needs better handling of e.g.:
![image](https://github.com/user-attachments/assets/88bf9af4-a6ab-4b8c-b7d4-72f567e00344)
![image](https://github.com/user-attachments/assets/fd3977c4-4d28-4fdc-aea3-c7a876d2ecf4)
