### PR TITLE
Fix reroutes ignore change in radius

### DIFF
--- a/src/LGraph.ts
+++ b/src/LGraph.ts
@@ -1048,9 +1048,9 @@ export class LGraph implements LinkNetwork, Serialisable<SerialisableGraph> {
    */
   getRerouteOnPos(x: number, y: number): Reroute | undefined {
     for (const reroute of this.reroutes.values()) {
-      const pos = reroute.pos
+      const { pos } = reroute
 
-      if (isSortaInsideOctagon(x - pos[0], y - pos[1], 20))
+      if (isSortaInsideOctagon(x - pos[0], y - pos[1], 2 * Reroute.radius))
         return reroute
     }
   }

--- a/src/Reroute.ts
+++ b/src/Reroute.ts
@@ -283,21 +283,21 @@ export class Reroute implements Positionable, LinkSegment, Serialisable<Serialis
     ctx.arc(pos[0], pos[1], Reroute.radius, 0, 2 * Math.PI)
     ctx.fill()
 
-    ctx.lineWidth = 1
+    ctx.lineWidth = Reroute.radius * 0.1
     ctx.strokeStyle = "rgb(0,0,0,0.5)"
     ctx.stroke()
 
     ctx.fillStyle = "#ffffff55"
     ctx.strokeStyle = "rgb(0,0,0,0.3)"
     ctx.beginPath()
-    ctx.arc(pos[0], pos[1], 8, 0, 2 * Math.PI)
+    ctx.arc(pos[0], pos[1], Reroute.radius * 0.8, 0, 2 * Math.PI)
     ctx.fill()
     ctx.stroke()
 
     if (this.selected) {
       ctx.strokeStyle = "#fff"
       ctx.beginPath()
-      ctx.arc(pos[0], pos[1], 12, 0, 2 * Math.PI)
+      ctx.arc(pos[0], pos[1], Reroute.radius * 1.2, 0, 2 * Math.PI)
       ctx.stroke()
     }
   }


### PR DESCRIPTION
### Current

Only part of the reroute is drawn at the selected scale.

`radius = 2`

![image](https://github.com/user-attachments/assets/616784d6-766d-4e55-9941-5a07d6ba04a5)

### Proposed

Allows Reroute size to be changed via `radius` static property, per original design:

`radius = 2`

![image](https://github.com/user-attachments/assets/6c9b54b4-7367-4864-8b37-056267bb9139)

`radius = 7`

![image](https://github.com/user-attachments/assets/03eedbfe-b1f0-42fa-bf10-1e4a126cca03)

`radius = 20`

![image](https://github.com/user-attachments/assets/d2d2e2a0-57d5-4af0-bb0c-70d569abb8f1)
