### PR TITLE
Optimise positionableItems / empty getters

### DIFF
--- a/src/LGraph.ts
+++ b/src/LGraph.ts
@@ -117,7 +117,7 @@ export class LGraph implements LinkNetwork, Serialisable<SerialisableGraph> {
 
   /** @returns Whether the graph has no items */
   get empty(): boolean {
-    return this.positionableItems.length === 0
+    return this._nodes.length + this._groups.length + this.reroutes.size === 0
   }
 
   /** @returns All items on the canvas that can be selected */

--- a/src/LGraph.ts
+++ b/src/LGraph.ts
@@ -121,8 +121,11 @@ export class LGraph implements LinkNetwork, Serialisable<SerialisableGraph> {
   }
 
   /** @returns All items on the canvas that can be selected */
-  get positionableItems(): Positionable[] {
-    return [...this._nodes, ...this._groups, ...this.reroutes.values()]
+  *positionableItems(): Generator<LGraphNode | LGraphGroup | Reroute> {
+    for (const node of this._nodes) yield node
+    for (const group of this._groups) yield group
+    for (const reroute of this.reroutes.values()) yield reroute
+    return
   }
 
   #reroutes = new Map<RerouteId, Reroute>()

--- a/src/LGraphCanvas.ts
+++ b/src/LGraphCanvas.ts
@@ -3958,8 +3958,8 @@ export class LGraphCanvas {
     return this.graph.empty
   }
 
-  get positionableItems(): Positionable[] {
-    return this.graph.positionableItems
+  get positionableItems() {
+    return this.graph.positionableItems()
   }
 
   /**
@@ -8420,7 +8420,7 @@ export class LGraphCanvas {
    * If nothing is selected, the view is fitted around all items in the graph.
    */
   fitViewToSelectionAnimated(options: AnimationOptions = {}) {
-    const items: Positionable[] = this.selectedItems.size
+    const items = this.selectedItems.size
       ? Array.from(this.selectedItems)
       : this.positionableItems
     this.animateToBounds(createBounds(items), options)


### PR DESCRIPTION
- No change to internal functionality
- Replaces forced spread of all items on every property access with generator function
- Consumers that require an array can very cleanly spread into one