### PR TITLE
Remove LGraphNode.supported_extensions

### DIFF
--- a/src/LGraphNode.ts
+++ b/src/LGraphNode.ts
@@ -143,7 +143,6 @@ export class LGraphNode implements Positionable, IPinnable {
   static MAX_CONSOLE?: number
   static type?: string
   static category?: string
-  static supported_extensions?: string[]
   static filter?: string
   static skip_list?: boolean
 

--- a/src/LiteGraphGlobal.ts
+++ b/src/LiteGraphGlobal.ts
@@ -360,16 +360,6 @@ export class LiteGraphGlobal {
         enumerable: true,
         configurable: true,
       })
-
-      // used to know which nodes to create when dragging files to the canvas
-      if (base_class.supported_extensions) {
-        for (const i in base_class.supported_extensions) {
-          const ext = base_class.supported_extensions[i]
-          if (ext && typeof ext === "string") {
-            this.node_types_by_file_extension[ext.toLowerCase()] = base_class
-          }
-        }
-      }
     }
 
     this.registered_node_types[type] = base_class


### PR DESCRIPTION
Code search shows there is no current usage of the field. https://cs.comfy.org/search?q=context%3Aglobal+supported_extensions&patternType=keyword&case=yes&sm=0&df=%5B%22lang%22%2C%22JavaScript%22%2C%22lang%3Ajavascript%22%5D&__cc=1

We might also want to remove `LiteGraph.node_types_by_file_extension` later as follow-up.