### PR TITLE
[Refactor] Move strokeShape from LGraphCanvas to draw

### DIFF
--- a/src/LGraphCanvas.ts
+++ b/src/LGraphCanvas.ts
@@ -56,7 +56,7 @@ import {
   isInRect,
   snapPoint,
 } from "./measure"
-import { drawSlot, LabelPosition } from "./draw"
+import { drawSlot, LabelPosition, strokeShape } from "./draw"
 import { DragAndScale } from "./DragAndScale"
 import { LinkReleaseContextExtended, LiteGraph, clamp } from "./litegraph"
 import { stringOrEmpty, stringOrNull } from "./strings"
@@ -130,16 +130,6 @@ interface IDialogOptions {
   checkForInput?: boolean
   closeOnLeave?: boolean
   onclose?(): void
-}
-
-interface IDrawSelectionBoundingOptions {
-  shape?: RenderShape
-  title_height?: number
-  title_mode?: TitleMode
-  colour?: CanvasColour
-  padding?: number
-  collapsed?: boolean
-  thickness?: number
 }
 
 /** @inheritdoc {@link LGraphCanvas.state} */
@@ -5200,7 +5190,7 @@ export class LGraphCanvas {
     ctx.fill()
 
     if (node.has_errors && !LiteGraph.use_legacy_node_error_indicator) {
-      this.strokeShape(ctx, area, {
+      strokeShape(ctx, area, {
         shape,
         title_mode,
         title_height,
@@ -5411,7 +5401,7 @@ export class LGraphCanvas {
 
       const padding = node.has_errors && !LiteGraph.use_legacy_node_error_indicator ? 20 : undefined
 
-      this.strokeShape(ctx, area, {
+      strokeShape(ctx, area, {
         shape,
         title_height,
         title_mode,
@@ -5423,94 +5413,6 @@ export class LGraphCanvas {
     // these counter helps in conditioning drawing based on if the node has been executed or an action occurred
     if (node.execute_triggered > 0) node.execute_triggered--
     if (node.action_triggered > 0) node.action_triggered--
-  }
-
-  /**
-   * Draws only the path of a shape on the canvas, without filling.
-   * Used to draw indicators for node status, e.g. "selected".
-   * @param ctx The 2D context to draw on
-   * @param area The position and size of the shape to render
-   */
-  strokeShape(
-    ctx: CanvasRenderingContext2D,
-    area: Rect,
-    {
-      /** The shape to render */
-      shape = RenderShape.BOX,
-      /** Shape will extend above the Y-axis 0 by this amount */
-      title_height = LiteGraph.NODE_TITLE_HEIGHT,
-      /** @deprecated This is node-specific: it should be removed entirely, and behaviour defined by the caller more explicitly */
-      title_mode = TitleMode.NORMAL_TITLE,
-      /** The colour that should be drawn */
-      colour = LiteGraph.NODE_BOX_OUTLINE_COLOR,
-      /** The distance between the edge of the {@link area} and the middle of the line */
-      padding = 6,
-      /** @deprecated This is node-specific: it should be removed entirely, and behaviour defined by the caller more explicitly */
-      collapsed = false,
-      /** Thickness of the line drawn (`lineWidth`) */
-      thickness = 1,
-    }: IDrawSelectionBoundingOptions = {},
-  ): void {
-    // Adjust area if title is transparent
-    if (title_mode === TitleMode.TRANSPARENT_TITLE) {
-      area[1] -= title_height
-      area[3] += title_height
-    }
-
-    // Set up context
-    const { lineWidth, strokeStyle } = ctx
-    ctx.lineWidth = thickness
-    ctx.globalAlpha = 0.8
-    ctx.strokeStyle = colour
-    ctx.beginPath()
-
-    // Draw shape based on type
-    const [x, y, width, height] = area
-    switch (shape) {
-    case RenderShape.BOX: {
-      ctx.rect(
-        x - padding,
-        y - padding,
-        width + 2 * padding,
-        height + 2 * padding,
-      )
-      break
-    }
-    case RenderShape.ROUND:
-    case RenderShape.CARD: {
-      const radius = this.round_radius + padding
-      const isCollapsed = shape === RenderShape.CARD && collapsed
-      const cornerRadii =
-          isCollapsed || shape === RenderShape.ROUND
-            ? [radius]
-            : [radius, 2, radius, 2]
-      ctx.roundRect(
-        x - padding,
-        y - padding,
-        width + 2 * padding,
-        height + 2 * padding,
-        cornerRadii,
-      )
-      break
-    }
-    case RenderShape.CIRCLE: {
-      const centerX = x + width / 2
-      const centerY = y + height / 2
-      const radius = Math.max(width, height) / 2 + padding
-      ctx.arc(centerX, centerY, radius, 0, Math.PI * 2)
-      break
-    }
-    }
-
-    // Stroke the shape
-    ctx.stroke()
-
-    // Reset context
-    ctx.lineWidth = lineWidth
-    ctx.strokeStyle = strokeStyle
-
-    // TODO: Store and reset value properly.  Callers currently expect this behaviour (e.g. muted nodes).
-    ctx.globalAlpha = 1
   }
 
   /**

--- a/src/LGraphCanvas.ts
+++ b/src/LGraphCanvas.ts
@@ -303,6 +303,13 @@ export class LGraphCanvas {
     this.#maximumFrameGap = value > Number.EPSILON ? 1000 / value : 0
   }
 
+  /**
+   * @deprecated Use {@link LiteGraphGlobal.ROUND_RADIUS} instead.
+   */
+  get round_radius() {
+    return LiteGraph.ROUND_RADIUS
+  }
+
   options: {
     skip_events?: any
     viewport?: any
@@ -378,7 +385,6 @@ export class LGraphCanvas {
   /** to render foreground objects (above nodes and connections) in the canvas affected by transform */
   onDrawForeground?: (arg0: CanvasRenderingContext2D, arg1: any) => void
   connections_width: number
-  round_radius: number
   /** The current node being drawn by {@link drawNode}.  This should NOT be used to determine the currently selected node.  See {@link selectedItems} */
   current_node: LGraphNode | null
   /** used for widgets */
@@ -618,7 +624,6 @@ export class LGraphCanvas {
     this.onAfterChange = null
 
     this.connections_width = 3
-    this.round_radius = 8
 
     this.current_node = null
     this.node_widget = null
@@ -4524,7 +4529,7 @@ export class LGraphCanvas {
 
     const area = node.boundingRect
     const gap = 3
-    const radius = this.round_radius + gap
+    const radius = LiteGraph.ROUND_RADIUS + gap
 
     const x = area[0] - gap
     const y = area[1] - gap
@@ -5181,8 +5186,8 @@ export class LGraphCanvas {
         area[2],
         area[3],
         shape == RenderShape.CARD
-          ? [this.round_radius, this.round_radius, 0, 0]
-          : [this.round_radius],
+          ? [LiteGraph.ROUND_RADIUS, LiteGraph.ROUND_RADIUS, 0, 0]
+          : [LiteGraph.ROUND_RADIUS],
       )
     } else if (shape == RenderShape.CIRCLE) {
       ctx.arc(size[0] * 0.5, size[1] * 0.5, size[0] * 0.5, 0, Math.PI * 2)
@@ -5237,8 +5242,8 @@ export class LGraphCanvas {
             size[0],
             title_height,
             collapsed
-              ? [this.round_radius]
-              : [this.round_radius, this.round_radius, 0, 0],
+              ? [LiteGraph.ROUND_RADIUS]
+              : [LiteGraph.ROUND_RADIUS, LiteGraph.ROUND_RADIUS, 0, 0],
           )
         }
         ctx.fill()

--- a/src/LGraphCanvas.ts
+++ b/src/LGraphCanvas.ts
@@ -310,6 +310,13 @@ export class LGraphCanvas {
     return LiteGraph.ROUND_RADIUS
   }
 
+  /**
+   * @deprecated Use {@link LiteGraphGlobal.ROUND_RADIUS} instead.
+   */
+  set round_radius(value: number) {
+    LiteGraph.ROUND_RADIUS = value
+  }
+
   options: {
     skip_events?: any
     viewport?: any

--- a/src/LGraphGroup.ts
+++ b/src/LGraphGroup.ts
@@ -18,7 +18,7 @@ import {
   snapPoint,
 } from "./measure"
 import { LGraphNode } from "./LGraphNode"
-import { RenderShape, TitleMode } from "./types/globalEnums"
+import { strokeShape } from "./draw"
 
 export interface IGraphGroupFlags extends Record<string, unknown> {
   pinned?: true
@@ -183,7 +183,7 @@ export class LGraphGroup implements Positionable, IPinnable {
     ctx.fillText(this.title + (this.pinned ? "📌" : ""), x + padding, y + font_size)
 
     if (LiteGraph.highlight_selected_group && this.selected) {
-      graphCanvas.strokeShape(ctx, this._bounding, {
+      strokeShape(ctx, this._bounding, {
         title_height: this.titleHeight,
         padding,
       })

--- a/src/LiteGraphGlobal.ts
+++ b/src/LiteGraphGlobal.ts
@@ -76,6 +76,7 @@ export class LiteGraphGlobal {
   DEFAULT_POSITION = [100, 100]
   /** ,"circle" */
   VALID_SHAPES = ["default", "box", "round", "card"]
+  ROUND_RADIUS = 8
 
   // shapes are used for nodes but also for slots
   BOX_SHAPE = RenderShape.BOX

--- a/src/draw.ts
+++ b/src/draw.ts
@@ -1,6 +1,6 @@
-import type { Vector2 } from "./litegraph"
-import type { INodeSlot } from "./interfaces"
-import { LinkDirection, RenderShape } from "./types/globalEnums"
+import { LiteGraph, type Vector2 } from "./litegraph"
+import type { CanvasColour, INodeSlot, Rect } from "./interfaces"
+import { LinkDirection, RenderShape, TitleMode } from "./types/globalEnums"
 
 export enum SlotType {
   Array = "array",
@@ -142,4 +142,102 @@ export function drawSlot(
   ctx.fillStyle = originalFillStyle
   ctx.strokeStyle = originalStrokeStyle
   ctx.lineWidth = originalLineWidth
+}
+
+interface IDrawSelectionBoundingOptions {
+  shape?: RenderShape
+  title_height?: number
+  title_mode?: TitleMode
+  colour?: CanvasColour
+  padding?: number
+  collapsed?: boolean
+  thickness?: number
+}
+
+/**
+ * Draws only the path of a shape on the canvas, without filling.
+ * Used to draw indicators for node status, e.g. "selected".
+ * @param ctx The 2D context to draw on
+ * @param area The position and size of the shape to render
+ */
+export function strokeShape(
+  ctx: CanvasRenderingContext2D,
+  area: Rect,
+  {
+    /** The shape to render */
+    shape = RenderShape.BOX,
+    /** Shape will extend above the Y-axis 0 by this amount */
+    title_height = LiteGraph.NODE_TITLE_HEIGHT,
+    /** @deprecated This is node-specific: it should be removed entirely, and behaviour defined by the caller more explicitly */
+    title_mode = TitleMode.NORMAL_TITLE,
+    /** The colour that should be drawn */
+    colour = LiteGraph.NODE_BOX_OUTLINE_COLOR,
+    /** The distance between the edge of the {@link area} and the middle of the line */
+    padding = 6,
+    /** @deprecated This is node-specific: it should be removed entirely, and behaviour defined by the caller more explicitly */
+    collapsed = false,
+    /** Thickness of the line drawn (`lineWidth`) */
+    thickness = 1,
+  }: IDrawSelectionBoundingOptions = {},
+): void {
+  // Adjust area if title is transparent
+  if (title_mode === TitleMode.TRANSPARENT_TITLE) {
+    area[1] -= title_height
+    area[3] += title_height
+  }
+
+  // Set up context
+  const { lineWidth, strokeStyle } = ctx
+  ctx.lineWidth = thickness
+  ctx.globalAlpha = 0.8
+  ctx.strokeStyle = colour
+  ctx.beginPath()
+
+  // Draw shape based on type
+  const [x, y, width, height] = area
+  switch (shape) {
+  case RenderShape.BOX: {
+    ctx.rect(
+      x - padding,
+      y - padding,
+      width + 2 * padding,
+      height + 2 * padding,
+    )
+    break
+  }
+  case RenderShape.ROUND:
+  case RenderShape.CARD: {
+    const radius = this.round_radius + padding
+    const isCollapsed = shape === RenderShape.CARD && collapsed
+    const cornerRadii =
+        isCollapsed || shape === RenderShape.ROUND
+          ? [radius]
+          : [radius, 2, radius, 2]
+    ctx.roundRect(
+      x - padding,
+      y - padding,
+      width + 2 * padding,
+      height + 2 * padding,
+      cornerRadii,
+    )
+    break
+  }
+  case RenderShape.CIRCLE: {
+    const centerX = x + width / 2
+    const centerY = y + height / 2
+    const radius = Math.max(width, height) / 2 + padding
+    ctx.arc(centerX, centerY, radius, 0, Math.PI * 2)
+    break
+  }
+  }
+
+  // Stroke the shape
+  ctx.stroke()
+
+  // Reset context
+  ctx.lineWidth = lineWidth
+  ctx.strokeStyle = strokeStyle
+
+  // TODO: Store and reset value properly.  Callers currently expect this behaviour (e.g. muted nodes).
+  ctx.globalAlpha = 1
 }

--- a/src/draw.ts
+++ b/src/draw.ts
@@ -146,6 +146,7 @@ export function drawSlot(
 
 interface IDrawSelectionBoundingOptions {
   shape?: RenderShape
+  round_radius?: number
   title_height?: number
   title_mode?: TitleMode
   colour?: CanvasColour
@@ -166,6 +167,8 @@ export function strokeShape(
   {
     /** The shape to render */
     shape = RenderShape.BOX,
+    /** The radius of the rounded corners for {@link RenderShape.ROUND} and {@link RenderShape.CARD} */
+    round_radius = LiteGraph.ROUND_RADIUS,
     /** Shape will extend above the Y-axis 0 by this amount */
     title_height = LiteGraph.NODE_TITLE_HEIGHT,
     /** @deprecated This is node-specific: it should be removed entirely, and behaviour defined by the caller more explicitly */
@@ -207,7 +210,7 @@ export function strokeShape(
   }
   case RenderShape.ROUND:
   case RenderShape.CARD: {
-    const radius = LiteGraph.ROUND_RADIUS + padding
+    const radius = round_radius + padding
     const isCollapsed = shape === RenderShape.CARD && collapsed
     const cornerRadii =
         isCollapsed || shape === RenderShape.ROUND

--- a/src/draw.ts
+++ b/src/draw.ts
@@ -207,7 +207,7 @@ export function strokeShape(
   }
   case RenderShape.ROUND:
   case RenderShape.CARD: {
-    const radius = this.round_radius + padding
+    const radius = LiteGraph.ROUND_RADIUS + padding
     const isCollapsed = shape === RenderShape.CARD && collapsed
     const cornerRadii =
         isCollapsed || shape === RenderShape.ROUND

--- a/src/litegraph.ts
+++ b/src/litegraph.ts
@@ -83,6 +83,7 @@ export type {
 export { CanvasPointer } from "./CanvasPointer"
 export { Reroute } from "./Reroute"
 export { createBounds } from "./measure"
+export { strokeShape } from "./draw"
 
 export function clamp(v: number, a: number, b: number): number {
   return a > v ? a : b < v ? b : v

--- a/test/__snapshots__/litegraph.test.ts.snap
+++ b/test/__snapshots__/litegraph.test.ts.snap
@@ -88,6 +88,7 @@ LiteGraphGlobal {
   "ON_TRIGGER": 3,
   "OUTPUT": 2,
   "RIGHT": 4,
+  "ROUND_RADIUS": 8,
   "ROUND_SHAPE": 2,
   "Reroute": [Function],
   "SPLINE_LINK": 2,


### PR DESCRIPTION
This PR:
- Deprecates `LGraphCanvas.round_radius`.
- Adds `LiteGraph.ROUND_RADIUS`.
- Moves strokeShape from LGraphCanvas to draw.