### PR TITLE
Emit node-double-click event

### DIFF
--- a/src/LGraphCanvas.ts
+++ b/src/LGraphCanvas.ts
@@ -2500,6 +2500,11 @@ export class LGraphCanvas {
           node.onNodeTitleDblClick?.(e, pos, this)
         }
         node.onDblClick?.(e, pos, this)
+        this.emitEvent({
+          subType: "node-double-click",
+          originalEvent: e,
+          node,
+        })
         this.processNodeDblClicked(node)
       }
 

--- a/src/litegraph.ts
+++ b/src/litegraph.ts
@@ -23,7 +23,7 @@ import type {
 import type { SlotShape, LabelPosition, SlotDirection, SlotType } from "./draw"
 import type { IWidget } from "./types/widgets"
 import type { RenderShape, TitleMode } from "./types/globalEnums"
-import type { CanvasEventDetail, GroupDoubleClickEventDetail } from "./types/events"
+import type { CanvasEventDetail } from "./types/events"
 import { LiteGraphGlobal } from "./LiteGraphGlobal"
 import { loadPolyfills } from "./polyfills"
 

--- a/src/litegraph.ts
+++ b/src/litegraph.ts
@@ -23,7 +23,7 @@ import type {
 import type { SlotShape, LabelPosition, SlotDirection, SlotType } from "./draw"
 import type { IWidget } from "./types/widgets"
 import type { RenderShape, TitleMode } from "./types/globalEnums"
-import type { CanvasEventDetail } from "./types/events"
+import type { CanvasEventDetail, GroupDoubleClickEventDetail } from "./types/events"
 import { LiteGraphGlobal } from "./LiteGraphGlobal"
 import { loadPolyfills } from "./polyfills"
 
@@ -133,13 +133,6 @@ export interface LinkReleaseContextExtended {
 }
 
 export interface LiteGraphCanvasEvent extends CustomEvent<CanvasEventDetail> {}
-
-export interface LiteGraphCanvasGroupEvent
-  extends CustomEvent<{
-    subType: "group-double-click"
-    originalEvent: MouseEvent
-    group: LGraphGroup
-  }> {}
 
 /** https://github.com/jagenjo/litegraph.js/blob/master/guides/README.md#lgraphnode */
 

--- a/src/types/events.ts
+++ b/src/types/events.ts
@@ -48,6 +48,7 @@ export type CanvasEventDetail =
   | DragggingCanvasEventDetail
   | ReadOnlyEventDetail
   | GroupDoubleClickEventDetail
+  | NodeDoubleClickEventDetail
   | EmptyDoubleClickEventDetail
   | ConnectingWidgetLinkEventDetail
   | EmptyReleaseEventDetail
@@ -79,6 +80,11 @@ export interface EmptyDoubleClickEventDetail extends OriginalEvent {
 export interface GroupDoubleClickEventDetail extends OriginalEvent {
   subType: "group-double-click"
   group: LGraphGroup
+}
+
+export interface NodeDoubleClickEventDetail extends OriginalEvent {
+  subType: "node-double-click"
+  node: LGraphNode
 }
 
 export interface DragggingCanvasEventDetail {


### PR DESCRIPTION
- Add `node-double-click` event to match the `group-double-click` event
- Remove unused interface `LiteGraphCanvasGroupEvent`