### PR TITLE
Add CanvasPointer API

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,6 @@ Try it in the [demo site](https://tamats.com/projects/litegraph/editor).
 - Customizable theme (colors, shapes, background)
 - Callbacks to personalize every action/drawing/event of nodes
 - Subgraphs (nodes that contain graphs themselves)
-- Live mode system (hides the graph but calls nodes to render whatever they want, useful to create UIs)
 - Graphs can be executed in NodeJS
 - Highly customizable nodes (color, shape, slots vertical or horizontal, widgets, custom rendering)
 - Easy to integrate in any JS application (one single file, no dependencies)

--- a/src/CanvasPointer.ts
+++ b/src/CanvasPointer.ts
@@ -1,0 +1,215 @@
+import type { CanvasPointerEvent } from "./types/events"
+import type { LGraphCanvas } from "./LGraphCanvas"
+import { dist2 } from "./measure"
+
+/**
+ * Allows click and drag actions to be declared ahead of time during a pointerdown event.
+ *
+ * Depending on whether the user clicks or drags the pointer, only the appropriate callbacks are called:
+ * {@link onClick}, {@link onDragStart}, {@link onDrag}, {@link onDragEnd}, and {@link finally}.
+ *
+ * @seealso
+ * - {@link LGraphCanvas.processMouseDown}
+ * - {@link LGraphCanvas.processMouseMove}
+ * - {@link LGraphCanvas.processMouseUp}
+ */
+export class CanvasPointer {
+  /** Maximum time in milliseconds to ignore click drift */
+  static bufferTime = 300
+
+  /** Maximum offset from click location */
+  static get maxClickDrift() {
+    return this.#maxClickDrift
+  }
+  static set maxClickDrift(value) {
+    this.#maxClickDrift = value
+    this.#maxClickDrift2 = value * value
+  }
+  static #maxClickDrift = 6
+  /** {@link maxClickDrift} squared.  Used to calculate click drift without `sqrt`. */
+  static #maxClickDrift2 = this.#maxClickDrift ** 2
+
+  /** The element this PointerState should capture input against when dragging. */
+  element: Element
+  /** Pointer ID used by drag capture. */
+  pointerId: number
+
+  /** Set to true when if the pointer moves far enough after a down event, before the corresponding up event is fired. */
+  dragStarted: boolean = false
+
+  /** Used downstream for touch event support. */
+  isDouble: boolean = false
+  /** Used downstream for touch event support. */
+  isDown: boolean = false
+
+  /**
+   * If `true`, {@link eDown}, {@link eMove}, and {@link eUp} will be set to
+   * `null` when {@link reset} is called.
+   *
+   * Default: `true`
+   */
+  clearEventsOnReset: boolean = true
+
+  /** The last pointerdown event for the primary button */
+  eDown: CanvasPointerEvent | null = null
+  /** The last pointermove event for the primary button */
+  eMove: CanvasPointerEvent | null = null
+  /** The last pointerup event for the primary button */
+  eUp: CanvasPointerEvent | null = null
+
+  /** Offset from original mouse down event. */
+  offset: Float32Array = new Float32Array(2)
+
+  /** If set, as soon as the mouse moves outside the click drift threshold, this action is run once. */
+  onDragStart?(): unknown
+
+  /**
+   * Called on pointermove whilst dragging.
+   * @param eMove The pointermove event of this ongoing drag action
+   */
+  onDrag?(eMove: CanvasPointerEvent): unknown
+
+  /**
+   * Called on pointerup after dragging (i.e. not called if clicked).
+   * @param upEvent The pointerup or pointermove event that triggered this callback
+   */
+  onDragEnd?(upEvent: CanvasPointerEvent): unknown
+
+  /**
+   * Callback that will be run once, the next time a pointerup event appears to be a normal click.
+   * @param upEvent The pointerup or pointermove event that triggered this callback
+   */
+  onClick?(upEvent: CanvasPointerEvent): unknown
+
+  /**
+   * Run-once callback, called at the end of any click or drag, whether or not it was successful in any way.
+   *
+   * The setter of this callback will call the existing value before replacing it.
+   * Another way: setting this value twice will execute the first value.
+   *
+   * Always assume that once set, the finally() callback will be called exactly once.
+   */
+  get finally() {
+    return this.#finally
+  }
+  set finally(value) {
+    try {
+      this.#finally?.()
+    } finally {
+      this.#finally = value
+    }
+  }
+  #finally?: () => unknown
+
+  constructor(element: Element) {
+    this.element = element
+  }
+
+  down(e: CanvasPointerEvent): void {
+    if (e.button !== 0) return
+
+    this.reset()
+    this.eDown = e
+    this.pointerId = e.pointerId
+    this.element.setPointerCapture(e.pointerId)
+  }
+
+  move(e: CanvasPointerEvent): void {
+    const { eDown } = this
+    if (!eDown) return
+
+    // No buttons down, but eDown exists - clean up & leave
+    if (!e.buttons) {
+      this.reset()
+      return
+    }
+
+    // Primary button released - treat as pointerup.
+    if (!(e.buttons & 1)) {
+      this.#completeClick(e)
+      this.reset()
+      return
+    }
+    this.eMove = e
+    this.onDrag?.(e)
+
+    // Dragging, but no callback to run
+    if (this.dragStarted) return
+
+    const longerThanBufferTime = e.timeStamp - eDown.timeStamp > CanvasPointer.bufferTime
+    if (longerThanBufferTime || this.#isPastThreshold(e)) {
+      this.#setDragStarted()
+    }
+  }
+
+  up(e: CanvasPointerEvent): boolean {
+    if (e.button !== 0) return false
+
+    this.#completeClick(e)
+    const { dragStarted } = this
+    this.reset()
+    return !dragStarted
+  }
+
+  #completeClick(e: CanvasPointerEvent): void {
+    if (!this.eDown) return
+
+    this.eUp = e
+
+    if (this.dragStarted) {
+      // A move event already started drag
+      this.onDragEnd?.(e)
+    } else if (this.#isPastThreshold(e)) {
+      // Teleport without a move event (e.g. tab out, move, tab back)
+      this.#setDragStarted()
+      this.onDragEnd?.(e)
+    } else {
+      // Normal click event
+      this.onClick?.(e)
+    }
+  }
+
+  /**
+   * Checks whether the pointer is currently past the max click drift threshold.
+   * @param e The most recent pointer event
+   * @returns `true` if the most recent pointer event is past the the click drift threshold, otherwise `false`
+   */
+  #isPastThreshold(e: PointerEvent): boolean {
+    const { eDown, offset } = this
+    offset[0] = e.clientX - eDown.clientX
+    offset[1] = e.clientY - eDown.clientY
+
+    const drift = dist2(eDown.clientX, eDown.clientY, e.clientX, e.clientY)
+    return drift > CanvasPointer.#maxClickDrift2
+  }
+
+  #setDragStarted(): void {
+    this.dragStarted = true
+    this.onDragStart?.()
+    delete this.onDragStart
+  }
+
+  reset(): void {
+    // The setter executes the callback before clearing it
+    this.finally = undefined
+    delete this.onClick
+    delete this.onDragStart
+    delete this.onDrag
+    delete this.onDragEnd
+
+    this.isDown = false
+    this.isDouble = false
+    this.dragStarted = false
+    this.offset.fill(0)
+
+    if (this.clearEventsOnReset) {
+      this.eDown = null
+      this.eMove = null
+      this.eUp = null
+    }
+
+    const { element, pointerId } = this
+    if (element.hasPointerCapture(pointerId))
+      element.releasePointerCapture(pointerId)
+  }
+}

