### PR TITLE
Export Reroute class the same as other similar classes

### DIFF
--- a/src/LiteGraphGlobal.ts
+++ b/src/LiteGraphGlobal.ts
@@ -17,6 +17,7 @@ import { LGraphNode } from "./LGraphNode"
 import { SlotShape, SlotDirection, SlotType, LabelPosition } from "./draw"
 import type { Dictionary, ISlotType, Rect } from "./interfaces"
 import { distance, isInsideRectangle, overlapBounding } from "./measure"
+import { Reroute } from "./Reroute"
 
 /**
  * The Global Scope. It contains all the registered node classes.
@@ -265,6 +266,7 @@ export class LiteGraphGlobal {
   LGraphCanvas = LGraphCanvas
   ContextMenu = ContextMenu
   CurveEditor = CurveEditor
+  Reroute = Reroute
 
   onNodeTypeRegistered?(type: string, base_class: typeof LGraphNode): void
   onNodeTypeReplaced?(type: string, base_class: typeof LGraphNode, prev: unknown): void

--- a/src/litegraph.ts
+++ b/src/litegraph.ts
@@ -81,6 +81,7 @@ export type {
   ISerialisedGraph,
 } from "./types/serialisation"
 export { CanvasPointer } from "./CanvasPointer"
+export { Reroute } from "./Reroute"
 export { createBounds } from "./measure"
 
 export function clamp(v: number, a: number, b: number): number {

--- a/test/__snapshots__/litegraph.test.ts.snap
+++ b/test/__snapshots__/litegraph.test.ts.snap
@@ -89,6 +89,7 @@ LiteGraphGlobal {
   "OUTPUT": 2,
   "RIGHT": 4,
   "ROUND_SHAPE": 2,
+  "Reroute": [Function],
   "SPLINE_LINK": 2,
   "STRAIGHT_LINK": 0,
   "SlotDirection": {


### PR DESCRIPTION
Allows users to configure and utilise the Reroute class in the same manner as all other configurable classes.