### PR TITLE
Group snap after resize

### DIFF
--- a/src/LGraphGroup.ts
+++ b/src/LGraphGroup.ts
@@ -18,7 +18,6 @@ import {
   snapPoint,
 } from "./measure"
 import { LGraphNode } from "./LGraphNode"
-import { RenderShape, TitleMode } from "./types/globalEnums"
 
 export interface IGraphGroupFlags extends Record<string, unknown> {
   pinned?: true


### PR DESCRIPTION
- Resolves Comfy-Org/ComfyUI_frontend/issues/1185
- When resized using fit to grid or any method calling `LGraphGroup,resizeTo`, groups do not respect Always Snap to Grid
- Unexpected UX: any workflow reload (undo/redo etc), groups that were fit, but not moved, will now be snapped