--- a/src/CanvasPointer.ts
+++ b/src/CanvasPointer.ts
@@ -122,8 +122,6 @@ export class CanvasPointer {
    * @param e The `pointerdown` event
    */
   down(e: CanvasPointerEvent): void {
-    if (e.button !== 0) return
-
     this.reset()
     this.eDown = e
     this.pointerId = e.pointerId
@@ -145,7 +143,7 @@ export class CanvasPointer {
     }
 
     // Primary button released - treat as pointerup.
-    if (!(e.buttons & 1)) {
+    if (!(e.buttons & eDown.buttons)) {
       this.#completeClick(e)
       this.reset()
       return
@@ -167,7 +165,7 @@ export class CanvasPointer {
    * @param e The `pointerup` event
    */
   up(e: CanvasPointerEvent): boolean {
-    if (e.button !== 0) return false
+    if (e.button !== this.eDown?.button) return false
 
     this.#completeClick(e)
     const { dragStarted } = this

--- a/src/CanvasPointer.ts
+++ b/src/CanvasPointer.ts
@@ -20,7 +20,7 @@ import { dist2 } from "./measure"
  */
 export class CanvasPointer {
   /** Maximum time in milliseconds to ignore click drift */
-  static bufferTime = 300
+  static bufferTime = 150
 
   /** Maximum gap between pointerup and pointerdown events to be considered as a double click */
   static doubleClickTime = 300

--- a/src/CanvasPointer.ts
+++ b/src/CanvasPointer.ts
@@ -6,12 +6,12 @@ import { dist2 } from "./measure"
  * Allows click and drag actions to be declared ahead of time during a pointerdown event.
  *
  * Depending on whether the user clicks or drags the pointer, only the appropriate callbacks are called:
- * * {@link onClick}
- * * {@link onDoubleClick}
- * * {@link onDragStart}
- * * {@link onDrag}
- * * {@link onDragEnd}
- * * {@link finally}
+ * - {@link onClick}
+ * - {@link onDoubleClick}
+ * - {@link onDragStart}
+ * - {@link onDrag}
+ * - {@link onDragEnd}
+ * - {@link finally}
  *
  * @seealso
  * - {@link LGraphCanvas.processMouseDown}
@@ -117,6 +117,10 @@ export class CanvasPointer {
     this.element = element
   }
 
+  /**
+   * Callback for `pointerdown` events.  To be used as the event handler (or called by it).
+   * @param e The `pointerdown` event
+   */
   down(e: CanvasPointerEvent): void {
     if (e.button !== 0) return
 
@@ -126,6 +130,10 @@ export class CanvasPointer {
     this.element.setPointerCapture(e.pointerId)
   }
 
+  /**
+   * Callback for `pointermove` events.  To be used as the event handler (or called by it).
+   * @param e The `pointermove` event
+   */
   move(e: CanvasPointerEvent): void {
     const { eDown } = this
     if (!eDown) return
@@ -154,6 +162,10 @@ export class CanvasPointer {
     }
   }
 
+  /**
+   * Callback for `pointerup` events.  To be used as the event handler (or called by it).
+   * @param e The `pointerup` event
+   */
   up(e: CanvasPointerEvent): boolean {
     if (e.button !== 0) return false
 
@@ -219,6 +231,12 @@ export class CanvasPointer {
     delete this.onDragStart
   }
 
+  /**
+   * Resets the state of this {@link CanvasPointer} instance.
+   *
+   * The {@link finally} callback is first executed, then all callbacks and intra-click
+   * state is cleared.
+   */
   reset(): void {
     // The setter executes the callback before clearing it
     this.finally = undefined

--- a/src/CanvasPointer.ts
+++ b/src/CanvasPointer.ts
@@ -46,7 +46,7 @@ export class CanvasPointer {
   dragStarted: boolean = false
 
   /** The {@link eUp} from the last successful click */
-  eLastUp?: CanvasPointerEvent
+  eLastDown?: CanvasPointerEvent
 
   /** Used downstream for touch event support. */
   isDouble: boolean = false
@@ -191,11 +191,11 @@ export class CanvasPointer {
     } else if (this.onDoubleClick && this.#isDoubleClick()) {
       // Double-click event
       this.onDoubleClick(e)
-      this.eLastUp = undefined
+      this.eLastDown = undefined
     } else {
       // Normal click event
       this.onClick?.(e)
-      this.eLastUp = e
+      this.eLastDown = eDown
     }
   }
 
@@ -221,15 +221,15 @@ export class CanvasPointer {
    * @returns `true` if the latest pointer event is past the the click drift threshold
    */
   #isDoubleClick(): boolean {
-    const { eUp, eLastUp } = this
-    if (!eUp || !eLastUp) return false
+    const { eDown, eLastDown } = this
+    if (!eDown || !eLastDown) return false
 
     // Use thrice the drift distance for double-click gap
     const tolerance2 = (3 * CanvasPointer.#maxClickDrift) ** 2
-    const diff = eUp.timeStamp - eLastUp.timeStamp
+    const diff = eDown.timeStamp - eLastDown.timeStamp
     return diff > 0 &&
       diff < CanvasPointer.doubleClickTime &&
-      this.#hasSamePosition(eUp, eLastUp, tolerance2)
+      this.#hasSamePosition(eDown, eLastDown, tolerance2)
   }
 
   #setDragStarted(): void {

--- a/src/CanvasPointer.ts
+++ b/src/CanvasPointer.ts
@@ -203,11 +203,16 @@ export class CanvasPointer {
    * Checks if two events occurred near each other - not further apart than the maximum click drift.
    * @param a The first event to compare
    * @param b The second event to compare
+   * @param tolerance2 The maximum distance (squared) before the positions are considered different
    * @returns `true` if the two events were no more than {@link maxClickDrift} apart, otherwise `false`
    */
-  #hasSamePosition(a: PointerEvent, b: PointerEvent): boolean {
+  #hasSamePosition(
+    a: PointerEvent,
+    b: PointerEvent,
+    tolerance2 = CanvasPointer.#maxClickDrift2,
+  ): boolean {
     const drift = dist2(a.clientX, a.clientY, b.clientX, b.clientY)
-    return drift <= CanvasPointer.#maxClickDrift2
+    return drift <= tolerance2
   }
 
   /**
@@ -219,10 +224,12 @@ export class CanvasPointer {
     const { eUp, eLastUp } = this
     if (!eUp || !eLastUp) return false
 
+    // Use thrice the drift distance for double-click gap
+    const tolerance2 = (3 * CanvasPointer.#maxClickDrift) ** 2
     const diff = eUp.timeStamp - eLastUp.timeStamp
     return diff > 0 &&
       diff < CanvasPointer.doubleClickTime &&
-      this.#hasSamePosition(eUp, eLastUp)
+      this.#hasSamePosition(eUp, eLastUp, tolerance2)
   }
 
   #setDragStarted(): void {

--- a/src/DragAndScale.ts
+++ b/src/DragAndScale.ts
@@ -1,6 +1,7 @@
 import type { Point, Rect, Rect32 } from "./interfaces"
 import type { CanvasMouseEvent } from "./types/events"
 import { LiteGraph } from "./litegraph"
+import { isInRect } from "./measure"
 
 export class DragAndScale {
     /** Maximum scale (zoom in) */
@@ -98,7 +99,7 @@ export class DragAndScale {
         e.canvasy = y
         e.dragging = this.dragging
 
-        const is_inside = !this.viewport || (this.viewport && x >= this.viewport[0] && x < (this.viewport[0] + this.viewport[2]) && y >= this.viewport[1] && y < (this.viewport[1] + this.viewport[3]))
+        const is_inside = !this.viewport || isInRect(x, y, this.viewport)
 
         let ignore = false
         if (this.onmouse) {

--- a/src/LGraph.ts
+++ b/src/LGraph.ts
@@ -826,9 +826,6 @@ export class LGraph implements LinkNetwork, Serialisable<SerialisableGraph> {
                 const canvas = this.list_of_graphcanvas[i]
                 if (canvas.selected_nodes[node.id])
                     delete canvas.selected_nodes[node.id]
-
-                if (canvas.node_dragged == node)
-                    canvas.node_dragged = null
             }
         }
 

--- a/src/LGraph.ts
+++ b/src/LGraph.ts
@@ -1223,18 +1223,6 @@ export class LGraph implements LinkNetwork, Serialisable<SerialisableGraph> {
         this.canvasAction(c => c.onConnectionChange?.())
     }
     /**
-     * returns if the graph is in live mode
-     */
-    isLive(): boolean {
-        if (!this.list_of_graphcanvas) return false
-
-        for (let i = 0; i < this.list_of_graphcanvas.length; ++i) {
-            const c = this.list_of_graphcanvas[i]
-            if (c.live_mode) return true
-        }
-        return false
-    }
-    /**
      * clears the triggered slot animation in all links (stop visual animation)
      */
     clearTriggeredSlots(): void {

--- a/src/LGraph.ts
+++ b/src/LGraph.ts
@@ -1319,7 +1319,7 @@ export class LGraph implements LinkNetwork, Serialisable<SerialisableGraph> {
 
         const node = this.getNodeById(link.target_id)
         node?.disconnectInput(link.target_slot)
-        
+
         link.disconnect(this)
     }
 

--- a/src/LGraphCanvas.ts
+++ b/src/LGraphCanvas.ts
@@ -8,7 +8,7 @@ import type { LGraph } from "./LGraph"
 import type { ContextMenu } from "./ContextMenu"
 import { EaseFunction, LGraphEventMode, LinkDirection, LinkMarkerShape, LinkRenderType, RenderShape, TitleMode } from "./types/globalEnums"
 import { LGraphGroup } from "./LGraphGroup"
-import { isInsideRectangle, distance, overlapBounding, isPointInRectangle, findPointOnCurve, containsRect, createBounds } from "./measure"
+import { isInsideRectangle, distance, overlapBounding, isPointInRect, findPointOnCurve, containsRect, createBounds } from "./measure"
 import { drawSlot, LabelPosition } from "./draw"
 import { DragAndScale } from "./DragAndScale"
 import { LinkReleaseContextExtended, LiteGraph, clamp } from "./litegraph"
@@ -2678,7 +2678,7 @@ export class LGraphCanvas {
         this.adjustMouseEvent(e)
 
         const pos: Point = [e.clientX, e.clientY]
-        if (this.viewport && !isPointInRectangle(pos, this.viewport)) return
+        if (this.viewport && !isPointInRect(pos, this.viewport)) return
 
         let scale = this.ds.scale
 
@@ -3190,7 +3190,7 @@ export class LGraphCanvas {
 
         // Select reroutes - the centre point is inside the select area
         for (const reroute of graph.reroutes.values()) {
-            if (!isPointInRectangle(reroute.pos, dragRect)) continue
+            if (!isPointInRect(reroute.pos, dragRect)) continue
 
             selectedItems.add(reroute)
             reroute.selected = true

--- a/src/LGraphCanvas.ts
+++ b/src/LGraphCanvas.ts
@@ -2377,6 +2377,8 @@ export class LGraphCanvas {
      * @param node The node to process a click event for
      */
     #processMiddleButton(e: CanvasPointerEvent, node: LGraphNode) {
+        const { pointer } = this
+
         if (LiteGraph.middle_click_slot_add_default_node &&
             node &&
             this.allow_interaction &&
@@ -2426,7 +2428,7 @@ export class LGraphCanvas {
                     e.canvasY - 80
                 ]
                 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-                const nodeCreated = this.createDefaultNodeForSlot({
+                pointer.onClick = () => this.createDefaultNodeForSlot({
                     nodeFrom: !mClikSlot_isOut ? null : node,
                     slotFrom: !mClikSlot_isOut ? null : mClikSlot_index,
                     nodeTo: !mClikSlot_isOut ? node : null,
@@ -2436,13 +2438,13 @@ export class LGraphCanvas {
                     posAdd: [!mClikSlot_isOut ? -30 : 30, -alphaPosY * 130],
                     posSizeFix: [!mClikSlot_isOut ? -1 : 0, 0]
                 })
-                return
             }
         }
 
         // Drag canvas using middle mouse button
         if (this.allow_dragcanvas) {
-            this.dragging_canvas = true
+            pointer.onDragStart = () => this.dragging_canvas = true
+            pointer.finally = () => this.dragging_canvas = false
         }
     }
 

--- a/src/LGraphCanvas.ts
+++ b/src/LGraphCanvas.ts
@@ -2748,7 +2748,7 @@ export class LGraphCanvas {
             const y = e.canvasY
             const node = graph.getNodeOnPos(x, y, this.visible_nodes)
 
-            if (this.connecting_links?.length && !isClick) {
+            if (this.connecting_links?.length) {
                 //node below mouse
                 const firstLink = this.connecting_links[0]
                 if (node) {
@@ -2824,10 +2824,6 @@ export class LGraphCanvas {
                     }
                 }
             } else {
-                if (isClick && !node && !graph.getGroupTitlebarOnPos(x, y) && (!this.reroutesEnabled || !graph.getRerouteOnPos(x, y))) {
-                    this.processSelect(null, e)
-                }
-
                 this.dirty_canvas = true
 
                 // @ts-expect-error Unused param

--- a/src/LGraphCanvas.ts
+++ b/src/LGraphCanvas.ts
@@ -2119,9 +2119,6 @@ export class LGraphCanvas {
                             if (LiteGraph.click_do_break_link_to || (LiteGraph.ctrl_alt_click_do_break_link && ctrlOrMeta && e.altKey && !e.shiftKey)) {
                                 node.disconnectInput(i)
                             } else if (e.shiftKey || this.allow_reconnect_links) {
-                                if (this.allow_reconnect_links && !LiteGraph.click_do_break_link_to)
-                                    node.disconnectInput(i)
-
                                 const connecting: ConnectingLink = {
                                     node: linked_node,
                                     slot,
@@ -2129,7 +2126,12 @@ export class LGraphCanvas {
                                     pos: linked_node.getConnectionPos(false, slot),
                                 }
                                 this.connecting_links = [connecting]
-                                pointer.onDragStart = () => connecting.output = linked_node.outputs[slot]
+
+                                pointer.onDragStart = () => {
+                                    if (this.allow_reconnect_links && !LiteGraph.click_do_break_link_to)
+                                        node.disconnectInput(i)
+                                    connecting.output = linked_node.outputs[slot]
+                                }
 
                                 this.dirty_bgcanvas = true
                             }

--- a/src/LGraphCanvas.ts
+++ b/src/LGraphCanvas.ts
@@ -1910,19 +1910,21 @@ export class LGraphCanvas {
 
     #processPrimaryButton(ctrlOrMeta: boolean, e: CanvasPointerEvent, node: LGraphNode, is_double_click: boolean) {
         const { pointer, graph } = this
+        const x = e.canvasX
+        const y = e.canvasY
         if (ctrlOrMeta && !e.altKey) {
             const dragRect = new Float32Array(4)
-            dragRect[0] = e.canvasX
-            dragRect[1] = e.canvasY
+            dragRect[0] = x
+            dragRect[1] = y
             dragRect[2] = 1
             dragRect[3] = 1
 
-            pointer.onClick = e => {
+            pointer.onClick = eUp => {
                 // Click, not drag
                 const clickedItem = node
-                    ?? (this.reroutesEnabled ? graph.getRerouteOnPos(e.canvasX, e.canvasY) : null)
-                    ?? graph.getGroupTitlebarOnPos(e.canvasX, e.canvasY)
-                this.processSelect(clickedItem, e)
+                    ?? (this.reroutesEnabled ? graph.getRerouteOnPos(eUp.canvasX, eUp.canvasY) : null)
+                    ?? graph.getGroupTitlebarOnPos(eUp.canvasX, eUp.canvasY)
+                this.processSelect(clickedItem, eUp)
             }
             pointer.onDragStart = () => this.dragging_rectangle = dragRect
             pointer.onDragEnd = upEvent => this.#handleMultiSelect(upEvent, dragRect)
@@ -1968,7 +1970,7 @@ export class LGraphCanvas {
             // Not collapsed
             if (!node.flags.collapsed && !this.live_mode) {
                 // Resize node
-                if (node.resizable !== false && node.inResizeCorner(e.canvasX, e.canvasY)) {
+                if (node.resizable !== false && node.inResizeCorner(x, y)) {
                     pointer.onDragStart = () => {
                         graph.beforeChange()
                         this.resizing_node = node
@@ -1987,8 +1989,8 @@ export class LGraphCanvas {
                         const output = node.outputs[i]
                         const link_pos = node.getConnectionPos(false, i)
                         if (isInsideRectangle(
-                            e.canvasX,
-                            e.canvasY,
+                            x,
+                            y,
                             link_pos[0] - 15,
                             link_pos[1] - 10,
                             30,
@@ -2055,8 +2057,8 @@ export class LGraphCanvas {
                         const input = node.inputs[i]
                         const link_pos = node.getConnectionPos(true, i)
                         if (isInsideRectangle(
-                            e.canvasX,
-                            e.canvasY,
+                            x,
+                            y,
                             link_pos[0] - 15,
                             link_pos[1] - 10,
                             30,
@@ -2114,7 +2116,7 @@ export class LGraphCanvas {
 
             // Click was inside the node, but not on input/output, or the resize corner
             let block_drag_node = node.pinned
-            const pos: Point = [e.canvasX - node.pos[0], e.canvasY - node.pos[1]]
+            const pos: Point = [x - node.pos[0], y - node.pos[1]]
 
             // Widget
             const widget = this.processNodeWidgets(node, this.graph_mouse, e)
@@ -2167,7 +2169,7 @@ export class LGraphCanvas {
             //clicked outside of nodes
             // Reroutes
             if (this.reroutesEnabled) {
-                const reroute = graph.getRerouteOnPos(e.canvasX, e.canvasY)
+                const reroute = graph.getRerouteOnPos(x, y)
                 if (reroute) {
                     if (e.shiftKey) {
                         // Connect new link from reroute
@@ -2212,7 +2214,7 @@ export class LGraphCanvas {
                 if (!centre) continue
 
                 // FIXME: Clean up
-                if (isInsideRectangle(e.canvasX, e.canvasY, centre[0] - 4, centre[1] - 4, 8, 8)) {
+                if (isInsideRectangle(x, y, centre[0] - 4, centre[1] - 4, 8, 8)) {
                     this.showLinkMenu(linkSegment, e)
                     //clear tooltip
                     this.over_link_center = null
@@ -2220,7 +2222,7 @@ export class LGraphCanvas {
                 }
 
                 // If we shift click on a link then start a link from that input
-                if ((e.shiftKey || e.altKey) && linkSegment.path && this.ctx.isPointInStroke(linkSegment.path, e.canvasX, e.canvasY)) {
+                if ((e.shiftKey || e.altKey) && linkSegment.path && this.ctx.isPointInStroke(linkSegment.path, x, y)) {
                     if (e.shiftKey && !e.altKey) {
                         const slot = linkSegment.origin_slot
                         const originNode = graph._nodes_by_id[linkSegment.origin_id]
@@ -2238,7 +2240,7 @@ export class LGraphCanvas {
 
                         return
                     } else if (this.reroutesEnabled && e.altKey && !e.shiftKey) {
-                        const newReroute = graph.createReroute([e.canvasX, e.canvasY], linkSegment)
+                        const newReroute = graph.createReroute([x, y], linkSegment)
                         pointer.onDragStart = () => {
                             this.processSelect(newReroute, e)
                             this.isDragging = true
@@ -2253,16 +2255,16 @@ export class LGraphCanvas {
             this.ctx.lineWidth = lineWidth
 
             // Groups
-            const group = graph.getGroupOnPos(e.canvasX, e.canvasY)
+            const group = graph.getGroupOnPos(x, y)
             this.selected_group = group
             if (group) {
-                if (group.isInResize(e.canvasX, e.canvasY)) {
+                if (group.isInResize(x, y)) {
                     pointer.onDragStart = () => this.resizingGroup = group
                     pointer.finally = () => this.resizingGroup = null
                 } else {
                     const f = group.font_size || LiteGraph.DEFAULT_GROUP_FONT_SIZE
                     const headerHeight = f * 1.4
-                    if (isInsideRectangle(e.canvasX, e.canvasY, group.pos[0], group.pos[1], group.size[0], headerHeight)) {
+                    if (isInsideRectangle(x, y, group.pos[0], group.pos[1], group.size[0], headerHeight)) {
                         pointer.onDragStart = () => {
                             group.recomputeInsideNodes()
                             this.processSelect(group, e, true)

--- a/src/LGraphCanvas.ts
+++ b/src/LGraphCanvas.ts
@@ -354,6 +354,7 @@ export class LGraphCanvas {
     resizing_node?: LGraphNode
     /** @deprecated See {@link LGraphCanvas.resizingGroup} */
     selected_group_resizing?: boolean
+    /** @deprecated See {@link pointer}.{@link CanvasPointer.dragStarted dragStarted} */
     last_mouse_dragging: boolean
     onMouseDown: (arg0: CanvasMouseEvent) => void
     _highlight_pos?: Point
@@ -1863,6 +1864,8 @@ export class LGraphCanvas {
         const { pointer, graph } = this
         const x = e.canvasX
         const y = e.canvasY
+
+        // Multi-select drag rectangle
         if (ctrlOrMeta && !e.altKey) {
             const dragRect = new Float32Array(4)
             dragRect[0] = x
@@ -2094,7 +2097,6 @@ export class LGraphCanvas {
 
             this.dirty_canvas = true
         } else {
-            //clicked outside of nodes
             // Reroutes
             if (this.reroutesEnabled) {
                 const reroute = graph.getRerouteOnPos(x, y)
@@ -2131,8 +2133,7 @@ export class LGraphCanvas {
                 }
             }
 
-            // Links, Groups, Canvas BG
-            //search for link connector
+            // Links - paths of links & reroutes
             // Set the width of the line for isPointInStroke checks
             const { lineWidth } = this.ctx
             this.ctx.lineWidth = this.connections_width + 7

--- a/src/LGraphCanvas.ts
+++ b/src/LGraphCanvas.ts
@@ -171,19 +171,12 @@ export class LGraphCanvas {
         readOnly: false,
     }
 
-    /** @inheritdoc {@link LGraphCanvasState.draggingCanvas} */
-    get dragging_canvas(): boolean {
-        return this.state.draggingCanvas
-    }
-    set dragging_canvas(value: boolean) {
-        this.state.draggingCanvas = value
-    }
-
     // Whether the canvas was previously being dragged prior to pressing space key.
     // null if space key is not pressed.
     private _previously_dragging_canvas: boolean | null = null
 
-    /** @inheritdoc {@link LGraphCanvasState.readOnly} */
+    //#region Legacy accessors
+    /** @deprecated @inheritdoc {@link LGraphCanvasState.readOnly} */
     get read_only(): boolean {
         return this.state.readOnly
     }
@@ -197,6 +190,16 @@ export class LGraphCanvas {
     set isDragging(value: boolean) {
         this.state.draggingItems = value
     }
+
+    /** @deprecated @inheritdoc {@link LGraphCanvasState.draggingCanvas} */
+    get dragging_canvas(): boolean {
+        return this.state.draggingCanvas
+    }
+    set dragging_canvas(value: boolean) {
+        this.state.draggingCanvas = value
+    }
+    //#endregion Legacy accessors
+
 
     get title_text_font(): string {
         return `${LiteGraph.NODE_TEXT_SIZE}px Arial`

--- a/src/LGraphCanvas.ts
+++ b/src/LGraphCanvas.ts
@@ -8,7 +8,7 @@ import type { LGraph } from "./LGraph"
 import type { ContextMenu } from "./ContextMenu"
 import { EaseFunction, LGraphEventMode, LinkDirection, LinkMarkerShape, LinkRenderType, RenderShape, TitleMode } from "./types/globalEnums"
 import { LGraphGroup } from "./LGraphGroup"
-import { isInsideRectangle, distance, overlapBounding, isPointInRect, findPointOnCurve, containsRect, createBounds } from "./measure"
+import { distance, overlapBounding, isPointInRect, findPointOnCurve, containsRect, isInRectangle, createBounds } from "./measure"
 import { drawSlot, LabelPosition } from "./draw"
 import { DragAndScale } from "./DragAndScale"
 import { LinkReleaseContextExtended, LiteGraph, clamp } from "./litegraph"
@@ -1918,7 +1918,7 @@ export class LGraphCanvas {
                         pointer.finally = () => this.isDragging = false
                         return
                     }
-                } else if (isInsideRectangle(x, y, centre[0] - 4, centre[1] - 4, 8, 8)) {
+                } else if (isInRectangle(x, y, centre[0] - 4, centre[1] - 4, 8, 8)) {
                     pointer.onClick = () => this.showLinkMenu(linkSegment, e)
                     pointer.onDragStart = () => this.dragging_canvas = true
                     pointer.finally = () => this.dragging_canvas = false
@@ -1942,7 +1942,7 @@ export class LGraphCanvas {
                 } else {
                     const f = group.font_size || LiteGraph.DEFAULT_GROUP_FONT_SIZE
                     const headerHeight = f * 1.4
-                    if (isInsideRectangle(x, y, group.pos[0], group.pos[1], group.size[0], headerHeight)) {
+                    if (isInRectangle(x, y, group.pos[0], group.pos[1], group.size[0], headerHeight)) {
                         pointer.onDragStart = () => {
                             group.recomputeInsideNodes()
                             this.processSelect(group, e, true)
@@ -2029,7 +2029,7 @@ export class LGraphCanvas {
                 for (let i = 0, l = node.outputs.length; i < l; ++i) {
                     const output = node.outputs[i]
                     const link_pos = node.getConnectionPos(false, i)
-                    if (isInsideRectangle(
+                    if (isInRectangle(
                         x,
                         y,
                         link_pos[0] - 15,
@@ -2097,7 +2097,7 @@ export class LGraphCanvas {
                 for (let i = 0, l = node.inputs.length; i < l; ++i) {
                     const input = node.inputs[i]
                     const link_pos = node.getConnectionPos(true, i)
-                    if (isInsideRectangle(
+                    if (isInRectangle(
                         x,
                         y,
                         link_pos[0] - 15,
@@ -2395,7 +2395,7 @@ export class LGraphCanvas {
                 for (let i = 0, l = node.outputs.length; i < l; ++i) {
                     const output = node.outputs[i]
                     const link_pos = node.getConnectionPos(false, i)
-                    if (isInsideRectangle(e.canvasX, e.canvasY, link_pos[0] - 15, link_pos[1] - 10, 30, 20)) {
+                    if (isInRectangle(e.canvasX, e.canvasY, link_pos[0] - 15, link_pos[1] - 10, 30, 20)) {
                         mClikSlot = output
                         mClikSlot_index = i
                         mClikSlot_isOut = true
@@ -2409,7 +2409,7 @@ export class LGraphCanvas {
                 for (let i = 0, l = node.inputs.length; i < l; ++i) {
                     const input = node.inputs[i]
                     const link_pos = node.getConnectionPos(true, i)
-                    if (isInsideRectangle(e.canvasX, e.canvasY, link_pos[0] - 15, link_pos[1] - 10, 30, 20)) {
+                    if (isInRectangle(e.canvasX, e.canvasY, link_pos[0] - 15, link_pos[1] - 10, 30, 20)) {
                         mClikSlot = input
                         mClikSlot_index = i
                         mClikSlot_isOut = false
@@ -2903,7 +2903,7 @@ export class LGraphCanvas {
                 const link_pos = node.getConnectionPos(true, i)
                 let is_inside = false
                 if (node.horizontal) {
-                    is_inside = isInsideRectangle(
+                    is_inside = isInRectangle(
                         canvasx,
                         canvasy,
                         link_pos[0] - 5,
@@ -2915,7 +2915,7 @@ export class LGraphCanvas {
                     // TODO: Find a cheap way to measure text, and do it on node label change instead of here
                     // Input icon width + text approximation
                     const width = 20 + (((input.label?.length ?? input.name?.length) || 3) * 7)
-                    is_inside = isInsideRectangle(
+                    is_inside = isInRectangle(
                         canvasx,
                         canvasy,
                         link_pos[0] - 10,
@@ -2944,7 +2944,7 @@ export class LGraphCanvas {
                 const link_pos = node.getConnectionPos(false, i)
                 let is_inside = false
                 if (node.horizontal) {
-                    is_inside = isInsideRectangle(
+                    is_inside = isInRectangle(
                         canvasx,
                         canvasy,
                         link_pos[0] - 5,
@@ -2953,7 +2953,7 @@ export class LGraphCanvas {
                         20
                     )
                 } else {
-                    is_inside = isInsideRectangle(
+                    is_inside = isInRectangle(
                         canvasx,
                         canvasy,
                         link_pos[0] - 10,
@@ -3990,7 +3990,7 @@ export class LGraphCanvas {
             const centre = linkSegment._pos
             if (!centre) continue
 
-            if (isInsideRectangle(e.canvasX, e.canvasY, centre[0] - 4, centre[1] - 4, 8, 8)) {
+            if (isInRectangle(e.canvasX, e.canvasY, centre[0] - 4, centre[1] - 4, 8, 8)) {
                 return linkSegment
             }
         }

--- a/src/LGraphCanvas.ts
+++ b/src/LGraphCanvas.ts
@@ -301,6 +301,7 @@ export class LGraphCanvas {
     /** @deprecated See {@link LGraphCanvas.selectedItems} */
     selected_group: LGraphGroup | null = null
     visible_nodes: LGraphNode[] = []
+    /** @deprecated Does not handle multi-node move, and can return the wrong node.  See {@link LGraphCanvas.selectedItems}. */
     node_dragged?: LGraphNode
     node_over?: LGraphNode
     node_capturing_input?: LGraphNode
@@ -371,7 +372,7 @@ export class LGraphCanvas {
     /** called after modifying the graph */
     onAfterChange?(graph: LGraph): void
     onClear?: () => void
-    /** called after moving a node */
+    /** called after moving a node @deprecated Does not handle multi-node move, and can return the wrong node. */
     onNodeMoved?: (node_dragged: LGraphNode) => void
     /** called if the selection changes */
     onSelectionChange?: (selected_nodes: Dictionary<LGraphNode>) => void
@@ -2557,6 +2558,18 @@ export class LGraphCanvas {
             //left button
             this.node_widget = null
             this.selected_group = null
+
+            if (this.isDragging && LiteGraph.always_round_positions) {
+                const selected = this.selectedItems
+                const allItems = getAllNestedItems(selected)
+
+                allItems.forEach(x => {
+                    x.pos[0] = Math.round(x.pos[0])
+                    x.pos[1] = Math.round(x.pos[1])
+                })
+                this.dirty_canvas = true
+                this.dirty_bgcanvas = true
+            }
             this.isDragging = false
 
             const node = this.graph.getNodeOnPos(

--- a/src/LGraphCanvas.ts
+++ b/src/LGraphCanvas.ts
@@ -208,7 +208,7 @@ export class LGraphCanvas {
 
     options: { skip_events?: any; viewport?: any; skip_render?: any; autoresize?: any }
     background_image: string
-    ds: DragAndScale
+    readonly ds: DragAndScale
     zoom_modify_alpha: boolean
     zoom_speed: number
     node_title_color: string
@@ -258,9 +258,9 @@ export class LGraphCanvas {
     linkMarkerShape: LinkMarkerShape = LinkMarkerShape.Circle
     links_render_mode: number
     /** mouse in canvas coordinates, where 0,0 is the top-left corner of the blue rectangle */
-    mouse: Point
+    readonly mouse: Point
     /** mouse in graph coordinates, where 0,0 is the top-left corner of the blue rectangle */
-    graph_mouse: Point
+    readonly graph_mouse: Point
     /** @deprecated LEGACY: REMOVE THIS, USE {@link graph_mouse} INSTEAD */
     canvas_mouse: Point
     /** to personalize the search box */
@@ -277,14 +277,17 @@ export class LGraphCanvas {
     current_node: LGraphNode | null
     /** used for widgets */
     node_widget?: [LGraphNode, IWidget] | null
+    /** The link to draw a tooltip for. */
     over_link_center: LinkSegment | null
     last_mouse_position: Point
+    /** The visible area of this canvas.  Tightly coupled with {@link ds}. */
     visible_area?: Rect32
     /** Contains all links and reroutes that were rendered.  Repopulated every render cycle. */
     renderedPaths: Set<LinkSegment> = new Set()
     visible_links?: LLink[]
     connecting_links: ConnectingLink[] | null
-    viewport?: Rect
+    /** The viewport of this canvas.  Tightly coupled with {@link ds}. */
+    readonly viewport?: Rect
     autoresize: boolean
     static active_canvas: LGraphCanvas
     static onMenuNodeOutputs?(entries: IOptionalSlotData<INodeOutputSlot>[]): IOptionalSlotData<INodeOutputSlot>[]
@@ -316,7 +319,7 @@ export class LGraphCanvas {
     dirty_area?: Rect
     /** @deprecated Unused */
     node_in_panel?: LGraphNode
-    last_mouse: Point = [0, 0]
+    last_mouse: ReadOnlyPoint = [0, 0]
     last_mouseclick: number = 0
     pointer_is_down: boolean = false
     pointer_is_double: boolean = false
@@ -1603,11 +1606,12 @@ export class LGraphCanvas {
     */
     }
     /**
-     * marks as dirty the canvas, this way it will be rendered again
+     * Ensures the canvas will be redrawn on the next frame by setting the dirty flag(s).
+     * Without parameters, this function does nothing.
+     * @todo Impl. `setDirty()` or similar as shorthand to redraw everything.
      *
-     * @class LGraphCanvas
-     * @param {bool} fgcanvas if the foreground canvas is dirty (the one containing the nodes)
-     * @param {bool} bgcanvas if the background canvas is dirty (the one containing the wires)
+     * @param fgcanvas If true, marks the foreground canvas as dirty (nodes and anything drawn on top of them).  Default: false
+     * @param bgcanvas If true, mark the background canvas as dirty (background, groups, links).  Default: false
      */
     setDirty(fgcanvas: boolean, bgcanvas?: boolean): void {
         if (fgcanvas) this.dirty_canvas = true
@@ -2310,7 +2314,7 @@ export class LGraphCanvas {
 
         LGraphCanvas.active_canvas = this
         this.adjustMouseEvent(e)
-        const mouse: Point = [e.clientX, e.clientY]
+        const mouse: ReadOnlyPoint = [e.clientX, e.clientY]
         this.mouse[0] = mouse[0]
         this.mouse[1] = mouse[1]
         const delta = [
@@ -3875,7 +3879,7 @@ export class LGraphCanvas {
     }
 
     /** Get the target snap / highlight point in graph space */
-    #getHighlightPosition(): Point {
+    #getHighlightPosition(): ReadOnlyPoint {
         return LiteGraph.snaps_for_comfy
             ? this._highlight_pos ?? this.graph_mouse
             : this.graph_mouse
@@ -3886,7 +3890,7 @@ export class LGraphCanvas {
      * Partial border over target node and a highlight over the slot itself.
      * @param ctx Canvas 2D context
      */
-    #renderSnapHighlight(ctx: CanvasRenderingContext2D, highlightPos: Point): void {
+    #renderSnapHighlight(ctx: CanvasRenderingContext2D, highlightPos: ReadOnlyPoint): void {
         if (!this._highlight_pos) return
 
         ctx.fillStyle = "#ffcc00"

--- a/src/LGraphCanvas.ts
+++ b/src/LGraphCanvas.ts
@@ -8,7 +8,7 @@ import type { LGraph } from "./LGraph"
 import type { ContextMenu } from "./ContextMenu"
 import { CanvasItem, EaseFunction, LGraphEventMode, LinkDirection, LinkMarkerShape, LinkRenderType, RenderShape, TitleMode } from "./types/globalEnums"
 import { LGraphGroup } from "./LGraphGroup"
-import { distance, overlapBounding, isPointInRect, findPointOnCurve, containsRect, isInRectangle, createBounds } from "./measure"
+import { distance, overlapBounding, isPointInRect, findPointOnCurve, containsRect, isInRectangle, createBounds, isInRect } from "./measure"
 import { drawSlot, LabelPosition } from "./draw"
 import { DragAndScale } from "./DragAndScale"
 import { LinkReleaseContextExtended, LiteGraph, clamp } from "./litegraph"
@@ -1737,7 +1737,7 @@ export class LGraphCanvas {
         const x = e.clientX
         const y = e.clientY
         this.ds.viewport = this.viewport
-        const is_inside = !this.viewport || (this.viewport && x >= this.viewport[0] && x < (this.viewport[0] + this.viewport[2]) && y >= this.viewport[1] && y < (this.viewport[1] + this.viewport[3]))
+        const is_inside = !this.viewport || isInRect(x, y, this.viewport)
 
         if (!is_inside) return
 
@@ -3303,7 +3303,7 @@ export class LGraphCanvas {
         this.adjustMouseEvent(e)
         const x = e.clientX
         const y = e.clientY
-        const is_inside = !this.viewport || (this.viewport && x >= this.viewport[0] && x < (this.viewport[0] + this.viewport[2]) && y >= this.viewport[1] && y < (this.viewport[1] + this.viewport[3]))
+        const is_inside = !this.viewport || isInRect(x, y, this.viewport)
         if (!is_inside) return
 
         const pos = [e.canvasX, e.canvasY]

--- a/src/LGraphCanvas.ts
+++ b/src/LGraphCanvas.ts
@@ -1977,7 +1977,6 @@ export class LGraphCanvas {
             }
         }
 
-        console.log("pointer.onDragStart:", !!pointer.onDragStart)
         if (!pointer.onDragStart && !pointer.onClick && !pointer.onDrag && this.allow_dragcanvas) {
             pointer.onClick = () => this.processSelect(null, e)
             pointer.finally = () => this.dragging_canvas = false
@@ -2697,16 +2696,13 @@ export class LGraphCanvas {
 
         /** The mouseup event occurred near the mousedown event. */
         /** Normal-looking click event - mouseUp occurred near mouseDown, without dragging. */
-        // FIXME: Bang bang
-        const isClick = !!pointer.up(e)
-        console.debug("processMouseUp.pointerState", isClick)
+        const isClick = pointer.up(e)
         if (isClick === true) {
             pointer.isDown = false
             pointer.isDouble = false
-            // this.connecting_links = null
-            // this.dragging_canvas = false
-            // this.dragging_rectangle = null
-            // this.resizing_node = null
+            // Required until all link behaviour is added to Pointer API
+            this.connecting_links = null
+            this.dragging_canvas = false
 
             graph.change()
 

--- a/src/LGraphCanvas.ts
+++ b/src/LGraphCanvas.ts
@@ -1912,12 +1912,17 @@ export class LGraphCanvas {
 
                         return
                     } else if (this.reroutesEnabled && e.altKey && !e.shiftKey) {
+                        pointer.finally = () => {
+                            this.emitAfterChange()
+                            this.isDragging = false
+                        }
+
+                        this.emitBeforeChange()
                         const newReroute = graph.createReroute([x, y], linkSegment)
                         pointer.onDragStart = () => {
                             this.processSelect(newReroute, e)
                             this.isDragging = true
                         }
-                        pointer.finally = () => this.isDragging = false
                         return
                     }
                 } else if (isInRectangle(x, y, centre[0] - 4, centre[1] - 4, 8, 8)) {

--- a/src/LGraphCanvas.ts
+++ b/src/LGraphCanvas.ts
@@ -1919,7 +1919,10 @@ export class LGraphCanvas {
                         return
                     }
                 } else if (isInsideRectangle(x, y, centre[0] - 4, centre[1] - 4, 8, 8)) {
-                    this.showLinkMenu(linkSegment, e)
+                    pointer.onClick = () => this.showLinkMenu(linkSegment, e)
+                    pointer.onDragStart = () => this.dragging_canvas = true
+                    pointer.finally = () => this.dragging_canvas = false
+
                     //clear tooltip
                     this.over_link_center = null
                     return

--- a/src/LGraphCanvas.ts
+++ b/src/LGraphCanvas.ts
@@ -2156,14 +2156,6 @@ export class LGraphCanvas {
                 const centre = linkSegment._pos
                 if (!centre) continue
 
-                // FIXME: Clean up
-                if (isInsideRectangle(x, y, centre[0] - 4, centre[1] - 4, 8, 8)) {
-                    this.showLinkMenu(linkSegment, e)
-                    //clear tooltip
-                    this.over_link_center = null
-                    return
-                }
-
                 // If we shift click on a link then start a link from that input
                 if ((e.shiftKey || e.altKey) && linkSegment.path && this.ctx.isPointInStroke(linkSegment.path, x, y)) {
                     if (e.shiftKey && !e.altKey) {
@@ -2191,6 +2183,11 @@ export class LGraphCanvas {
                         pointer.finally = () => this.isDragging = false
                         return
                     }
+                } else if (isInsideRectangle(x, y, centre[0] - 4, centre[1] - 4, 8, 8)) {
+                    this.showLinkMenu(linkSegment, e)
+                    //clear tooltip
+                    this.over_link_center = null
+                    return
                 }
             }
 

--- a/src/LGraphCanvas.ts
+++ b/src/LGraphCanvas.ts
@@ -1781,7 +1781,7 @@ export class LGraphCanvas {
 
         if (!is_inside) return
 
-        let node = graph.getNodeOnPos(e.canvasX, e.canvasY, this.visible_nodes)
+        const node = graph.getNodeOnPos(e.canvasX, e.canvasY, this.visible_nodes)
 
         const now = LiteGraph.getTime()
         const is_double_click = (now - this.last_mouseclick < 300)
@@ -1791,8 +1791,8 @@ export class LGraphCanvas {
         this.graph_mouse[1] = e.canvasY
         this.last_click_position = [this.mouse[0], this.mouse[1]]
 
-        this.pointer.isDouble = this.pointer.isDown && e.isPrimary
-        this.pointer.isDown = true
+        pointer.isDouble = pointer.isDown && e.isPrimary
+        pointer.isDown = true
 
         this.canvas.focus()
 
@@ -1807,7 +1807,7 @@ export class LGraphCanvas {
         const ctrlAlt = ctrlOrMeta && !e.shiftKey && e.altKey
 
         //left button mouse / single finger
-        if (e.button === 0 && !this.pointer.isDouble) {
+        if (e.button === 0 && !pointer.isDouble) {
             this.#processPrimaryButton(ctrlOrMeta, e, node, is_double_click)
         } else if (e.button === 1) {
             // Middle button
@@ -1881,7 +1881,7 @@ export class LGraphCanvas {
             if (!skip_action && this.allow_dragcanvas) {
                 this.dragging_canvas = true
             }
-        } else if ((e.button === 2 || this.pointer.isDouble) && this.allow_interaction && !this.read_only) {
+        } else if ((e.button === 2 || pointer.isDouble) && this.allow_interaction && !this.read_only) {
             // Right / aux button
 
             // Sticky select - won't remove single nodes

--- a/src/LGraphGroup.ts
+++ b/src/LGraphGroup.ts
@@ -3,7 +3,7 @@ import type { LGraph } from "./LGraph"
 import type { ISerialisedGroup } from "./types/serialisation"
 import { LiteGraph } from "./litegraph"
 import { LGraphCanvas } from "./LGraphCanvas"
-import { containsCentre, containsRect, isInsideRectangle, isPointInRectangle, createBounds } from "./measure"
+import { containsCentre, containsRect, isInRectangle, isPointInRectangle, createBounds } from "./measure"
 import { LGraphNode } from "./LGraphNode"
 import { RenderShape, TitleMode } from "./types/globalEnums"
 
@@ -283,8 +283,8 @@ export class LGraphGroup implements Positionable, IPinnable {
     }
 
     isPointInTitlebar(x: number, y: number): boolean {
-        const b = this._bounding
-        return isInsideRectangle(x, y, b[0], b[1], b[2], this.titleHeight)
+        const b = this.boundingRect
+        return isInRectangle(x, y, b[0], b[1], b[2], this.titleHeight)
     }
 
     isInResize(x: number, y: number): boolean {

--- a/src/LGraphGroup.ts
+++ b/src/LGraphGroup.ts
@@ -1,4 +1,4 @@
-import type { IContextMenuValue, IPinnable, Point, Positionable, ReadOnlyRect, Size } from "./interfaces"
+import type { IContextMenuValue, IPinnable, Point, Positionable, Size } from "./interfaces"
 import type { LGraph } from "./LGraph"
 import type { ISerialisedGroup } from "./types/serialisation"
 import { LiteGraph } from "./litegraph"
@@ -63,7 +63,6 @@ export class LGraphGroup implements Positionable, IPinnable {
         this._size[0] = Math.max(LGraphGroup.minWidth, v[0])
         this._size[1] = Math.max(LGraphGroup.minHeight, v[1])
     }
-
 
     get boundingRect() {
         return this._bounding

--- a/src/LGraphGroup.ts
+++ b/src/LGraphGroup.ts
@@ -3,7 +3,7 @@ import type { LGraph } from "./LGraph"
 import type { ISerialisedGroup } from "./types/serialisation"
 import { LiteGraph } from "./litegraph"
 import { LGraphCanvas } from "./LGraphCanvas"
-import { containsCentre, containsRect, isInRectangle, isPointInRectangle, createBounds } from "./measure"
+import { containsCentre, containsRect, isInRectangle, isPointInRect, createBounds } from "./measure"
 import { LGraphNode } from "./LGraphNode"
 import { RenderShape, TitleMode } from "./types/globalEnums"
 
@@ -209,7 +209,7 @@ export class LGraphGroup implements Positionable, IPinnable {
 
         // Move reroutes we overlap the centre point of
         for (const reroute of reroutes.values()) {
-            if (isPointInRectangle(reroute.pos, this._bounding))
+            if (isPointInRect(reroute.pos, this._bounding))
                 children.add(reroute)
         }
 

--- a/src/LGraphNode.ts
+++ b/src/LGraphNode.ts
@@ -1568,6 +1568,36 @@ export class LGraphNode implements Positionable, IPinnable {
     }
 
     /**
+     * Gets the widget on this node at the given co-ordinates.
+     * @param canvasX X co-ordinate in graph space
+     * @param canvasY Y co-ordinate in graph space
+     * @returns The widget found, otherwise `null`
+     */
+    getWidgetOnPos(canvasX: number, canvasY: number): IWidget | null {
+        const { widgets, pos, size } = this
+        if (!widgets?.length) return null
+
+        const x = canvasX - pos[0]
+        const y = canvasY - pos[1]
+        const nodeWidth = size[0]
+
+        for (const widget of widgets) {
+            if (!widget || widget.disabled) continue
+
+            const h = widget.computeSize
+                ? widget.computeSize(nodeWidth)[1]
+                : LiteGraph.NODE_WIDGET_HEIGHT
+            const w = widget.width || nodeWidth
+            if (
+                widget.last_y !== undefined &&
+                isInRectangle(x, y, 6, widget.last_y, w - 12, h)
+            )
+                return widget
+        }
+        return null
+    }
+
+    /**
      * Returns the input slot with a given name (used for dynamic slots), -1 if not found
      * @param name the name of the slot
      * @param returnObj if the obj itself wanted

--- a/src/LGraphNode.ts
+++ b/src/LGraphNode.ts
@@ -1582,7 +1582,7 @@ export class LGraphNode implements Positionable, IPinnable {
         const nodeWidth = size[0]
 
         for (const widget of widgets) {
-            if (!widget || (widget.disabled && !includeDisabled)) continue
+            if (!widget || (widget.disabled && !includeDisabled) || widget.hidden || (widget.advanced && !this.showAdvanced)) continue
 
             const h = widget.computeSize
                 ? widget.computeSize(nodeWidth)[1]

--- a/src/LGraphNode.ts
+++ b/src/LGraphNode.ts
@@ -1573,7 +1573,7 @@ export class LGraphNode implements Positionable, IPinnable {
      * @param canvasY Y co-ordinate in graph space
      * @returns The widget found, otherwise `null`
      */
-    getWidgetOnPos(canvasX: number, canvasY: number): IWidget | null {
+    getWidgetOnPos(canvasX: number, canvasY: number, includeDisabled = false): IWidget | null {
         const { widgets, pos, size } = this
         if (!widgets?.length) return null
 
@@ -1582,7 +1582,7 @@ export class LGraphNode implements Positionable, IPinnable {
         const nodeWidth = size[0]
 
         for (const widget of widgets) {
-            if (!widget || widget.disabled) continue
+            if (!widget || (widget.disabled && !includeDisabled)) continue
 
             const h = widget.computeSize
                 ? widget.computeSize(nodeWidth)[1]

--- a/src/LGraphNode.ts
+++ b/src/LGraphNode.ts
@@ -9,7 +9,7 @@ import type { Reroute, RerouteId } from "./Reroute"
 import { LGraphEventMode, NodeSlotType, TitleMode, RenderShape } from "./types/globalEnums"
 import { BadgePosition, LGraphBadge } from "./LGraphBadge"
 import { type LGraphNodeConstructor, LiteGraph } from "./litegraph"
-import { isInsideRectangle, isXyInRectangle } from "./measure"
+import { isInRectangle, isXyInRect } from "./measure"
 import { LLink } from "./LLink"
 
 export type NodeId = number | string
@@ -1333,7 +1333,7 @@ export class LGraphNode implements Positionable, IPinnable {
     inResizeCorner(canvasX: number, canvasY: number): boolean {
         const rows = this.outputs ? this.outputs.length : 1
         const outputs_offset = (this.constructor.slot_start_y || 0) + rows * LiteGraph.NODE_SLOT_HEIGHT
-        return isInsideRectangle(canvasX,
+        return isInRectangle(canvasX,
             canvasY,
             this.pos[0] + this.size[0] - 15,
             this.pos[1] + Math.max(this.size[1] - 15, outputs_offset),
@@ -1521,7 +1521,7 @@ export class LGraphNode implements Positionable, IPinnable {
      * @return {boolean}
      */
     isPointInside(x: number, y: number): boolean {
-        return isXyInRectangle(x, y, this.boundingRect)
+        return isXyInRect(x, y, this.boundingRect)
     }
 
     /**
@@ -1532,7 +1532,7 @@ export class LGraphNode implements Positionable, IPinnable {
      */
     isPointInCollapse(x: number, y: number): boolean {
         const squareLength = LiteGraph.NODE_TITLE_HEIGHT
-        return isInsideRectangle(x, y, this.pos[0], this.pos[1] - squareLength, squareLength, squareLength)
+        return isInRectangle(x, y, this.pos[0], this.pos[1] - squareLength, squareLength, squareLength)
     }
 
     /**
@@ -1548,7 +1548,7 @@ export class LGraphNode implements Positionable, IPinnable {
             for (let i = 0, l = this.inputs.length; i < l; ++i) {
                 const input = this.inputs[i]
                 this.getConnectionPos(true, i, link_pos)
-                if (isInsideRectangle(x, y, link_pos[0] - 10, link_pos[1] - 5, 20, 10)) {
+                if (isInRectangle(x, y, link_pos[0] - 10, link_pos[1] - 5, 20, 10)) {
                     return { input, slot: i, link_pos }
                 }
             }
@@ -1558,7 +1558,7 @@ export class LGraphNode implements Positionable, IPinnable {
             for (let i = 0, l = this.outputs.length; i < l; ++i) {
                 const output = this.outputs[i]
                 this.getConnectionPos(false, i, link_pos)
-                if (isInsideRectangle(x, y, link_pos[0] - 10, link_pos[1] - 5, 20, 10)) {
+                if (isInRectangle(x, y, link_pos[0] - 10, link_pos[1] - 5, 20, 10)) {
                     return { output, slot: i, link_pos }
                 }
             }

--- a/src/LGraphNode.ts
+++ b/src/LGraphNode.ts
@@ -9,7 +9,7 @@ import type { Reroute, RerouteId } from "./Reroute"
 import { LGraphEventMode, NodeSlotType, TitleMode, RenderShape } from "./types/globalEnums"
 import { BadgePosition, LGraphBadge } from "./LGraphBadge"
 import { type LGraphNodeConstructor, LiteGraph } from "./litegraph"
-import { isInRectangle, isXyInRect } from "./measure"
+import { isInRectangle, isInRect } from "./measure"
 import { LLink } from "./LLink"
 
 export type NodeId = number | string
@@ -1521,7 +1521,7 @@ export class LGraphNode implements Positionable, IPinnable {
      * @return {boolean}
      */
     isPointInside(x: number, y: number): boolean {
-        return isXyInRect(x, y, this.boundingRect)
+        return isInRect(x, y, this.boundingRect)
     }
 
     /**

--- a/src/LGraphNode.ts
+++ b/src/LGraphNode.ts
@@ -322,8 +322,11 @@ export class LGraphNode implements Positionable, IPinnable {
     onGetOutputs?(this: LGraphNode): INodeOutputSlot[]
     onMouseUp?(this: LGraphNode, e: CanvasMouseEvent, pos: Point): void
     onMouseEnter?(this: LGraphNode, e: CanvasMouseEvent): void
+    /** Blocks drag if return value is truthy. @param pos Offset from {@link LGraphNode.pos}. */
     onMouseDown?(this: LGraphNode, e: CanvasMouseEvent, pos: Point, canvas: LGraphCanvas): boolean
+    /** @param pos Offset from {@link LGraphNode.pos}. */
     onDblClick?(this: LGraphNode, e: CanvasMouseEvent, pos: Point, canvas: LGraphCanvas): void
+    /** @param pos Offset from {@link LGraphNode.pos}. */
     onNodeTitleDblClick?(this: LGraphNode, e: CanvasMouseEvent, pos: Point, canvas: LGraphCanvas): void
     onDrawTitle?(this: LGraphNode, ctx: CanvasRenderingContext2D): void
     onDrawTitleText?(this: LGraphNode, ctx: CanvasRenderingContext2D, title_height: number, size: Size, scale: number, title_text_font: string, selected: boolean): void

--- a/src/LiteGraphGlobal.ts
+++ b/src/LiteGraphGlobal.ts
@@ -132,6 +132,8 @@ export class LiteGraphGlobal {
     ctrl_alt_click_do_break_link = true // [true!] who accidentally ctrl-alt-clicks on an in/output? nobody! that's who!
     snaps_for_comfy = true // [true!] snaps links when dragging connections over valid targets
     snap_highlights_node = true // [true!] renders a partial border to highlight when a dragged link is snapped to a node
+    /** After moving items on the canvas, their positions will be rounded.  Effectively "snap to grid" with a grid size of 1. */
+    always_round_positions = false
 
     search_hide_on_mouse_leave = true // [false on mobile] better true if not touch device, TODO add an helper/listener to close if false
     search_filter_enabled = false // [true!] enable filtering slots type in the search widget, !requires auto_load_slot_types or manual set registered_slot_[in/out]_types and slot_types_[in/out]

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -219,7 +219,7 @@ export interface IContextMenuOptions extends IContextMenuBase {
     scroll_speed?: number
     left?: number
     top?: number
-    scale?: string
+    scale?: number
     node?: LGraphNode
     autoopen?: boolean
 }

--- a/src/litegraph.ts
+++ b/src/litegraph.ts
@@ -25,6 +25,7 @@ export { LGraphBadge, BadgePosition }
 export { SlotShape, LabelPosition, SlotDirection, SlotType }
 export { EaseFunction, LinkMarkerShape } from "./types/globalEnums"
 export type { SerialisableGraph, SerialisableLLink } from "./types/serialisation"
+export { CanvasPointer } from "./CanvasPointer"
 export { createBounds } from "./measure"
 
 export function clamp(v: number, a: number, b: number): number {

--- a/src/measure.ts
+++ b/src/measure.ts
@@ -1,4 +1,4 @@
-import type { Point, Positionable, ReadOnlyPoint, ReadOnlyRect } from "./interfaces"
+import type { Point, Positionable, ReadOnlyPoint, ReadOnlyRect, Rect } from "./interfaces"
 import { LinkDirection } from "./types/globalEnums"
 
 /**
@@ -46,12 +46,12 @@ export function isInRectangle(x: number, y: number, left: number, top: number, w
 }
 
 /**
- * Determines whether a point is inside a rectangle.
+ * Determines whether a {@link Point} is inside a {@link Rect}.
  * @param point The point to check, as `x, y`
  * @param rect The rectangle, as `x, y, width, height`
  * @returns `true` if the point is inside the rect, otherwise `false`
  */
-export function isPointInRectangle(point: ReadOnlyPoint, rect: ReadOnlyRect): boolean {
+export function isPointInRect(point: ReadOnlyPoint, rect: ReadOnlyRect): boolean {
     return point[0] >= rect[0]
         && point[0] < rect[0] + rect[2]
         && point[1] >= rect[1]
@@ -59,13 +59,13 @@ export function isPointInRectangle(point: ReadOnlyPoint, rect: ReadOnlyRect): bo
 }
 
 /**
- * Determines whether a point is inside a rectangle.
+ * Determines whether the point represented by {@link x}, {@link y} is inside a {@link Rect}.
  * @param x X co-ordinate of the point to check
  * @param y Y co-ordinate of the point to check
  * @param rect The rectangle, as `x, y, width, height`
  * @returns `true` if the point is inside the rect, otherwise `false`
  */
-export function isXyInRect(x: number, y: number, rect: ReadOnlyRect): boolean {
+export function isInRect(x: number, y: number, rect: ReadOnlyRect): boolean {
     return x >= rect[0]
         && x < rect[0] + rect[2]
         && y >= rect[1]
@@ -136,7 +136,7 @@ export function overlapBounding(a: ReadOnlyRect, b: ReadOnlyRect): boolean {
 export function containsCentre(a: ReadOnlyRect, b: ReadOnlyRect): boolean {
     const centreX = b[0] + (b[2] * 0.5)
     const centreY = b[1] + (b[3] * 0.5)
-    return isXyInRect(centreX, centreY, a)
+    return isInRect(centreX, centreY, a)
 }
 
 /**

--- a/src/measure.ts
+++ b/src/measure.ts
@@ -28,15 +28,34 @@ export function dist2(x1: number, y1: number, x2: number, y2: number): number {
 
 /**
  * Determines whether a point is inside a rectangle.
+ * 
+ * Otherwise identical to {@link isInsideRectangle}, it also returns `true` if `x` equals `left` or `y` equals `top`.
+ * @param x Point x
+ * @param y Point y
+ * @param left Rect x
+ * @param top Rect y
+ * @param width Rect width
+ * @param height Rect height
+ * @returns `true` if the point is inside the rect, otherwise `false`
+ */
+export function isInRectangle(x: number, y: number, left: number, top: number, width: number, height: number): boolean {
+    return x >= left
+        && x < left + width
+        && y >= top
+        && y < top + height
+}
+
+/**
+ * Determines whether a point is inside a rectangle.
  * @param point The point to check, as `x, y`
  * @param rect The rectangle, as `x, y, width, height`
  * @returns `true` if the point is inside the rect, otherwise `false`
  */
 export function isPointInRectangle(point: ReadOnlyPoint, rect: ReadOnlyRect): boolean {
-    return rect[0] <= point[0]
-        && rect[0] + rect[2] > point[0]
-        && rect[1] <= point[1]
-        && rect[1] + rect[3] > point[1]
+    return point[0] >= rect[0]
+        && point[0] < rect[0] + rect[2]
+        && point[1] >= rect[1]
+        && point[1] < rect[1] + rect[3]
 }
 
 /**
@@ -46,15 +65,21 @@ export function isPointInRectangle(point: ReadOnlyPoint, rect: ReadOnlyRect): bo
  * @param rect The rectangle, as `x, y, width, height`
  * @returns `true` if the point is inside the rect, otherwise `false`
  */
-export function isXyInRectangle(x: number, y: number, rect: ReadOnlyRect): boolean {
-    return rect[0] <= x
-        && rect[0] + rect[2] > x
-        && rect[1] <= y
-        && rect[1] + rect[3] > y
+export function isXyInRect(x: number, y: number, rect: ReadOnlyRect): boolean {
+    return x >= rect[0]
+        && x < rect[0] + rect[2]
+        && y >= rect[1]
+        && y < rect[1] + rect[3]
 }
 
 /**
- * Determines whether a point is inside a rectangle.
+ * Determines whether a point (`x, y`) is inside a rectangle.
+ * 
+ * This is the original litegraph implementation.  It returns `false` if `x` is equal to `left`, or `y` is equal to `top`.
+ * @deprecated
+ * Use {@link isInRectangle} to match inclusive of top left.
+ * This function returns a false negative when an integer point (e.g. pixel) is on the leftmost or uppermost edge of a rectangle.
+ * 
  * @param x Point x
  * @param y Point y
  * @param left Rect x
@@ -111,7 +136,7 @@ export function overlapBounding(a: ReadOnlyRect, b: ReadOnlyRect): boolean {
 export function containsCentre(a: ReadOnlyRect, b: ReadOnlyRect): boolean {
     const centreX = b[0] + (b[2] * 0.5)
     const centreY = b[1] + (b[3] * 0.5)
-    return isXyInRectangle(centreX, centreY, a)
+    return isXyInRect(centreX, centreY, a)
 }
 
 /**

--- a/src/measure.ts
+++ b/src/measure.ts
@@ -16,12 +16,14 @@ export function distance(a: ReadOnlyPoint, b: ReadOnlyPoint): number {
 /**
  * Calculates the distance2 (squared) between two points (2D vector).
  * Much faster when only comparing distances (closest/furthest point).
- * @param a Point a as `x, y`
- * @param b Point b as `x, y`
- * @returns Distance2 (squared) between point {@link a} & {@link b}
+ * @param x1 Origin point X
+ * @param y1 Origin point Y
+ * @param x2 Destination point X
+ * @param y2 Destination point Y
+ * @returns Distance2 (squared) between point [{@link x1}, {@link y1}] & [{@link x2}, {@link y2}]
  */
-export function dist2(a: ReadOnlyPoint, b: ReadOnlyPoint): number {
-    return ((b[0] - a[0]) * (b[0] - a[0])) + ((b[1] - a[1]) * (b[1] - a[1]))
+export function dist2(x1: number, y1: number, x2: number, y2: number): number {
+    return ((x2 - x1) * (x2 - x1)) + ((y2 - y1) * (y2 - y1))
 }
 
 /**

--- a/src/types/events.ts
+++ b/src/types/events.ts
@@ -21,29 +21,20 @@ export interface IDeltaPosition {
     deltaY: number
 }
 
+interface LegacyMouseEvent {
+    /** @deprecated Part of DragAndScale mouse API - incomplete / not maintained */
+    dragging?: boolean
+    click_time?: number
+}
+
 /** PointerEvent with canvasX/Y and deltaX/Y properties */
 export interface CanvasPointerEvent extends PointerEvent, CanvasMouseEvent { }
 
 /** MouseEvent with canvasX/Y and deltaX/Y properties */
-export interface CanvasMouseEvent extends MouseEvent, ICanvasPosition, IDeltaPosition {
-    /** @deprecated Part of DragAndScale mouse API - incomplete / not maintained */
-    dragging?: boolean
-    click_time?: number
-    dataTransfer?: unknown
-}
-
-/** WheelEvent with canvasX/Y properties */
-export interface CanvasWheelEvent extends WheelEvent, ICanvasPosition {
-    dragging?: boolean
-    click_time?: number
-    dataTransfer?: unknown
-}
+export interface CanvasMouseEvent extends MouseEvent, Readonly<ICanvasPosition>, Readonly<IDeltaPosition>, LegacyMouseEvent { }
 
 /** DragEvent with canvasX/Y and deltaX/Y properties */
 export interface CanvasDragEvent extends DragEvent, ICanvasPosition, IDeltaPosition { }
-
-/** TouchEvent with canvasX/Y and deltaX/Y properties */
-export interface CanvasTouchEvent extends TouchEvent, ICanvasPosition, IDeltaPosition { }
 
 export type CanvasEventDetail =
     GenericEventDetail

--- a/src/types/events.ts
+++ b/src/types/events.ts
@@ -10,15 +10,15 @@ import type { LGraphGroup } from "../LGraphGroup"
 /** For Canvas*Event - adds graph space co-ordinates (property names are shipped) */
 export interface ICanvasPosition {
     /** X co-ordinate of the event, in graph space (NOT canvas space) */
-    canvasX?: number
+    canvasX: number
     /** Y co-ordinate of the event, in graph space (NOT canvas space) */
-    canvasY?: number
+    canvasY: number
 }
 
 /** For Canvas*Event */
 export interface IDeltaPosition {
-    deltaX?: number
-    deltaY?: number
+    deltaX: number
+    deltaY: number
 }
 
 /** PointerEvent with canvasX/Y and deltaX/Y properties */

--- a/src/types/globalEnums.ts
+++ b/src/types/globalEnums.ts
@@ -16,6 +16,22 @@ export enum RenderShape {
     HollowCircle = 7,
 }
 
+/** Bit flags used to indicate what the pointer is currently hovering over. */
+export enum CanvasItem {
+    /** No items / none */
+    Nothing = 0,
+    /** At least one node */
+    Node = 1 << 0,
+    /** At least one group */
+    Group = 1 << 1,
+    /** A reroute (not its path) */
+    Reroute = 1 << 2,
+    /** The path of a link */
+    Link = 1 << 3,
+    /** A resize in the bottom-right corner */
+    ResizeSe = 1 << 4,
+}
+
 /** The direction that a link point will flow towards - e.g. horizontal outputs are right by default */
 export enum LinkDirection {
     NONE = 0,

--- a/test/__snapshots__/litegraph.test.ts.snap
+++ b/test/__snapshots__/litegraph.test.ts.snap
@@ -134,6 +134,7 @@ LiteGraphGlobal {
   "allow_multi_output_for_events": true,
   "allow_scripts": false,
   "alt_drag_do_clone_nodes": false,
+  "always_round_positions": false,
   "auto_load_slot_types": false,
   "auto_sort_node_types": false,
   "catch_exceptions": true,


### PR DESCRIPTION
### Default behaviour changes

This is a fundamental change to the way Litegraph handles pointer interaction.  Each pointer event is now tracked and managed by a `CanvasPointer`, created by the canvas as `LGraphCanvas.pointer`.

- Dragging multiple items no longer requires that the shift key be held down
  - Clicking an item when multiple nodes / etc are selected will still deselect everything else
- Clicking a connected link on an input no longer disconnects and reconnects it
- Double-clicking requires that both clicks occur nearby
- Makes adding an option (later) to customise what modifier keys do actually feasible

#### Bug fixes
- Intermittent issue where clicking a node slightly displaces it
- Alt-clicking to add a reroute creates two undo steps

For users, a lot of the change will be subtle, but it should "feel" more like a stable, native app.  It should also result in fewer unexpected changes in the future.

For devs, the process to add / change click & drag actions has been **drastically** simplified.

#### Selecting multiple items

- `Ctrl + drag` - Begin multi-select
- `Ctrl + Shift + drag` - Add to selection
  - `Ctrl + drag`, `Shift` - Alternate add to selection
- `Ctrl + drag`, `Alt` - Remove from selection

#### Click "drift"

A small amount of buffering is performed between down/up events to prevent accidental micro-drag events.  If either of the two controls are exceeded, the event will be considered a drag event, not a click.
- `buffterTime` is the maximum time that tiny movements can be ignored (Default: 150ms)
- `maxClickDrift` controls how far a click can drift from its down event before it is considered a drag (Default: 6)

#### Double-click

When double clicking, the double click callback is executed shortly after one normal click callback (if present).  At present, dragging from the second click simply invalidates the event - nothing will happen.
- `doubleClickTime` is the maximum time between two `down` events for them to be considered a double click (Default: 300ms)
- Distance between the two events must be less than `3 * maxClickDrift`

#### Configuration
All above configuration is via class static.  Could be converted to instance-based.

### Implementing

Clicking, double-clicking, and dragging can now all be configured during the initial `pointerdown` event, and the correct callback(s) will be executed.

A click event can be as simple as:
```ts
if (node.isClickedInSpot(e.canvasX, e.canvasY)) this.pointer.onClick = () => node.gotClickInSpot()
```

Full usage can be seen in the old `processMouseDown` handler, which is still in place (several monkey patches in the wild).


#### Registering a click or drag event

Example usage:
```typescript
const { pointer } = this
// Click / double click - executed on pointerup
pointer.onClick = (e) => node.executeClick(e)
pointer.onDoubleClick = node.gotDoubleClick

// Drag events - executed on pointermove
pointer.onDragStart = (e) => {
  node.isBeingDragged = true
  canvas.startedDragging(e)
}
pointer.onDrag = () => {}
// finally() is preferred where possible, as it is guaranteed to run
pointer.onDragEnd = () => {}

// Always run, regardless of outcome
pointer.finally = () => node.isBeingDragged = false
```

### Hovering over
Adds API for downstream consumers to handle custom cursors.  A bitwise enum of items,
```typescript
type LGraphCanvasState = {
  /** If `true`, pointer move events will set the canvas cursor style. */
  shouldSetCursor: boolean,
  /** Bit flags indicating what is currently below the pointer. */
  hoveringOver: CanvasItem,
  ...
}

// Disable litegraph cursors
canvas.state.shouldSetCursor = false

// Checking state - bit operators
if (canvas.state.hoveringOver & CanvasItem.ResizeSe) element.style.cursor = 'se-resize'
```

### Removed public interfaces
All are unused and incomplete.  Have bugs beyond just typescript typing, and are (currently) not worth maintaining.  If any of these features are desired down the track, they can be reimplemented.
- Live mode
- Subgraph
- `dragged_node`