### PR TITLE
Fix slider regression caused by CanvasPointer

### DIFF
--- a/src/LGraphCanvas.ts
+++ b/src/LGraphCanvas.ts
@@ -2518,6 +2518,7 @@ export class LGraphCanvas {
       if (widget.options.read_only) break
 
       pointer.onDrag = (eMove) => {
+        const x = eMove.canvasX - node.pos[0]
         const slideFactor = clamp((x - 15) / (width - 30), 0, 1)
         widget.value = widget.options.min + (widget.options.max - widget.options.min) * slideFactor
         if (oldValue != widget.value) {


### PR DESCRIPTION
Resolves Comfy-Org/ComfyUI_frontend/issues/1696

Changes the slider drag callback to use the current value from `pointermove` event rather than the the original `pointerdown` event, to set the slider value.