### PR TITLE
Fix invalid callback return value preventing canvas redraw

### DIFF
--- a/src/LGraphCanvas.ts
+++ b/src/LGraphCanvas.ts
@@ -2963,7 +2963,8 @@ export class LGraphCanvas {
           if (widget?.mouse) {
             const x = e.canvasX - node.pos[0]
             const y = e.canvasY - node.pos[1]
-            this.dirty_canvas = widget.mouse(e, [x, y], node)
+            const result = widget.mouse(e, [x, y], node)
+            if (result != null) this.dirty_canvas = result
           }
         }
       } else {

--- a/src/LGraphCanvas.ts
+++ b/src/LGraphCanvas.ts
@@ -2804,6 +2804,18 @@ export class LGraphCanvas {
 
     e.dragging = this.last_mouse_dragging
 
+    if (this.node_widget) {
+      // Legacy widget mouse callbacks for pointermove events
+      const [node, widget] = this.node_widget
+
+      if (widget?.mouse) {
+        const x = e.canvasX - node.pos[0]
+        const y = e.canvasY - node.pos[1]
+        const result = widget.mouse(e, [x, y], node)
+        if (result != null) this.dirty_canvas = result
+      }
+    }
+
     /** See {@link state}.{@link LGraphCanvasState.hoveringOver hoveringOver} */
     let underPointer = CanvasItem.Nothing
     // get node over
@@ -2956,16 +2968,6 @@ export class LGraphCanvas {
         // Resize corner
         if (node.inResizeCorner(e.canvasX, e.canvasY)) {
           underPointer |= CanvasItem.ResizeSe
-        } else if (this.node_widget) {
-          // Legacy widget mouse callbacks for pointermove events
-          const widget = this.node_widget[1]
-
-          if (widget?.mouse) {
-            const x = e.canvasX - node.pos[0]
-            const y = e.canvasY - node.pos[1]
-            const result = widget.mouse(e, [x, y], node)
-            if (result != null) this.dirty_canvas = result
-          }
         }
       } else {
         // Not over a node


### PR DESCRIPTION
Problem / history:
- `widget.mouse()` return value controls canvas redraw
- Return value ignored due to Litegraph bug
- Return value not implemented by extension authors - there was no guidance and it did nothing (_not assigning blame_)
- Litegraph bug now fixed
- Nodes broken

Solution:
- If return value is nullish, ignore it
- If return value provided, use it to control canvas redraw

Additional:
- `pointermove` events are not fired outside of node bounds (no GH issues for this yet)
- Restores original behaviour by moving the widget callback out of conditional blocks

Resolves Comfy-Org/ComfyUI_frontend/issues/1641