### PR TITLE
Remove unnecessary getter/setter register on LGraphNode.shape

### DIFF
--- a/src/LiteGraphGlobal.ts
+++ b/src/LiteGraphGlobal.ts
@@ -331,36 +331,6 @@ export class LiteGraphGlobal {
     if (prev) {
       console.log("replacing node type: " + type)
     }
-    if (!Object.prototype.hasOwnProperty.call(base_class.prototype, "shape")) {
-      Object.defineProperty(base_class.prototype, "shape", {
-        set(this: LGraphNode, v: RenderShape | "default" | "box" | "round" | "circle" | "card") {
-          switch (v) {
-          case "default":
-            delete this._shape
-            break
-          case "box":
-            this._shape = RenderShape.BOX
-            break
-          case "round":
-            this._shape = RenderShape.ROUND
-            break
-          case "circle":
-            this._shape = RenderShape.CIRCLE
-            break
-          case "card":
-            this._shape = RenderShape.CARD
-            break
-          default:
-            this._shape = v
-          }
-        },
-        get() {
-          return this._shape
-        },
-        enumerable: true,
-        configurable: true,
-      })
-    }
 
     this.registered_node_types[type] = base_class
     if (base_class.constructor.name) this.Nodes[classname] = base_class


### PR DESCRIPTION
The same logic is repeated here in https://github.com/Comfy-Org/litegraph.js/blob/610ebd6ffecbbda3d8fe90e19f8850467f5e7d87/src/LGraphNode.ts#L300-L324.

Any `base_node` that inherits `LGraphNode` should automatically get the setter and getter defined.