### PR TITLE
Fix widget.mouse callback does not receive pointerup events

### DIFF
--- a/src/LGraphCanvas.ts
+++ b/src/LGraphCanvas.ts
@@ -2658,8 +2658,8 @@ export class LGraphCanvas {
     default:
       // Legacy custom widget callback
       if (widget.mouse) {
-        pointer.onClick = eUp => widget.mouse(eUp, [eUp.canvasX - node[0], eUp.canvasY - node[1]], node)
-        this.dirty_canvas = widget.mouse(e, [x, y], node)
+        const result = widget.mouse(e, [x, y], node)
+        if (result != null) this.dirty_canvas = result
       }
       break
     }
@@ -2670,7 +2670,17 @@ export class LGraphCanvas {
       node.graph._version++
     }
 
-    pointer.finally = () => this.node_widget = null
+    // Clean up state var
+    pointer.finally = () => {
+      // Legacy custom widget callback
+      if (widget.mouse) {
+        const { eUp } = pointer
+        const { canvasX, canvasY } = eUp
+        widget.mouse(eUp, [canvasX - node[0], canvasY - node[1]], node)
+      }
+
+      this.node_widget = null
+    }
 
     function setWidgetValue(
       canvas: LGraphCanvas,

--- a/src/LGraphCanvas.ts
+++ b/src/LGraphCanvas.ts
@@ -2656,7 +2656,11 @@ export class LGraphCanvas {
       )
       break
     default:
-      if (widget.mouse) this.dirty_canvas = widget.mouse(e, [x, y], node)
+      // Legacy custom widget callback
+      if (widget.mouse) {
+        pointer.onClick = eUp => widget.mouse(eUp, [eUp.canvasX - node[0], eUp.canvasY - node[1]], node)
+        this.dirty_canvas = widget.mouse(e, [x, y], node)
+      }
       break
     }
 


### PR DESCRIPTION
Resolves #341

~~On a valid click, custom widgets using the `widget.mouse` callback will receive the `pointerup` event.~~

`pointerup` events are now sent to custom widgets in the same fashion as prior to #308.

A potential edge case break with this impl. is external mutation of `LGraphCanvas.node_widget` during a drag event.  Can be revisited if required, but I don't think this should be supported to begin with.