### PR TITLE
Remove scaling of context menus

### DIFF
--- a/src/ContextMenu.ts
+++ b/src/ContextMenu.ts
@@ -180,8 +180,6 @@ export class ContextMenu {
 
     root.style.left = left + "px"
     root.style.top = top + "px"
-
-    if (options.scale) root.style.transform = `scale(${Math.round(options.scale * 4) * 0.25})`
   }
 
   addItem(


### PR DESCRIPTION
Fixes https://github.com/Comfy-Org/ComfyUI_frontend/issues/2358.

Currently, context menus are scaled based on the Litegraph scale (`app.graph.extra.ds.scale`) using CSS transform. This PR removes the scaling behavior, meaning the menus will no longer change size based on how zoomed in or out the graph is. However, users can still adjust the menu size through browser zoom, like other menus.

Alternatives:

- Maintain the current scaling, manually calculate height in js, subscribe to resizes. However, there are compatability issues with `transform` such as incorrect rendering of the browser scrollbar.
- Use the Litegraph scale to individually resize context menu components via properties other than `transform`
- Revert https://github.com/Comfy-Org/ComfyUI_frontend/issues/2358, remove scrollbars and go back to manual scrolling implementation

I think it is preferable to not rely on `transform` when possible, as supporting it introduces unnecessary complexity and leads to less maintainable code.
