### PR TITLE
Fix custom widget mouseover

### DIFF
--- a/src/LGraphCanvas.ts
+++ b/src/LGraphCanvas.ts
@@ -2956,9 +2956,9 @@ export class LGraphCanvas {
         // Resize corner
         if (node.inResizeCorner(e.canvasX, e.canvasY)) {
           underPointer |= CanvasItem.ResizeSe
-        } else {
+        } else if (this.node_widget) {
           // Legacy widget mouse callbacks for pointermove events
-          const widget = node.getWidgetOnPos(e.canvasX, e.canvasY)
+          const widget = this.node_widget[1]
 
           if (widget?.mouse) {
             const x = e.canvasX - node.pos[0]


### PR DESCRIPTION
Resolves #338

`LGraphCanvas.node_widget` is set during `processMouseDown` - a legacy state variable that is set to the last widget that was clicked.  Cleared on pointerup.

Some custom widgets expect to handle all pointer events, whilst others expect to only receive pointerdown events.  The API was unclear, so guesswork appears to have been used.

Using node_widget, they should only receive movement events whilst dragging on the widget.