### PR TITLE
Fix deeply nested context menus remain open

### DIFF
--- a/src/ContextMenu.ts
+++ b/src/ContextMenu.ts
@@ -360,8 +360,6 @@ export class ContextMenu {
   ): CustomEvent {
     const evt = document.createEvent("CustomEvent")
     evt.initCustomEvent(event_name, true, true, params) // canBubble, cancelable, detail
-    // @ts-expect-error
-    evt.srcElement = origin
     if (element.dispatchEvent) element.dispatchEvent(evt)
     // @ts-expect-error
     else if (element.__events) element.__events.dispatchEvent(evt)

--- a/src/ContextMenu.ts
+++ b/src/ContextMenu.ts
@@ -332,7 +332,7 @@ export class ContextMenu {
   }
 
   close(e?: MouseEvent, ignore_parent_menu?: boolean): void {
-    this.root.parentNode?.removeChild(this.root)
+    this.root.remove()
     if (this.parentMenu && !ignore_parent_menu) {
       this.parentMenu.lock = false
       this.parentMenu.current_submenu = null


### PR DESCRIPTION
- Resolves https://github.com/Comfy-Org/ComfyUI_frontend/issues/2059

Removes a line of broken legacy code.  This was detected during TS conversion, but the error was squashed to prevent unintentional downstream breakage. 

Issue report indicates it is always an error, and is safe to remove.
