### PR TITLE
Fix custom widget pointerup receives NaN pos

### DIFF
--- a/src/LGraphCanvas.ts
+++ b/src/LGraphCanvas.ts
@@ -2677,7 +2677,7 @@ export class LGraphCanvas {
       if (widget.mouse) {
         const { eUp } = pointer
         const { canvasX, canvasY } = eUp
-        widget.mouse(eUp, [canvasX - node[0], canvasY - node[1]], node)
+        widget.mouse(eUp, [canvasX - node.pos[0], canvasY - node.pos[1]], node)
       }
 
       this.node_widget = null


### PR DESCRIPTION
Fixes basic syntax error causing one of the widget.mouse calls to return `[NaN, NaN]` for pos.

The parameter is entirely redundant, as it is just a subtraction of fields in the other two paramters.  It is however, currently in use.