### PR TITLE
Improve link drag & drop

### DIFF
--- a/src/LGraphCanvas.ts
+++ b/src/LGraphCanvas.ts
@@ -2328,10 +2328,10 @@ export class LGraphCanvas implements ConnectionColorContext {
                   connecting.output = linked_node.outputs[slot]
                 }
                 pointer.onDragEnd = (upEvent) => {
-                  this.#processConnectingLinks(upEvent)
                   if (this.allow_reconnect_links && !LiteGraph.click_do_break_link_to) {
                     node.disconnectInput(i)
                   }
+                  this.#processConnectingLinks(upEvent)
                   connecting.output = linked_node.outputs[slot]
                   this.connecting_links = null
                 }


### PR DESCRIPTION
- Resolves https://github.com/Comfy-Org/litegraph.js/issues/309#issuecomment-2508726168
- Output issue still pending
- Splits connecting links `pointerup` handler to separate function, which can now be called from `CanvasPointer` callbacks
  - Minor refactor; no functional changes

### Behaviour change

When moving existing links from an input slot, the link will not be disconnected until the drop event occurs.

### Current

Shift + drag

https://github.com/user-attachments/assets/0b98f9bf-3d5f-467e-9a9b-e5695e5a0d0b

### Proposed

Shift + drag

https://github.com/user-attachments/assets/0bc36215-0247-41da-8050-e8df09addf23