### PR TITLE
Use scrollbars in context menu

### DIFF
--- a/public/css/litegraph.css
+++ b/public/css/litegraph.css
@@ -24,6 +24,16 @@
   box-shadow: 0 0 10px black !important;
   background-color: #2e2e2e !important;
   z-index: 10;
+  max-height: -webkit-fill-available;
+  overflow-y: auto;
+}
+
+/* Enable scrolling overflow in Firefox */
+@supports not (max-height: -webkit-fill-available) {
+  .litegraph.litecontextmenu {
+    max-height: 80vh;
+    overflow-y: scroll;
+  }
 }
 
 .litegraph.litecontextmenu.dark {

--- a/src/ContextMenu.ts
+++ b/src/ContextMenu.ts
@@ -115,19 +115,6 @@ export class ContextMenu {
       true,
     )
 
-    function on_mouse_wheel(e: WheelEvent) {
-      const pos = parseInt(root.style.top)
-      root.style.top = (pos + e.deltaY * options.scroll_speed).toFixed() + "px"
-      e.preventDefault()
-      return true
-    }
-
-    if (!options.scroll_speed) {
-      options.scroll_speed = 0.1
-    }
-
-    root.addEventListener("wheel", on_mouse_wheel, true)
-
     this.root = root
 
     // title

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -269,6 +269,7 @@ export interface IContextMenuOptions extends IContextMenuBase {
   parentMenu?: ContextMenu
   event?: MouseEvent
   extra?: unknown
+  /** @deprecated Context menu scrolling is now controlled by the browser */
   scroll_speed?: number
   left?: number
   top?: number


### PR DESCRIPTION
Replaces manual scroll logic in context menu with native browser scrolling via CSS properties.


![Selection_684](https://github.com/user-attachments/assets/f28b40f7-c6c2-40a5-a223-c8fc65c2c06d)


This feature has been requested many times, for example:

- https://github.com/Comfy-Org/ComfyUI_frontend/issues/102
- https://github.com/comfyanonymous/ComfyUI/issues/6162
- https://github.com/comfyanonymous/ComfyUI/issues/4193
- https://github.com/comfyanonymous/ComfyUI/issues/144

According to code search, [this](https://github.com/OgreLemonSoup/ComfyUI-Load-Image-Gallery/blob/772819f29c5129836c287038735c542010246c02/js/LoadImageGallery.js) is the only instance of someone using `scroll_speed` and this change would not significantly affect that.

[invertMenuScrolling.ts](https://github.com/Comfy-Org/ComfyUI_frontend/blob/9c1eacf0afa359eeb6ab03dd7fbfc10e9fe46f3c/src/extensions/core/invertMenuScrolling.ts#L4) will have to be changed to manually invert scrolling, otherwise the setting must be removed.

I have tested on:

- Firefox
- Brave, Opera, Chrome
- Edge for Linux


Please advise if there are any side effects or scenarios that should be considered or if you think both scrolling behaviors should be available so as to be chosen by the user.

