### PR TITLE
Snapsize

### DIFF
--- a/src/LGraphCanvas.ts
+++ b/src/LGraphCanvas.ts
@@ -2205,10 +2205,14 @@ export class LGraphCanvas {
             if (this.read_only) return
 
             // Resize only by the exact pointer movement
-            const resized = group.resize(
+            const pos: Point = [
               eMove.canvasX - group.pos[0] - offsetX,
               eMove.canvasY - group.pos[1] - offsetY,
-            )
+            ]
+            // Unless snapping.
+            snapPoint(pos, this.#snapToGrid)
+
+            const resized = group.resize(pos[0], pos[1])
             if (resized) this.dirty_bgcanvas = true
           }
           pointer.finally = () => this.resizingGroup = null

--- a/src/LGraphCanvas.ts
+++ b/src/LGraphCanvas.ts
@@ -2226,6 +2226,7 @@ export class LGraphCanvas {
             )
           ) {
             // In title bar
+            pointer.onClick = () => this.processSelect(group, e)
             pointer.onDragStart = (pointer) => {
               group.recomputeInsideNodes()
               this.#startDraggingItems(group, pointer, true)


### PR DESCRIPTION
Replaces group & node resize with improved CanvasPointer callbacks.

### Bringing back the resize snap

https://github.com/user-attachments/assets/434f3a09-3853-4a95-8e8e-a09bd34dbdf7

### Preventing unwanted teleportation

#### Old

https://github.com/user-attachments/assets/518ec60c-6c87-4e05-8c6e-15ae5e2d9820

#### New

https://github.com/user-attachments/assets/732ac8b1-4b4a-4436-9927-e5d1cc49cdf7

### Multiple ways to click title bars

https://github.com/user-attachments/assets/66dafc35-ab54-4331-b546-84c5377a06f1

