### PR TITLE
Stricter return value check on LGraphCanvas.getExtraMenuOptions

### DIFF
--- a/src/LGraphCanvas.ts
+++ b/src/LGraphCanvas.ts
@@ -8061,7 +8061,7 @@ export class LGraphCanvas {
     }
 
     const extra = this.getExtraMenuOptions?.(this, options)
-    return extra
+    return Array.isArray(extra)
       ? options.concat(extra)
       : options
   }
@@ -8159,7 +8159,7 @@ export class LGraphCanvas {
     if (outputs?.length) options[1].disabled = false
 
     const extra = node.getExtraMenuOptions?.(this, options)
-    if (extra) {
+    if (Array.isArray(extra) && extra.length > 0) {
       extra.push(null)
       options = extra.concat(options)
     }


### PR DESCRIPTION
In javascript `!![]` evals to `true`, so the old check would always pass if the callback obeys the type signature, which can cause an extra `null` item being added (separator). This PR fixes the issue which makes empty array return value generate a separator.

```typescript
getExtraMenuOptions?(
  this: LGraphNode,
  canvas: LGraphCanvas,
  options: IContextMenuValue[],
): IContextMenuValue[]
```