### PR TITLE
Disable interaction with links and reroutes when visibility is off

### DIFF
--- a/src/LGraphCanvas.ts
+++ b/src/LGraphCanvas.ts
@@ -2126,7 +2126,7 @@ export class LGraphCanvas {
       this.#processNodeClick(e, ctrlOrMeta, node)
     } else {
       // Reroutes
-      if (this.reroutesEnabled) {
+      if (this.reroutesEnabled && this.links_render_mode !== LinkRenderType.HIDDEN_LINK) {
         const reroute = graph.getRerouteOnPos(x, y)
         if (reroute) {
           if (e.shiftKey) {
@@ -5548,6 +5548,7 @@ export class LGraphCanvas {
   drawConnections(ctx: CanvasRenderingContext2D): void {
     const rendered = this.renderedPaths
     rendered.clear()
+    if (this.links_render_mode === LinkRenderType.HIDDEN_LINK) return
     const visibleReroutes: Reroute[] = []
 
     const now = LiteGraph.getTime()
@@ -8251,7 +8252,7 @@ export class LGraphCanvas {
       menu_info = this.getCanvasMenuOptions()
 
       // Check for reroutes
-      if (this.reroutesEnabled) {
+      if (this.reroutesEnabled && this.links_render_mode !== LinkRenderType.HIDDEN_LINK) {
         const reroute = this.graph.getRerouteOnPos(event.canvasX, event.canvasY)
         if (reroute) {
           menu_info.unshift({


### PR DESCRIPTION
Return early from `drawConnections` after clearing `renderedPaths` when link visibility is toggled off, fixing #392 and #394 and hiding reroutes alongside links.

Add checks to prevent reroute entries in the context menu and ignore reroute clicks when link visibility is disabled.


Before / After:

https://github.com/user-attachments/assets/a7e6972f-aad9-43d1-b2d1-84a05b4f7a01


https://github.com/user-attachments/assets/55812173-8968-43e2-b984-c53f6c4ea312

