### PR TITLE
Allow resizing node from any corner

### DIFF
--- a/API.md
+++ b/API.md
@@ -185,7 +185,7 @@ type LGraphCanvasState = {
 canvas.state.shouldSetCursor = false
 
 // Checking state - bit operators
-if (canvas.state.hoveringOver & CanvasItem.ResizeSe) element.style.cursor = 'se-resize'
+if (canvas.state.hoveringOver & CanvasItem.ResizeNwSe) element.style.cursor = 'nwse-resize'
 ```
 
 </detail>

--- a/src/LGraphCanvas.ts
+++ b/src/LGraphCanvas.ts
@@ -2429,6 +2429,9 @@ export class LGraphCanvas {
             }
             }
 
+            snapPoint(newPos, this.#snapToGrid)
+            snapPoint(newSize, this.#snapToGrid)
+
             const minSize = node.computeSize()
             if (newSize[0] < minSize[0]) {
               const diff = minSize[0] - newSize[0]

--- a/src/LGraphCanvas.ts
+++ b/src/LGraphCanvas.ts
@@ -2357,7 +2357,8 @@ export class LGraphCanvas {
         node.collapse()
         this.setDirty(true, true)
       }
-    } else if (!node.flags.collapsed) {
+    }
+    if (!node.flags.collapsed) {
       // Resize node
       if (node.resizable !== false) {
         const corner = node.getResizeCorner(x, y)
@@ -3133,7 +3134,7 @@ export class LGraphCanvas {
 
         // Resize corner
         const corner = node.getResizeCorner(e.canvasX, e.canvasY)
-        if (corner) {
+        if (corner && !node.flags.collapsed) {
           switch (corner) {
           case ResizeCorner.TopLeft:
           case ResizeCorner.BottomRight:
@@ -3160,7 +3161,8 @@ export class LGraphCanvas {
             group &&
             !e.ctrlKey &&
             !this.read_only &&
-            group.isInResize(e.canvasX, e.canvasY)
+            group.isInResize(e.canvasX, e.canvasY) &&
+            !node.flags.collapsed
           ) {
             underPointer |= CanvasItem.ResizeNwSe
           }
@@ -3193,7 +3195,7 @@ export class LGraphCanvas {
         this.#dirty()
       }
 
-      if (this.resizing_node) {
+      if (this.resizing_node && !node.flags.collapsed) {
         switch (this.resizing_corner) {
         case ResizeCorner.TopLeft:
         case ResizeCorner.BottomRight:

--- a/src/LGraphNode.ts
+++ b/src/LGraphNode.ts
@@ -26,6 +26,7 @@ import {
   NodeSlotType,
   TitleMode,
   RenderShape,
+  ResizeCorner,
 } from "./types/globalEnums"
 import { BadgePosition, LGraphBadge } from "./LGraphBadge"
 import { type LGraphNodeConstructor, LiteGraph } from "./litegraph"
@@ -1482,17 +1483,41 @@ export class LGraphNode implements Positionable, IPinnable {
     return size
   }
 
-  inResizeCorner(canvasX: number, canvasY: number): boolean {
+  getResizeCorner(canvasX: number, canvasY: number): ResizeCorner | null {
     const rows = this.outputs ? this.outputs.length : 1
     const outputs_offset = (this.constructor.slot_start_y || 0) + rows * LiteGraph.NODE_SLOT_HEIGHT
-    return isInRectangle(
-      canvasX,
-      canvasY,
-      this.pos[0] + this.size[0] - 15,
-      this.pos[1] + Math.max(this.size[1] - 15, outputs_offset),
-      20,
-      20,
-    )
+    const minHeight = Math.max(this.size[1], outputs_offset)
+
+    const corners = [
+      {
+        corner: ResizeCorner.TopLeft,
+        x: this.pos[0],
+        y: this.pos[1],
+      },
+      {
+        corner: ResizeCorner.TopRight,
+        x: this.pos[0] + this.size[0] - 20,
+        y: this.pos[1],
+      },
+      {
+        corner: ResizeCorner.BottomLeft,
+        x: this.pos[0],
+        y: this.pos[1] + minHeight - 20,
+      },
+      {
+        corner: ResizeCorner.BottomRight,
+        x: this.pos[0] + this.size[0] - 20,
+        y: this.pos[1] + minHeight - 20,
+      },
+    ]
+
+    for (const corner of corners) {
+      if (isInRectangle(canvasX, canvasY, corner.x, corner.y, 20, 20)) {
+        return corner.corner
+      }
+    }
+
+    return null
   }
 
   /**

--- a/src/LGraphNode.ts
+++ b/src/LGraphNode.ts
@@ -1486,7 +1486,7 @@ export class LGraphNode implements Positionable, IPinnable {
   getResizeCorner(canvasX: number, canvasY: number): ResizeCorner | null {
     const rows = this.outputs ? this.outputs.length : 1
     const outputs_offset = (this.constructor.slot_start_y || 0) + rows * LiteGraph.NODE_SLOT_HEIGHT
-    const minHeight = Math.max(this.size[1], outputs_offset)
+    const minHeight = Math.max(this.size[1] - 15, outputs_offset)
 
     const corners = [
       {
@@ -1496,18 +1496,18 @@ export class LGraphNode implements Positionable, IPinnable {
       },
       {
         corner: ResizeCorner.TopRight,
-        x: this.pos[0] + this.size[0] - 20,
+        x: this.pos[0] + this.size[0] - 15,
         y: this.pos[1],
       },
       {
         corner: ResizeCorner.BottomLeft,
         x: this.pos[0],
-        y: this.pos[1] + minHeight - 20,
+        y: this.pos[1] + minHeight,
       },
       {
         corner: ResizeCorner.BottomRight,
-        x: this.pos[0] + this.size[0] - 20,
-        y: this.pos[1] + minHeight - 20,
+        x: this.pos[0] + this.size[0] - 15,
+        y: this.pos[1] + minHeight,
       },
     ]
 

--- a/src/LGraphNode.ts
+++ b/src/LGraphNode.ts
@@ -1492,12 +1492,12 @@ export class LGraphNode implements Positionable, IPinnable {
       {
         corner: ResizeCorner.TopLeft,
         x: this.pos[0],
-        y: this.pos[1],
+        y: this.pos[1] - LiteGraph.NODE_TITLE_HEIGHT,
       },
       {
         corner: ResizeCorner.TopRight,
         x: this.pos[0] + this.size[0] - 15,
-        y: this.pos[1],
+        y: this.pos[1] - LiteGraph.NODE_TITLE_HEIGHT,
       },
       {
         corner: ResizeCorner.BottomLeft,

--- a/src/types/globalEnums.ts
+++ b/src/types/globalEnums.ts
@@ -34,8 +34,10 @@ export enum CanvasItem {
   Reroute = 1 << 2,
   /** The path of a link */
   Link = 1 << 3,
-  /** A resize in the bottom-right corner */
-  ResizeSe = 1 << 4,
+  /** A resize in the top-left or bottom-right corner */
+  ResizeNwSe = 1 << 4,
+  /** A resize in the top-right or bottom-left corner */
+  ResizeNeSw = 1 << 5,
 }
 
 /** The direction that a link point will flow towards - e.g. horizontal outputs are right by default */
@@ -89,4 +91,11 @@ export enum EaseFunction {
   EASE_IN_QUAD = "easeInQuad",
   EASE_OUT_QUAD = "easeOutQuad",
   EASE_IN_OUT_QUAD = "easeInOutQuad",
+}
+
+export enum ResizeCorner {
+  TopLeft = 1,
+  TopRight = 2,
+  BottomLeft = 3,
+  BottomRight = 4,
 }


### PR DESCRIPTION
Other than the top left and right corners causing a slight bump in size after initial cursor movement that should be investigated, this seems to work.

Not familiar with how to address and/or adjust the frontend tests currently.