### PR TITLE
Fix LGraphNode.height

### DIFF
--- a/src/LGraphNode.ts
+++ b/src/LGraphNode.ts
@@ -2725,8 +2725,12 @@ export class LGraphNode implements Positionable, IPinnable {
       : this.size[0]
   }
 
+  /**
+   * Returns the height of the node, including the title bar.
+   */
   get height() {
-    return this.collapsed ? LiteGraph.NODE_TITLE_HEIGHT : this.size[1]
+    const bodyHeight = this.collapsed ? 0 : this.size[1]
+    return LiteGraph.NODE_TITLE_HEIGHT + bodyHeight
   }
 
   drawBadges(ctx: CanvasRenderingContext2D, { gap = 2 } = {}): void {

--- a/src/LGraphNode.ts
+++ b/src/LGraphNode.ts
@@ -2726,8 +2726,7 @@ export class LGraphNode implements Positionable, IPinnable {
   }
 
   get height() {
-    // @ts-expect-error Not impl.
-    return this.collapsed ? LiteGraph.NODE_COLLAPSED_HEIGHT : this.size[1]
+    return this.collapsed ? LiteGraph.NODE_TITLE_HEIGHT : this.size[1]
   }
 
   drawBadges(ctx: CanvasRenderingContext2D, { gap = 2 } = {}): void {


### PR DESCRIPTION
`LiteGraph.NODE_COLLAPSED_HEIGHT` is undefined. Currently there is no dependency on LGraphNode.height so it should be safe to make the change.
