### PR TITLE
Add LGraph.empty

### DIFF
--- a/src/LGraph.ts
+++ b/src/LGraph.ts
@@ -115,6 +115,16 @@ export class LGraph implements LinkNetwork, Serialisable<SerialisableGraph> {
   inputs: Dictionary<IGraphInput>
   outputs: Dictionary<IGraphInput>
 
+  /** @returns Whether the graph has no items */
+  get empty(): boolean {
+    return this.positionableItems.length === 0
+  }
+
+  /** @returns All items on the canvas that can be selected */
+  get positionableItems(): Positionable[] {
+    return [...this._nodes, ...this._groups, ...this.reroutes.values()]
+  }
+
   #reroutes = new Map<RerouteId, Reroute>()
   /** All reroutes in this graph. */
   public get reroutes(): Map<RerouteId, Reroute> {

--- a/src/LGraphCanvas.ts
+++ b/src/LGraphCanvas.ts
@@ -3954,15 +3954,12 @@ export class LGraphCanvas {
     }
   }
 
-  /**
-   * @returns All items on the canvas that can be selected
-   */
+  get empty(): boolean {
+    return this.graph.empty
+  }
+
   get positionableItems(): Positionable[] {
-    return [
-      ...this.graph._nodes,
-      ...this.graph._groups,
-      ...this.graph.reroutes.values(),
-    ]
+    return this.graph.positionableItems
   }
 
   /**


### PR DESCRIPTION
This PR adds `LGraph.empty` shorthand to check whether the graph is empty.