### PR TITLE
Add Reroutes

### DIFF
--- a/src/LGraph.ts
+++ b/src/LGraph.ts
@@ -1322,8 +1322,10 @@ export class LGraph implements LinkNetwork, Serialisable<SerialisableGraph> {
 
         const node = this.getNodeById(link.target_id)
         node?.disconnectInput(link.target_slot)
+        
+        link.disconnect(this)
     }
-    //save and recover app state ***************************************
+
     /**
      * Creates a Object containing all the info about this graph, it can be serialized
      * @deprecated Use {@link asSerialisable}, which returns the newer schema version.

--- a/src/LGraph.ts
+++ b/src/LGraph.ts
@@ -940,6 +940,16 @@ export class LGraph implements LinkNetwork, Serialisable<SerialisableGraph> {
     }
 
     /**
+     * Returns the top-most group with a titlebar in the provided position.
+     * @param x The x coordinate in canvas space
+     * @param y The y coordinate in canvas space
+     * @return The group or null
+     */
+    getGroupTitlebarOnPos(x: number, y: number): LGraphGroup | undefined {
+        return this._groups.toReversed().find(g => g.isPointInTitlebar(x, y))
+    }
+
+    /**
      * Finds a reroute a the given graph point
      * @param x X co-ordinate in graph space
      * @param y Y co-ordinate in graph space

--- a/src/LGraphCanvas.ts
+++ b/src/LGraphCanvas.ts
@@ -2089,25 +2089,30 @@ export class LGraphCanvas {
                             }
 
                             // If we shift click on a link then start a link from that input
-                            if (e.shiftKey && linkSegment.path && this.ctx.isPointInStroke(linkSegment.path, e.canvasX, e.canvasY)) {
-                                const fromLink = linkSegment instanceof Reroute && linkSegment.linkIds.size
-                                    ? graph._links.get(linkSegment.linkIds.values().next().value)
-                                    : linkSegment instanceof LLink ? linkSegment : null
-                                if (!fromLink) break
+                            if ((e.shiftKey || e.altKey) && linkSegment.path && this.ctx.isPointInStroke(linkSegment.path, e.canvasX, e.canvasY)) {
+                                if (e.shiftKey && !e.altKey) {
+                                    const slot = linkSegment.origin_slot
+                                    const originNode = graph._nodes_by_id[linkSegment.origin_id]
 
-                                const slot = fromLink.origin_slot
-                                const originNode = graph._nodes_by_id[fromLink.origin_id]
+                                    const connecting: ConnectingLink = {
+                                        node: originNode,
+                                        slot,
+                                        output: originNode.outputs[slot],
+                                        pos: originNode.getConnectionPos(false, slot),
+                                    }
+                                    this.connecting_links = [connecting]
+                                    if (linkSegment.parentId) connecting.afterRerouteId = linkSegment.parentId
 
-                                this.connecting_links ??= []
-                                this.connecting_links.push({
-                                    node: originNode,
-                                    slot,
-                                    output: originNode.outputs[slot],
-                                    pos: originNode.getConnectionPos(false, slot),
-                                })
-                                if (fromLink.parentId) this.connecting_links[0].afterRerouteId = fromLink.parentId
-                                skip_action = true
-                                break
+                                    skip_action = true
+                                    break
+                                } else if (e.altKey && !e.shiftKey) {
+                                    const newReroute = graph.createReroute([e.canvasX, e.canvasY], linkSegment)
+                                    this.processSelect(newReroute, e)
+                                    this.isDragging = true
+
+                                    skip_action = true
+                                    break
+                                }
                             }
                         }
 

--- a/src/LGraphCanvas.ts
+++ b/src/LGraphCanvas.ts
@@ -5052,6 +5052,8 @@ export class LGraphCanvas {
 
                 // Has reroutes
                 if (reroutes.length) {
+                    let startControl: Point
+
                     const l = reroutes.length
                     for (let j = 0; j < l; j++) {
                         const reroute = reroutes[j]
@@ -5061,6 +5063,7 @@ export class LGraphCanvas {
 
                             const prevReroute = this.graph.reroutes.get(reroute.parentId)
                             const startPos = prevReroute?.pos ?? start_node_slotpos
+                            reroute.calculateAngle(this.last_draw_time, this.graph, startPos)
 
                             this.renderLink(
                                 ctx,
@@ -5072,8 +5075,18 @@ export class LGraphCanvas {
                                 null,
                                 start_dir,
                                 end_dir,
+                                {
+                                    startControl,
+                                    endControl: reroute.controlPoint,
+                                    reroute,
+                                },
                             )
                         }
+
+                        // Calculate start control for the next iter control point
+                        const nextPos = reroutes[j + 1]?.pos ?? end_node_slotpos
+                        const dist = Math.min(80, distance(reroute.pos, nextPos) * 0.25)
+                        startControl = [dist * reroute.cos, dist * reroute.sin]
                     }
 
                     // Render final link segment
@@ -5087,6 +5100,7 @@ export class LGraphCanvas {
                         null,
                         start_dir,
                         end_dir,
+                        { startControl },
                     )
 
                     // Render the reroute circles

--- a/src/LGraphCanvas.ts
+++ b/src/LGraphCanvas.ts
@@ -3644,7 +3644,7 @@ export class LGraphCanvas {
                 }
             }
 
-            if (this.connecting_links) {
+            if (this.connecting_links?.length) {
                 //current connection (the one being dragged by the mouse)
                 for (const link of this.connecting_links) {
                     ctx.lineWidth = this.connections_width
@@ -3652,8 +3652,8 @@ export class LGraphCanvas {
 
                     const connInOrOut = link.output || link.input
 
-                    const connType = connInOrOut.type
-                    let connDir = connInOrOut.dir
+                    const connType = connInOrOut?.type
+                    let connDir = connInOrOut?.dir
                     if (connDir == null) {
                         if (link.output)
                             connDir = link.node.horizontal ? LinkDirection.DOWN : LinkDirection.RIGHT
@@ -3661,7 +3661,7 @@ export class LGraphCanvas {
                         else
                             connDir = link.node.horizontal ? LinkDirection.UP : LinkDirection.LEFT
                     }
-                    const connShape = connInOrOut.shape
+                    const connShape = connInOrOut?.shape
 
                     switch (connType) {
                         case LiteGraph.EVENT:
@@ -4361,8 +4361,8 @@ export class LGraphCanvas {
         const render_text = !low_quality
         const highlightColour = LiteGraph.NODE_TEXT_HIGHLIGHT_COLOR ?? LiteGraph.NODE_SELECTED_TITLE_COLOR ?? LiteGraph.NODE_TEXT_COLOR
 
-        const out_slot = this.connecting_links ? this.connecting_links[0].output : null
-        const in_slot = this.connecting_links ? this.connecting_links[0].input : null
+        const out_slot = this.connecting_links?.[0]?.output
+        const in_slot = this.connecting_links?.[0]?.input
         ctx.lineWidth = 1
 
         let max_y = 0

--- a/src/LGraphCanvas.ts
+++ b/src/LGraphCanvas.ts
@@ -2693,8 +2693,6 @@ export class LGraphCanvas {
                         }
                     }
                 }
-
-                this.connecting_links = null
             } //not dragging connection
             else if (this.resizing_node) {
                 this.#dirty()
@@ -2732,6 +2730,8 @@ export class LGraphCanvas {
                     e.canvasY - this.node_capturing_input.pos[1]
                 ])
             }
+
+            this.connecting_links = null
         } else if (e.which == 2) {
             //middle button
             this.dirty_canvas = true
@@ -3671,11 +3671,12 @@ export class LGraphCanvas {
                             link_color = LiteGraph.CONNECTING_LINK_COLOR
                     }
 
-                    const highlightPos: Point = this.#getHighlightPosition()
+                    const pos = this.graph.reroutes.get(link.afterRerouteId)?.pos ?? link.pos
+                    const highlightPos = this.#getHighlightPosition()
                     //the connection being dragged by the mouse
                     this.renderLink(
                         ctx,
-                        link.pos,
+                        pos,
                         highlightPos,
                         null,
                         false,
@@ -3689,8 +3690,8 @@ export class LGraphCanvas {
                     if (connType === LiteGraph.EVENT ||
                         connShape === RenderShape.BOX) {
                         ctx.rect(
-                            link.pos[0] - 6 + 0.5,
-                            link.pos[1] - 5 + 0.5,
+                            pos[0] - 6 + 0.5,
+                            pos[1] - 5 + 0.5,
                             14,
                             10
                         )
@@ -3703,15 +3704,15 @@ export class LGraphCanvas {
                             10
                         )
                     } else if (connShape === RenderShape.ARROW) {
-                        ctx.moveTo(link.pos[0] + 8, link.pos[1] + 0.5)
-                        ctx.lineTo(link.pos[0] - 4, link.pos[1] + 6 + 0.5)
-                        ctx.lineTo(link.pos[0] - 4, link.pos[1] - 6 + 0.5)
+                        ctx.moveTo(pos[0] + 8, pos[1] + 0.5)
+                        ctx.lineTo(pos[0] - 4, pos[1] + 6 + 0.5)
+                        ctx.lineTo(pos[0] - 4, pos[1] - 6 + 0.5)
                         ctx.closePath()
                     }
                     else {
                         ctx.arc(
-                            link.pos[0],
-                            link.pos[1],
+                            pos[0],
+                            pos[1],
                             4,
                             0,
                             Math.PI * 2

--- a/src/LGraphCanvas.ts
+++ b/src/LGraphCanvas.ts
@@ -2717,8 +2717,8 @@ export class LGraphCanvas {
                 this.node_dragged = null
             } //no node being dragged
             else {
-                if (!node && e.click_time < 300 && !this.graph.groups.some(x => x.isPointInTitlebar(e.canvasX, e.canvasY))) {
-                    this.deselectAll()
+                if (!node && e.click_time < 300 && !this.graph.getGroupTitlebarOnPos(e.canvasX, e.canvasY) && !this.graph.getRerouteOnPos(e.canvasX, e.canvasY)) {
+                    this.processSelect(null, e)
                 }
 
                 this.dirty_canvas = true

--- a/src/LGraphCanvas.ts
+++ b/src/LGraphCanvas.ts
@@ -5113,6 +5113,7 @@ export class LGraphCanvas {
 
     /**
      * draws a link between two points
+     * @param ctx Canvas 2D rendering context
      * @param {vec2} a start pos
      * @param {vec2} b end pos
      * @param {Object} link the link object with all the link info
@@ -5122,17 +5123,33 @@ export class LGraphCanvas {
      * @param {LinkDirection} start_dir the direction enum
      * @param {LinkDirection} end_dir the direction enum
      * @param {number} num_sublines number of sublines (useful to represent vec3 or rgb)
-     **/
-    renderLink(ctx: CanvasRenderingContext2D,
-        a: Point,
-        b: Point,
+     */
+    renderLink(
+        ctx: CanvasRenderingContext2D,
+        a: ReadOnlyPoint,
+        b: ReadOnlyPoint,
         link: LLink,
         skip_border: boolean,
         flow: number,
         color: CanvasColour,
         start_dir: LinkDirection,
         end_dir: LinkDirection,
-        num_sublines?: number): void {
+        {
+            startControl,
+            endControl,
+            reroute,
+            num_sublines = 1
+        }: {
+            /** When defined, render data will be saved to this reroute instead of the {@link link}. */
+            reroute?: Reroute
+            /** Offset of the bezier curve control point from {@link a point a} (output side) */
+            startControl?: ReadOnlyPoint
+            /** Offset of the bezier curve control point from {@link b point b} (input side) */
+            endControl?: ReadOnlyPoint
+            /** Number of sublines (useful to represent vec3 or rgb) */
+            num_sublines?: number
+        } = {},
+    ): void {
 
         if (link) {
             this.visible_links.push(link)
@@ -5164,10 +5181,9 @@ export class LGraphCanvas {
 
         //begin line shape
         const path = new Path2D()
-        if (link) {
-            // Store the path on the link for hittests
-            link.path = path
-        }
+        if (reroute) reroute.path = path
+        else if (link) link.path = path
+
         for (let i = 0; i < num_sublines; i += 1) {
             const offsety = (i - (num_sublines - 1) * 0.5) * 5
 

--- a/src/LGraphCanvas.ts
+++ b/src/LGraphCanvas.ts
@@ -7800,6 +7800,16 @@ export class LGraphCanvas {
             menu_info = this.getNodeMenuOptions(node)
         } else {
             menu_info = this.getCanvasMenuOptions()
+
+            // Check for reroutes
+            const reroute = this.graph.getRerouteOnPos(event.canvasX, event.canvasY)
+            if (reroute) {
+                menu_info.unshift({
+                    content: "Delete Reroute",
+                    callback: () => this.graph.removeReroute(reroute.id)
+                }, null)
+            }
+
             const group = this.graph.getGroupOnPos(
                 event.canvasX,
                 event.canvasY

--- a/src/LGraphCanvas.ts
+++ b/src/LGraphCanvas.ts
@@ -2029,6 +2029,17 @@ export class LGraphCanvas {
                 }
             } //clicked outside of nodes
             else {
+                if (!skip_action && !this.read_only) {
+                    // Check for reroutes
+                    const reroute = graph.getRerouteOnPos(e.canvasX, e.canvasY)
+                    if (reroute) {
+                        this.processSelect(reroute, e)
+
+                        this.isDragging = true
+                        skip_action = true
+                    }
+                }
+
                 if (!skip_action) {
                     //search for link connector
                     if (!this.read_only) {

--- a/src/LGraphCanvas.ts
+++ b/src/LGraphCanvas.ts
@@ -3291,7 +3291,7 @@ export class LGraphCanvas {
      * @returns All items on the canvas that can be selected
      */
     get positionableItems(): Positionable[] {
-        return [...this.graph._nodes, ...this.graph._groups]
+        return [...this.graph._nodes, ...this.graph._groups, ...this.graph.reroutes.values()]
     }
 
     /**

--- a/src/LGraphCanvas.ts
+++ b/src/LGraphCanvas.ts
@@ -15,6 +15,7 @@ import { LinkReleaseContextExtended, LiteGraph, clamp } from "./litegraph"
 import { stringOrEmpty, stringOrNull } from "./strings"
 import { alignNodes, distributeNodes, getBoundaryNodes } from "./utils/arrange"
 import { Reroute, type RerouteId } from "./Reroute"
+import { getAllNestedItems } from "./utils/collections"
 
 interface IShowSearchOptions {
     node_to?: LGraphNode
@@ -2477,22 +2478,15 @@ export class LGraphCanvas {
             // Items being dragged
             if (this.isDragging && !this.live_mode) {
                 const selected = this.selectedItems
-                const allItems = e.ctrlKey ? selected : new Set<Positionable>()
-
-                if (!e.ctrlKey)
-                    selected?.forEach(x => addToSetRecursively(x, allItems))
+                const allItems = e.ctrlKey ? selected : getAllNestedItems(selected)
 
                 const deltaX = delta[0] / this.ds.scale
                 const deltaY = delta[1] / this.ds.scale
-                allItems.forEach(x => x.move(deltaX, deltaY, true))
+                for (const item of allItems) {
+                    if (!item.pinned) item.move(deltaX, deltaY, true)
+                }
 
                 this.#dirty()
-
-                function addToSetRecursively(item: Positionable, items: Set<Positionable>): void {
-                    if (items.has(item) || item.pinned) return
-                    items.add(item)
-                    item.children?.forEach(x => addToSetRecursively(x, items))
-                }
             }
 
             if (this.resizing_node && !this.live_mode) {

--- a/src/LGraphCanvas.ts
+++ b/src/LGraphCanvas.ts
@@ -3339,9 +3339,12 @@ export class LGraphCanvas {
                 this.onNodeDeselected?.(node)
             } else if (item instanceof LGraphGroup) {
                 graph.remove(item)
+            } else if (item instanceof Reroute) {
+                graph.removeReroute(item.id)
             }
         }
 
+        this.selectedItems.clear()
         this.selected_nodes = {}
         this.selectedItems.clear()
         this.current_node = null

--- a/src/LGraphCanvas.ts
+++ b/src/LGraphCanvas.ts
@@ -286,7 +286,7 @@ export class LGraphCanvas {
     /** A map of nodes that require selective-redraw */
     dirty_nodes = new Map<NodeId, LGraphNode>()
     dirty_area?: Rect
-    // Unused
+    /** @deprecated Unused */
     node_in_panel?: LGraphNode
     last_mouse: Point = [0, 0]
     last_mouseclick: number = 0
@@ -305,10 +305,13 @@ export class LGraphCanvas {
     _mouseout_callback?(e: CanvasMouseEvent): boolean
     _key_callback?(e: KeyboardEvent): boolean
     _ondrop_callback?(e: CanvasDragEvent): unknown
+    /** @deprecated WebGL */
     gl?: never
     bgctx?: CanvasRenderingContext2D
     is_rendering?: boolean
+    /** @deprecated Panels */
     block_click?: boolean
+    /** @deprecated Panels */
     last_click_position?: Point
     resizing_node?: LGraphNode
     /** @deprecated See {@link LGraphCanvas.resizingGroup} */
@@ -318,7 +321,9 @@ export class LGraphCanvas {
     _highlight_pos?: Point
     _highlight_input?: INodeInputSlot
     // TODO: Check if panels are used
+    /** @deprecated Panels */
     node_panel
+    /** @deprecated Panels */
     options_panel
     onDropItem: (e: Event) => any
     _bg_img: HTMLImageElement
@@ -327,7 +332,9 @@ export class LGraphCanvas {
     // TODO: This looks like another panel thing
     prompt_box: IDialog
     search_box: HTMLDivElement
+    /** @deprecated Panels */
     SELECTED_NODE: LGraphNode
+    /** @deprecated Panels */
     NODEPANEL_IS_OPEN: boolean
     getMenuOptions?(): IContextMenuValue[]
     getExtraMenuOptions?(canvas: LGraphCanvas, options: IContextMenuValue[]): IContextMenuValue[]
@@ -1741,8 +1748,8 @@ export class LGraphCanvas {
         let skip_action = false
         const now = LiteGraph.getTime()
         const is_double_click = (now - this.last_mouseclick < 300)
-        this.mouse[0] = e.clientX
-        this.mouse[1] = e.clientY
+        this.mouse[0] = x
+        this.mouse[1] = y
         this.graph_mouse[0] = e.canvasX
         this.graph_mouse[1] = e.canvasY
         this.last_click_position = [this.mouse[0], this.mouse[1]]
@@ -2222,7 +2229,7 @@ export class LGraphCanvas {
 
         }
 
-        this.last_mouse = [e.clientX, e.clientY]
+        this.last_mouse = [x, y]
         this.last_mouseclick = LiteGraph.getTime()
         this.last_mouse_dragging = true
 

--- a/src/LGraphCanvas.ts
+++ b/src/LGraphCanvas.ts
@@ -2717,7 +2717,7 @@ export class LGraphCanvas {
                     !node &&
                     e.click_time < 300 &&
                     !this.graph.getGroupTitlebarOnPos(e.canvasX, e.canvasY) &&
-                    (this.reroutesEnabled && !this.graph.getRerouteOnPos(e.canvasX, e.canvasY))
+                    (!this.reroutesEnabled || !this.graph.getRerouteOnPos(e.canvasX, e.canvasY))
                 ) {
                     this.processSelect(null, e)
                 }

--- a/src/LGraphCanvas.ts
+++ b/src/LGraphCanvas.ts
@@ -2044,7 +2044,24 @@ export class LGraphCanvas {
                     if (reroute) {
                         this.processSelect(reroute, e)
 
-                        this.isDragging = true
+                        if (e.shiftKey) {
+                            // Connect new link from reroute
+                            const link = graph._links.get(reroute.linkIds.values().next().value)
+
+                            const outputNode = graph.getNodeById(link.origin_id)
+                            const slot = link.origin_slot
+                            this.connecting_links = [{
+                                node: outputNode,
+                                slot,
+                                input: null,
+                                output: outputNode.outputs[slot],
+                                pos: outputNode.getConnectionPos(false, slot),
+                                afterRerouteId: reroute.id,
+                            }]
+                        } else {
+                            this.isDragging = true
+                        }
+
                         skip_action = true
                     }
                 }

--- a/src/LGraphCanvas.ts
+++ b/src/LGraphCanvas.ts
@@ -2570,6 +2570,12 @@ export class LGraphCanvas {
                             group.recomputeInsideNodes()
                             group.selected = true
                         }
+
+                        for (const reroute of this.graph.reroutes.values()) {
+                            if (!isPointInRectangle(reroute.pos, dragRect)) continue
+                            this.selectedItems.add(reroute)
+                            reroute.selected = true
+                        }
                     } else {
                         // will select of update selection
                         this.selectNodes([node], e.shiftKey || e.ctrlKey || e.metaKey) // add to selection add to selection with ctrlKey or shiftKey

--- a/src/LGraphCanvas.ts
+++ b/src/LGraphCanvas.ts
@@ -5222,68 +5222,56 @@ export class LGraphCanvas {
                 )
             } else if (this.links_render_mode == LinkRenderType.LINEAR_LINK) {
                 path.moveTo(a[0], a[1] + offsety)
-                let start_offset_x = 0
-                let start_offset_y = 0
-                let end_offset_x = 0
-                let end_offset_y = 0
+                const l = 15
                 switch (start_dir) {
                     case LinkDirection.LEFT:
-                        start_offset_x = -1
+                        innerA[0] += -l
                         break
                     case LinkDirection.RIGHT:
-                        start_offset_x = 1
+                        innerA[0] += l
                         break
                     case LinkDirection.UP:
-                        start_offset_y = -1
+                        innerA[1] += -l
                         break
                     case LinkDirection.DOWN:
-                        start_offset_y = 1
+                        innerA[1] += l
                         break
                 }
                 switch (end_dir) {
                     case LinkDirection.LEFT:
-                        end_offset_x = -1
+                        innerB[0] += -l
                         break
                     case LinkDirection.RIGHT:
-                        end_offset_x = 1
+                        innerB[0] += l
                         break
                     case LinkDirection.UP:
-                        end_offset_y = -1
+                        innerB[1] += -l
                         break
                     case LinkDirection.DOWN:
-                        end_offset_y = 1
+                        innerB[1] += l
                         break
                 }
-                const l = 15
-                path.lineTo(
-                    a[0] + start_offset_x * l,
-                    a[1] + start_offset_y * l + offsety
-                )
-                path.lineTo(
-                    b[0] + end_offset_x * l,
-                    b[1] + end_offset_y * l + offsety
-                )
+                path.lineTo(innerA[0], innerA[1] + offsety)
+                path.lineTo(innerB[0], innerB[1] + offsety)
                 path.lineTo(b[0], b[1] + offsety)
             } else if (this.links_render_mode == LinkRenderType.STRAIGHT_LINK) {
                 path.moveTo(a[0], a[1])
-                let start_x = a[0]
-                let start_y = a[1]
-                let end_x = b[0]
-                let end_y = b[1]
                 if (start_dir == LinkDirection.RIGHT) {
-                    start_x += 10
+                    innerA[0] += 10
                 } else {
-                    start_y += 10
+                    innerA[1] += 10
                 }
                 if (end_dir == LinkDirection.LEFT) {
-                    end_x -= 10
+                    innerB[0] -= 10
                 } else {
-                    end_y -= 10
+                    innerB[1] -= 10
                 }
-                path.lineTo(start_x, start_y)
-                path.lineTo((start_x + end_x) * 0.5, start_y)
-                path.lineTo((start_x + end_x) * 0.5, end_y)
-                path.lineTo(end_x, end_y)
+                const midX = (innerA[0] + innerB[0]) * 0.5
+
+                path.lineTo(innerA[0], innerA[1])
+                path.lineTo(midX, innerA[1])
+                path.lineTo(midX, innerB[1])
+                path.lineTo(innerB[0], innerB[1])
                 path.lineTo(b[0], b[1])
             } else {
                 return

--- a/src/LGraphCanvas.ts
+++ b/src/LGraphCanvas.ts
@@ -5173,14 +5173,16 @@ export class LGraphCanvas {
 
         //begin line shape
         const path = new Path2D()
-        if (reroute) reroute.path = path
-        else if (link) link.path = path
+
+        /** The link or reroute we're currently rendering */
+        const linkSegment = reroute ?? link
+        if (linkSegment) linkSegment.path = path
 
         const innerA = LGraphCanvas.#lTempA
         const innerB = LGraphCanvas.#lTempB
 
         /** Reference to {@link reroute._pos} if present, or {@link link._pos} if present.  Caches the centre point of the link. */
-        const pos: Point = reroute?._pos ?? link?._pos ?? [0, 0]
+        const pos: Point = linkSegment?._pos ?? [0, 0]
 
         for (let i = 0; i < num_sublines; i += 1) {
             const offsety = (i - (num_sublines - 1) * 0.5) * 5

--- a/src/LGraphNode.ts
+++ b/src/LGraphNode.ts
@@ -2150,7 +2150,7 @@ export class LGraphNode implements Positionable, IPinnable {
                     }
                 }
 
-                this.graph._links.delete(link_id)
+                link_info.disconnect(this.graph)
                 if (this.graph) this.graph._version++
 
                 this.onConnectionsChange?.(

--- a/src/LGraphNode.ts
+++ b/src/LGraphNode.ts
@@ -5,6 +5,7 @@ import type { ISerialisedNode } from "./types/serialisation"
 import type { LGraphCanvas } from "./LGraphCanvas"
 import type { CanvasMouseEvent } from "./types/events"
 import type { DragAndScale } from "./DragAndScale"
+import type { Reroute, RerouteId } from "./Reroute"
 import { LGraphEventMode, NodeSlotType, TitleMode, RenderShape } from "./types/globalEnums"
 import { BadgePosition, LGraphBadge } from "./LGraphBadge"
 import { type LGraphNodeConstructor, LiteGraph } from "./litegraph"
@@ -36,6 +37,8 @@ interface ConnectByTypeOptions {
     wildcardToTyped?: boolean
     /** Allow our typed slot to connect to wildcard slots on remote node. Default: true */
     typedToWildcard?: boolean
+    /** The {@link Reroute.id} that the connection is being dragged from. */
+    afterRerouteId?: RerouteId
 }
 
 /** Internal type used for type safety when implementing generic checks for inputs & outputs */
@@ -1291,7 +1294,7 @@ export class LGraphNode implements Positionable, IPinnable {
         if (this.widgets?.length) {
             for (let i = 0, l = this.widgets.length; i < l; ++i) {
                 const widget = this.widgets[i]
-                if (widget.hidden || (widget.advanced && !this.showAdvanced)) continue;
+                if (widget.hidden || (widget.advanced && !this.showAdvanced)) continue
 
                 widgets_height += widget.computeSize
                     ? widget.computeSize(size[0])[1] + 4
@@ -1795,7 +1798,7 @@ export class LGraphNode implements Positionable, IPinnable {
      */
     connectByType(slot: number | string, target_node: LGraphNode, target_slotType: ISlotType, optsIn?: ConnectByTypeOptions): LLink | null {
         const slotIndex = this.findConnectByTypeSlot(true, target_node, target_slotType, optsIn)
-        if (slotIndex !== null) return this.connect(slot, target_node, slotIndex)
+        if (slotIndex !== null) return this.connect(slot, target_node, slotIndex, optsIn?.afterRerouteId)
 
         console.debug("[connectByType]: no way to connect type: ", target_slotType, " to node: ", target_node)
         return null
@@ -1816,7 +1819,7 @@ export class LGraphNode implements Positionable, IPinnable {
             if ("generalTypeInCase" in optsIn) optsIn.typedToWildcard = !!optsIn.generalTypeInCase
         }
         const slotIndex = this.findConnectByTypeSlot(false, source_node, source_slotType, optsIn)
-        if (slotIndex !== null) return source_node.connect(slotIndex, this, slot)
+        if (slotIndex !== null) return source_node.connect(slotIndex, this, slot, optsIn?.afterRerouteId)
 
         console.debug("[connectByType]: no way to connect type: ", source_slotType, " to node: ", source_node)
         return null
@@ -1829,7 +1832,7 @@ export class LGraphNode implements Positionable, IPinnable {
      * @param {number | string} target_slot the input slot of the target node (could be the number of the slot or the string with the name of the slot, or -1 to connect a trigger)
      * @return {Object} the link_info is created, otherwise null
      */
-    connect(slot: number | string, target_node: LGraphNode, target_slot: ISlotType): LLink | null {
+    connect(slot: number | string, target_node: LGraphNode, target_slot: ISlotType, afterRerouteId?: RerouteId): LLink | null {
         // Allow legacy API support for searching target_slot by string, without mutating the input variables
         let targetIndex: number
 
@@ -1942,7 +1945,8 @@ export class LGraphNode implements Positionable, IPinnable {
             this.id,
             slot,
             target_node.id,
-            targetIndex
+            targetIndex,
+            afterRerouteId
         )
 
         //add to graph links list
@@ -1953,6 +1957,10 @@ export class LGraphNode implements Positionable, IPinnable {
         output.links.push(link_info.id)
         //connect in input
         target_node.inputs[targetIndex].link = link_info.id
+
+        // Reroutes
+        LLink.getReroutes(graph, link_info)
+            .forEach(x => x?.linkIds.add(nextId))
         graph._version++
 
         //link_info has been created now, so its updated

--- a/src/LGraphNode.ts
+++ b/src/LGraphNode.ts
@@ -2462,8 +2462,7 @@ export class LGraphNode implements Positionable, IPinnable {
                 const outNode = graph.getNodeById(outLink.target_id)
                 if (!outNode) return
 
-                // TODO: Add 4th param (afterRerouteId: inLink.parentId) when reroutes are merged.
-                const result = inNode.connect(inLink.origin_slot, outNode, outLink.target_slot)
+                const result = inNode.connect(inLink.origin_slot, outNode, outLink.target_slot, inLink.parentId)
                 madeAnyConnections ||= !!result
             }
         }

--- a/src/LGraphNode.ts
+++ b/src/LGraphNode.ts
@@ -1922,7 +1922,7 @@ export class LGraphNode implements Positionable, IPinnable {
         //if there is something already plugged there, disconnect
         if (target_node.inputs[targetIndex]?.link != null) {
             graph.beforeChange()
-            target_node.disconnectInput(targetIndex)
+            target_node.disconnectInput(targetIndex, true)
             changed = true
         }
         if (output.links?.length) {
@@ -2116,9 +2116,10 @@ export class LGraphNode implements Positionable, IPinnable {
     /**
      * Disconnect one input
      * @param slot Input slot index, or the name of the slot
+     * @param keepReroutes If `true`, reroutes will not be garbage collected.
      * @return true if disconnected successfully or already disconnected, otherwise false
      */
-    disconnectInput(slot: number | string): boolean {
+    disconnectInput(slot: number | string, keepReroutes?: boolean): boolean {
         // Allow search by string
         if (typeof slot === "string") {
             slot = this.findInputSlot(slot)
@@ -2158,7 +2159,7 @@ export class LGraphNode implements Positionable, IPinnable {
                     }
                 }
 
-                link_info.disconnect(this.graph)
+                link_info.disconnect(this.graph, keepReroutes)
                 if (this.graph) this.graph._version++
 
                 this.onConnectionsChange?.(

--- a/src/LLink.ts
+++ b/src/LLink.ts
@@ -30,6 +30,8 @@ export class LLink implements LinkSegment, Serialisable<SerialisableLLink> {
     _last_time?: number
     /** The last canvas 2D path that was used to render this link */
     path?: Path2D
+    /** @inheritdoc */
+    _centreAngle?: number
 
     #color?: CanvasColour
     /** Custom colour for this link only */

--- a/src/LLink.ts
+++ b/src/LLink.ts
@@ -5,7 +5,7 @@ import type { Serialisable, SerialisableLLink } from "./types/serialisation"
 
 export type LinkId = number
 
-export type SerialisedLLinkArray = [id: LinkId, origin_id: NodeId, origin_slot: number, target_id: NodeId, target_slot: number, type: ISlotType] 
+export type SerialisedLLinkArray = [id: LinkId, origin_id: NodeId, origin_slot: number, target_id: NodeId, target_slot: number, type: ISlotType]
 
 //this is the class in charge of storing link information
 export class LLink implements LinkSegment, Serialisable<SerialisableLLink> {
@@ -21,6 +21,7 @@ export class LLink implements LinkSegment, Serialisable<SerialisableLLink> {
     target_id: NodeId
     /** Input slot index */
     target_slot: number
+
     data?: number | string | boolean | { toToolTip?(): string }
     _data?: unknown
     /** Centre point of the link, calculated during render only - can be inaccurate */
@@ -37,13 +38,14 @@ export class LLink implements LinkSegment, Serialisable<SerialisableLLink> {
         this.#color = value === "" ? null : value
     }
 
-    constructor(id: LinkId, type: ISlotType, origin_id: NodeId, origin_slot: number, target_id: NodeId, target_slot: number) {
+    constructor(id: LinkId, type: ISlotType, origin_id: NodeId, origin_slot: number, target_id: NodeId, target_slot: number, parentId?: RerouteId) {
         this.id = id
         this.type = type
         this.origin_id = origin_id
         this.origin_slot = origin_slot
         this.target_id = target_id
         this.target_slot = target_slot
+        this.parentId = parentId
 
         this._data = null
         this._pos = new Float32Array(2) //center
@@ -60,7 +62,7 @@ export class LLink implements LinkSegment, Serialisable<SerialisableLLink> {
      * @returns A new LLink
      */
     static create(data: SerialisableLLink): LLink {
-        return new LLink(data.id, data.type, data.origin_id, data.origin_slot, data.target_id, data.target_slot)
+        return new LLink(data.id, data.type, data.origin_id, data.origin_slot, data.target_id, data.target_slot, data.parentId)
     }
 
     /**
@@ -99,6 +101,7 @@ export class LLink implements LinkSegment, Serialisable<SerialisableLLink> {
             this.origin_slot = o.origin_slot
             this.target_id = o.target_id
             this.target_slot = o.target_slot
+            this.parentId = o.parentId
         }
     }
 

--- a/src/LLink.ts
+++ b/src/LLink.ts
@@ -108,13 +108,14 @@ export class LLink implements LinkSegment, Serialisable<SerialisableLLink> {
     /**
      * Disconnects a link and removes it from the graph, cleaning up any reroutes that are no longer used
      * @param network The container (LGraph) where reroutes should be updated
+     * @param keepReroutes If `true`, reroutes will not be garbage collected.
      */
-    disconnect(network: LinkNetwork): void {
+    disconnect(network: LinkNetwork, keepReroutes?: boolean): void {
         const reroutes = LLink.getReroutes(network, this)
 
         for (const reroute of reroutes) {
             reroute.linkIds.delete(this.id)
-            if (!reroute.linkIds.size) network.reroutes.delete(reroute.id)
+            if (!keepReroutes && !reroute.linkIds.size) network.reroutes.delete(reroute.id)
         }
         network.links.delete(this.id)
     }

--- a/src/LLink.ts
+++ b/src/LLink.ts
@@ -106,6 +106,20 @@ export class LLink implements LinkSegment, Serialisable<SerialisableLLink> {
     }
 
     /**
+     * Disconnects a link and removes it from the graph, cleaning up any reroutes that are no longer used
+     * @param network The container (LGraph) where reroutes should be updated
+     */
+    disconnect(network: LinkNetwork): void {
+        const reroutes = LLink.getReroutes(network, this)
+
+        for (const reroute of reroutes) {
+            reroute.linkIds.delete(this.id)
+            if (!reroute.linkIds.size) network.reroutes.delete(reroute.id)
+        }
+        network.links.delete(this.id)
+    }
+
+    /**
      * @deprecated Prefer {@link LLink.asSerialisable} (returns an object, not an array)
      * @returns An array representing this LLink
      */

--- a/src/Reroute.ts
+++ b/src/Reroute.ts
@@ -56,6 +56,8 @@ export class Reroute implements Positionable, LinkSegment, Serialisable<Serialis
     /** @inheritdoc */
     path?: Path2D
     /** @inheritdoc */
+    _centreAngle?: number
+    /** @inheritdoc */
     _pos: Float32Array = new Float32Array(2)
 
     /** @inheritdoc */

--- a/src/Reroute.ts
+++ b/src/Reroute.ts
@@ -53,15 +53,20 @@ export class Reroute implements Positionable, LinkSegment, Serialisable<Serialis
     /** The ID ({@link LLink.id}) of every link using this reroute */
     linkIds: Set<LinkId>
 
+    /** @inheritdoc */
     path?: Path2D
+    /** @inheritdoc */
     _pos: Float32Array = new Float32Array(2)
 
+    /** @inheritdoc */
     get origin_id(): NodeId | undefined {
         // if (!this.linkIds.size) return this.#network.deref()?.reroutes.get(this.parentId)
         return this.#network.deref()
             ?.links.get(this.linkIds.values().next().value)
             ?.origin_id
     }
+
+    /** @inheritdoc */
     get origin_slot(): number | undefined {
         return this.#network.deref()
             ?.links.get(this.linkIds.values().next().value)

--- a/src/Reroute.ts
+++ b/src/Reroute.ts
@@ -1,6 +1,7 @@
 import type { CanvasColour, LinkSegment, LinkNetwork, Point, Positionable, ReadOnlyRect } from "./interfaces"
 import { LLink, type LinkId } from "./LLink"
 import type { SerialisableReroute, Serialisable } from "./types/serialisation"
+import type { NodeId } from "./LGraphNode"
 
 export type RerouteId = number
 
@@ -54,6 +55,18 @@ export class Reroute implements Positionable, LinkSegment, Serialisable<Serialis
 
     path?: Path2D
     _pos: Float32Array = new Float32Array(2)
+
+    get origin_id(): NodeId | undefined {
+        // if (!this.linkIds.size) return this.#network.deref()?.reroutes.get(this.parentId)
+        return this.#network.deref()
+            ?.links.get(this.linkIds.values().next().value)
+            ?.origin_id
+    }
+    get origin_slot(): number | undefined {
+        return this.#network.deref()
+            ?.links.get(this.linkIds.values().next().value)
+            ?.origin_slot
+    }
 
     /**
      * Initialises a new link reroute object.

--- a/src/Reroute.ts
+++ b/src/Reroute.ts
@@ -1,0 +1,193 @@
+import type { CanvasColour, LinkSegment, LinkNetwork, Point, Positionable, ReadOnlyRect } from "./interfaces"
+import { LLink, type LinkId } from "./LLink"
+import type { SerialisableReroute, Serialisable } from "./types/serialisation"
+
+export type RerouteId = number
+
+/**
+ * Represents an additional point on the graph that a link path will travel through.  Used for visual organisation only.
+ * 
+ * Requires no disposal or clean up.
+ * Stores only primitive values (IDs) to reference other items in its network, and a `WeakRef` to a {@link LinkNetwork} to resolve them.
+ */
+export class Reroute implements Positionable, LinkSegment, Serialisable<SerialisableReroute> {
+    static radius: number = 10
+
+    /** The network this reroute belongs to.  Contains all valid links and reroutes. */
+    #network: WeakRef<LinkNetwork>
+
+    #parentId?: RerouteId
+    /** @inheritdoc */
+    public get parentId(): RerouteId {
+        return this.#parentId
+    }
+    /** Ignores attempts to create an infinite loop. @inheritdoc */
+    public set parentId(value: RerouteId) {
+        if (value === this.id) return
+        if (this.getReroutes() === null) return
+        this.#parentId = value
+    }
+
+    #pos = new Float32Array(2)
+    /** @inheritdoc */
+    get pos(): Point {
+        return this.#pos
+    }
+    set pos(value: Point) {
+        if (!(value?.length >= 2)) throw new TypeError("Reroute.pos is an x,y point, and expects an indexable with at least two values.")
+        this.#pos[0] = value[0]
+        this.#pos[1] = value[1]
+    }
+
+    /** @inheritdoc */
+    get boundingRect(): ReadOnlyRect {
+        const { radius } = Reroute
+        const [x, y] = this.#pos
+        return [x - radius, y - radius, 2 * radius, 2 * radius]
+    }
+
+    /** @inheritdoc */
+    selected?: boolean
+
+    /** The ID ({@link LLink.id}) of every link using this reroute */
+    linkIds: Set<LinkId>
+
+    path?: Path2D
+    _pos: Float32Array = new Float32Array(2)
+
+    /**
+     * Initialises a new link reroute object.
+     * @param id Unique identifier for this reroute
+     * @param network The network of links this reroute belongs to.  Internally converted to a WeakRef.
+     * @param pos Position in graph coordinates
+     * @param linkIds Link IDs ({@link LLink.id}) of all links that use this reroute
+     */
+    constructor(
+        public readonly id: RerouteId,
+        network: LinkNetwork,
+        pos?: Point,
+        parentId?: RerouteId,
+        linkIds?: Iterable<LinkId>
+    ) {
+        this.#network = new WeakRef(network)
+        this.update(parentId, pos, linkIds)
+        this.linkIds ??= new Set()
+    }
+
+    /**
+     * Applies a new parentId to the reroute, and optinoally a new position and linkId.
+     * Primarily used for deserialisation.
+     * @param parentId The ID of the reroute prior to this reroute, or `undefined` if it is the first reroute connected to a nodes output
+     * @param pos The position of this reroute
+     * @param linkIds All link IDs that pass through this reroute
+     */
+    update(parentId: RerouteId | undefined, pos?: Point, linkIds?: Iterable<LinkId>): void {
+        this.parentId = parentId
+        if (pos) this.pos = pos
+        if (linkIds) this.linkIds = new Set(linkIds)
+    }
+
+    /**
+     * Validates the linkIds this reroute has.  Removes broken links.
+     * @param links Collection of valid links
+     * @returns true if any links remain after validation
+     */
+    validateLinks(links: Map<LinkId, LLink>): boolean {
+        const { linkIds } = this
+        for (const linkId of linkIds) {
+            if (!links.get(linkId)) linkIds.delete(linkId)
+        }
+        return linkIds.size > 0
+    }
+
+    /**
+     * Retrieves an ordered array of all reroutes from the node output.
+     * @param visited Internal.  A set of reroutes that this function has already visited whilst recursing up the chain.
+     * @returns An ordered array of all reroutes from the node output to this reroute, inclusive.
+     * `null` if an infinite loop is detected.
+     * `undefined` if the reroute chain or {@link LinkNetwork} are invalid.
+     */
+    getReroutes(visited = new Set<Reroute>()): Reroute[] | null | undefined {
+        // No parentId - last in the chain
+        if (this.#parentId === undefined) return [this]
+        // Invalid chain - looped
+        if (visited.has(this)) return null
+        visited.add(this)
+
+        const parent = this.#network.deref()?.reroutes.get(this.#parentId)
+        // Invalid parent (or network) - drop silently to recover
+        if (!parent) {
+            this.#parentId = undefined
+            return [this]
+        }
+
+        const reroutes = parent.getReroutes(visited)
+        reroutes?.push(this)
+        return reroutes
+    }
+
+    /**
+     * Internal.  Called by {@link LLink.findNextReroute}.  Not intended for use by itself.
+     * @param withParentId The rerouteId to look for
+     * @param visited A set of reroutes that have already been visited
+     * @returns The reroute that was found, `undefined` if no reroute was found, or `null` if an infinite loop was detected.
+     */
+    findNextReroute(withParentId: RerouteId, visited = new Set<Reroute>()): Reroute | null | undefined {
+        if (this.#parentId === withParentId) return this
+        if (visited.has(this)) return null
+        visited.add(this)
+
+        return this.#network.deref()
+            ?.reroutes.get(this.#parentId)
+            ?.findNextReroute(withParentId, visited)
+    }
+
+    /** @inheritdoc */
+    move(deltaX: number, deltaY: number) {
+        this.#pos[0] += deltaX
+        this.#pos[1] += deltaY
+    }
+
+    /**
+     * Renders the reroute on the canvas.
+     * @param ctx Canvas context to draw on
+     * @param colour Reroute colour (typically link colour)
+     * 
+     * @remarks Leaves {@link ctx}.fillStyle, strokeStyle, and lineWidth dirty (perf.).
+     */
+    draw(ctx: CanvasRenderingContext2D, colour: CanvasColour): void {
+        const { pos } = this
+        ctx.fillStyle = colour
+        ctx.beginPath()
+        ctx.arc(pos[0], pos[1], Reroute.radius, 0, 2 * Math.PI)
+        ctx.fill()
+
+        ctx.lineWidth = 1
+        ctx.strokeStyle = "rgb(0,0,0,0.5)"
+        ctx.stroke()
+
+        ctx.fillStyle = "#ffffff55"
+        ctx.strokeStyle = "rgb(0,0,0,0.3)"
+        ctx.beginPath()
+        ctx.arc(pos[0], pos[1], 8, 0, 2 * Math.PI)
+        ctx.fill()
+        ctx.stroke()
+
+        if (this.selected) {
+            ctx.strokeStyle = "#fff"
+            ctx.beginPath()
+            ctx.arc(pos[0], pos[1], 12, 0, 2 * Math.PI)
+            ctx.stroke()
+        }
+    }
+
+    /** @inheritdoc */
+    asSerialisable(): SerialisableReroute {
+        return {
+            id: this.id,
+            parentId: this.parentId,
+            pos: [this.pos[0], this.pos[1]],
+            linkIds: [...this.linkIds]
+        }
+    }
+}

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -85,6 +85,8 @@ export interface LinkSegment {
     path?: Path2D
     /** Centre point of the {@link path}.  Calculated during render only - can be inaccurate */
     readonly _pos: Float32Array
+    /** Y-forward along the {@link path} from its centre point, in radians.  `undefined` if using circles for link centres.  Calculated during render only - can be inaccurate. */
+    _centreAngle?: number
 
     /** Output node ID */
     readonly origin_id: NodeId

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -81,6 +81,11 @@ export interface LinkSegment {
     path?: Path2D
     /** Centre point of the {@link path}.  Calculated during render only - can be inaccurate */
     readonly _pos: Float32Array
+
+    /** Output node ID */
+    readonly origin_id: NodeId
+    /** Output slot index */
+    readonly origin_slot: number
 }
 
 export interface IInputOrOutput {

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -190,6 +190,7 @@ export interface ConnectingLink extends IInputOrOutput {
     slot: number
     pos: Point
     direction?: LinkDirection
+    afterRerouteId?: RerouteId
 }
 
 interface IContextMenuBase {

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -13,12 +13,18 @@ export type NullableProperties<T> = {
 
 export type CanvasColour = string | CanvasGradient | CanvasPattern
 
+/** An object containing a set of child objects */
+export interface Parent<TChild> {
+    /** All objects owned by the parent object. */
+    readonly children?: ReadonlySet<TChild>
+}
+
 /**
  * An object that can be positioned, selected, and moved.
  *
  * May contain other {@link Positionable} objects.
  */
-export interface Positionable {
+export interface Positionable extends Parent<Positionable> {
     id: NodeId | RerouteId | number
     /** Position in graph coordinates.  Default: 0,0 */
     pos: Point
@@ -27,8 +33,6 @@ export interface Positionable {
 
     /** See {@link IPinnable.pinned} */
     readonly pinned?: boolean
-
-    readonly children?: ReadonlySet<Positionable>
 
     /**
      * Adds a delta to the current position.

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -1,7 +1,8 @@
 import type { ContextMenu } from "./ContextMenu"
 import type { LGraphNode, NodeId } from "./LGraphNode"
 import type { LinkDirection, RenderShape } from "./types/globalEnums"
-import type { LinkId } from "./LLink"
+import type { LinkId, LLink } from "./LLink"
+import type { Reroute, RerouteId } from "./Reroute"
 
 export type Dictionary<T> = { [key: string]: T }
 
@@ -18,7 +19,7 @@ export type CanvasColour = string | CanvasGradient | CanvasPattern
  * May contain other {@link Positionable} objects.
  */
 export interface Positionable {
-    id: NodeId | number
+    id: NodeId | RerouteId | number
     /** Position in graph coordinates.  Default: 0,0 */
     pos: Point
     /** true if this object is part of the selection, otherwise false. */
@@ -58,6 +59,28 @@ export interface IPinnable {
     pinned: boolean
     pin(value?: boolean): void
     unpin(): void
+}
+
+/**
+ * Contains a list of links, reroutes, and nodes.
+ */
+export interface LinkNetwork {
+    links: Map<LinkId, LLink>
+    reroutes: Map<RerouteId, Reroute>
+    getNodeById(id: NodeId): LGraphNode | null
+}
+
+/** Contains a cached 2D canvas path and a centre point, with an optional forward angle. */
+export interface LinkSegment {
+    /** Link / reroute ID */
+    readonly id: LinkId | RerouteId
+    /** The {@link id} of the reroute that this segment starts from (output side), otherwise `undefined`.  */
+    readonly parentId?: RerouteId
+
+    /** The last canvas 2D path that was used to render this segment */
+    path?: Path2D
+    /** Centre point of the {@link path}.  Calculated during render only - can be inaccurate */
+    readonly _pos: Float32Array
 }
 
 export interface IInputOrOutput {

--- a/src/litegraph.ts
+++ b/src/litegraph.ts
@@ -23,7 +23,7 @@ export { INodeSlot, INodeInputSlot, INodeOutputSlot, ConnectingLink, CanvasColou
 export { IWidget }
 export { LGraphBadge, BadgePosition }
 export { SlotShape, LabelPosition, SlotDirection, SlotType }
-export { EaseFunction } from "./types/globalEnums"
+export { EaseFunction, LinkMarkerShape } from "./types/globalEnums"
 export type { SerialisableGraph, SerialisableLLink } from "./types/serialisation"
 export { createBounds } from "./measure"
 

--- a/src/types/globalEnums.ts
+++ b/src/types/globalEnums.ts
@@ -37,6 +37,16 @@ export enum LinkRenderType {
     SPLINE_LINK = 2,
 }
 
+/** The marker in the middle of a link */
+export enum LinkMarkerShape {
+    /** Do not display markers */
+    None = 0,
+    /** Circles (default) */
+    Circle = 1,
+    /** Directional arrows */
+    Arrow = 2,
+}
+
 export enum TitleMode {
     NORMAL_TITLE = 0,
     NO_TITLE = 1,

--- a/src/types/serialisation.ts
+++ b/src/types/serialisation.ts
@@ -4,8 +4,9 @@ import type { IGraphGroupFlags, LGraphGroup } from "../LGraphGroup"
 import type { LGraphNode, NodeId } from "../LGraphNode"
 import type { LiteGraph } from "../litegraph"
 import type { LinkId, LLink } from "../LLink"
+import type { RerouteId } from "../Reroute"
 import type { TWidgetValue } from "../types/widgets"
-import { RenderShape } from "./globalEnums"
+import type { RenderShape } from "./globalEnums"
 
 /**
  * An object that implements custom pre-serialization logic via {@link Serialisable.asSerialisable}.
@@ -27,6 +28,7 @@ export interface SerialisableGraph {
     groups?: ISerialisedGroup[]
     nodes?: ISerialisedNode[]
     links?: SerialisableLLink[]
+    reroutes?: SerialisableReroute[]
     extra?: Record<any, any>
 }
 
@@ -87,6 +89,14 @@ export interface IClipboardContents {
     nodes?: ISerialisedNode[]
     links?: TClipboardLink[]
 }
+
+export interface SerialisableReroute {
+    id: RerouteId
+    parentId?: RerouteId
+    pos: Point
+    linkIds: LinkId[]
+}
+
 export interface SerialisableLLink {
     /** Link ID */
     id: LinkId
@@ -100,4 +110,6 @@ export interface SerialisableLLink {
     target_slot: number
     /** Data type of the link */
     type: ISlotType
+    /** ID of the last reroute (from input to output) that this link passes through, otherwise `undefined` */
+    parentId?: RerouteId
 }

--- a/src/types/serialisation.ts
+++ b/src/types/serialisation.ts
@@ -69,7 +69,7 @@ export type ISerialisedGraph<
     groups: TGroup[]
     config: LGraph["config"]
     version: typeof LiteGraph.VERSION
-    extra?: unknown
+    extra?: Record<any, any>
 }
 
 /** Serialised LGraphGroup */

--- a/src/types/serialisation.ts
+++ b/src/types/serialisation.ts
@@ -1,4 +1,4 @@
-import type { ISlotType, Dictionary, INodeFlags, INodeInputSlot, INodeOutputSlot, Point, Rect, Size } from "../interfaces"
+import type { ISlotType, Dictionary, INodeFlags, INodeInputSlot, INodeOutputSlot, Point, Size } from "../interfaces"
 import type { LGraph, LGraphState } from "../LGraph"
 import type { IGraphGroupFlags, LGraphGroup } from "../LGraphGroup"
 import type { LGraphNode, NodeId } from "../LGraphNode"

--- a/src/utils/collections.ts
+++ b/src/utils/collections.ts
@@ -1,0 +1,18 @@
+import type { Parent } from "../interfaces"
+
+/**
+ * Creates a flat set of all items by recursively iterating through all child items.
+ * @param items The original set of items to iterate through
+ * @returns All items in the original set, and recursively, their children
+ */
+export function getAllNestedItems<TParent extends Parent<TParent>>(items: ReadonlySet<TParent>): Set<TParent> {
+    const allItems = new Set<TParent>()
+    items?.forEach(x => addRecursively(x, allItems))
+    return allItems
+
+    function addRecursively(item: TParent, flatSet: Set<TParent>): void {
+        if (flatSet.has(item)) return
+        flatSet.add(item)
+        item.children?.forEach(x => addRecursively(x, flatSet))
+    }
+}


### PR DESCRIPTION
### Link Reroutes

Native reroutes are added by this PR, along with the supporting framework.  Much of this work can be extended to implement new canvas types.

#### Scope
This PR gets the core infrastructure for reroutes in and testable, without touching ~~a thousand~~ two thousand lines of code.

More ways create & manage reroutes are planned.

#### Enabling
- ⚠️ Reroutes are off by default
- Enable per-canvas by setting
```typescript
canvas.reroutesEnabled = true
```

#### Alt drag from a link to create a reroute

https://github.com/user-attachments/assets/78403e3e-a79f-474f-bb70-cb5097d59664

#### Shift drag from a reroute to create another link

https://github.com/user-attachments/assets/97520b7d-8756-4aa4-9e2e-e6c939eaa6a4

### Link centre markers
- No marker
- Default circles
- New directional Arrow
![image](https://github.com/user-attachments/assets/63d7137c-8f0e-45fe-931e-33695beb819f)

### Bug fixes
- Fixes centre link markers: now always centred for all link types (fixes dots rendered off to the side of straight vertical links, etc)
- Fixes crash if input & output are null when connecting links