### PR TITLE
Fix canvas stuck in dragging state after using Pan Mode 

### DIFF
--- a/src/LGraphCanvas.ts
+++ b/src/LGraphCanvas.ts
@@ -3501,7 +3501,7 @@ export class LGraphCanvas {
       if (e.keyCode == 32) {
         // space
         this.read_only = false
-        this.dragging_canvas = this._previously_dragging_canvas && this.pointer.isDown ?? false
+        this.dragging_canvas = (this._previously_dragging_canvas ?? false) && this.pointer.isDown
         this._previously_dragging_canvas = null
       }
 

--- a/src/LGraphCanvas.ts
+++ b/src/LGraphCanvas.ts
@@ -3501,7 +3501,7 @@ export class LGraphCanvas {
       if (e.keyCode == 32) {
         // space
         this.read_only = false
-        this.dragging_canvas = this._previously_dragging_canvas ?? false
+        this.dragging_canvas = this._previously_dragging_canvas && this.pointer.isDown
         this._previously_dragging_canvas = null
       }
 

--- a/src/LGraphCanvas.ts
+++ b/src/LGraphCanvas.ts
@@ -3501,7 +3501,7 @@ export class LGraphCanvas {
       if (e.keyCode == 32) {
         // space
         this.read_only = false
-        this.dragging_canvas = this._previously_dragging_canvas && this.pointer.isDown
+        this.dragging_canvas = this._previously_dragging_canvas && this.pointer.isDown ?? false
         this._previously_dragging_canvas = null
       }
 


### PR DESCRIPTION
Fixes issue in which the canvas is left in a dragging state after using Pan Mode. `dragging_canvas` is set to false by the pointer cleanup but `_previously_dragging_canvas` is then `true` when the spacebar keyup occurs.

To reproduce issue:

1. Click (hold)
2. Space (hold)
3. Release click
4. Release space
5. Move mouse