### PR TITLE
Fix slider value display when widget.label is present

### DIFF
--- a/src/LGraphCanvas.ts
+++ b/src/LGraphCanvas.ts
@@ -6240,8 +6240,7 @@ export class LGraphCanvas {
           ctx.textAlign = "center"
           ctx.fillStyle = text_color
           ctx.fillText(
-            w.label ||
-            w.name +
+            (w.label || w.name) +
             "  " +
             Number(w.value).toFixed(
               w.options.precision != null ? w.options.precision : 3,


### PR DESCRIPTION
Resolves https://github.com/Comfy-Org/ComfyUI_frontend/issues/1913

Display value even the widget label is present.