### PR TITLE
Upstream grab cursor style

### DIFF
--- a/src/LGraphCanvas.ts
+++ b/src/LGraphCanvas.ts
@@ -3073,8 +3073,12 @@ export class LGraphCanvas {
     this.state.hoveringOver = underPointer
 
     if (this.state.shouldSetCursor) {
-      if (!underPointer) {
-        this.canvas.style.cursor = ""
+      if (this.state.draggingCanvas) {
+        this.canvas.style.cursor = "grabbing"
+      } else if (this.state.readOnly) {
+        this.canvas.style.cursor = "grab"
+      } else if (!underPointer) {
+        this.canvas.style.cursor = "default"
       } else if (underPointer & CanvasItem.ResizeSe) {
         this.canvas.style.cursor = "se-resize"
       } else if (underPointer & CanvasItem.Node) {


### PR DESCRIPTION
Upstreams cursor style adjustment based from ComfyUI_frontend. Previous change in litegraph broke the vue side watcher logic.

Ref: https://github.com/Comfy-Org/ComfyUI_frontend/blob/52180243955ffcf3ce6e03a346ab2fb55aebe29b/src/components/graph/GraphCanvas.vue#L222-L236