### PR TITLE
Fix fast widget conversion

### DIFF
--- a/src/LGraphCanvas.ts
+++ b/src/LGraphCanvas.ts
@@ -2472,7 +2472,6 @@ export class LGraphCanvas {
         this.graph_mouse[1] = e.canvasY
 
         if (e.isPrimary) this.pointer.move(e)
-        this.link_over_widget = null
 
         if (this.block_click) {
             e.preventDefault()


### PR DESCRIPTION
Resolves https://github.com/Comfy-Org/ComfyUI_frontend/issues/1611

Fixes a regression in fast widget conversion introduced in #308.  The fast widget conversion is only available for exactly one pointermove event.  Subsequent events clear it.  This explains how it passed tests.