### PR TITLE
Revert "[Refactor] Move node title background draw logic to LGraphNode"

### DIFF
--- a/src/LGraphCanvas.ts
+++ b/src/LGraphCanvas.ts
@@ -5201,10 +5201,36 @@ export class LGraphCanvas {
 
     // Title bar background (remember, it is rendered ABOVE the node)
     if (render_title || title_mode == TitleMode.TRANSPARENT_TITLE) {
-      node.drawTitleBarBackground(ctx, {
-        scale: this.ds.scale,
-        low_quality,
-      })
+      if (node.onDrawTitleBar) {
+        node.onDrawTitleBar(ctx, title_height, size, this.ds.scale, fgcolor)
+      } else if (
+        title_mode !== TitleMode.TRANSPARENT_TITLE
+      ) {
+        const title_color = node.constructor.title_color || fgcolor
+
+        if (collapsed) {
+          ctx.shadowColor = LiteGraph.DEFAULT_SHADOW_COLOR
+        }
+
+        ctx.fillStyle = title_color
+        ctx.beginPath()
+
+        if (shape == RenderShape.BOX || low_quality) {
+          ctx.rect(0, -title_height, size[0], title_height)
+        } else if (shape == RenderShape.ROUND || shape == RenderShape.CARD) {
+          ctx.roundRect(
+            0,
+            -title_height,
+            size[0],
+            title_height,
+            collapsed
+              ? [LiteGraph.ROUND_RADIUS]
+              : [LiteGraph.ROUND_RADIUS, LiteGraph.ROUND_RADIUS, 0, 0],
+          )
+        }
+        ctx.fill()
+        ctx.shadowColor = "transparent"
+      }
 
       // title box
       const box_size = 10

--- a/src/LGraphNode.ts
+++ b/src/LGraphNode.ts
@@ -2799,57 +2799,6 @@ export class LGraphNode implements Positionable, IPinnable {
   }
 
   /**
-   * Renders the node's title bar background
-   */
-  drawTitleBarBackground(ctx: CanvasRenderingContext2D, options: {
-    scale: number
-    title_height?: number
-    low_quality?: boolean
-  }): void {
-    const {
-      scale,
-      title_height = LiteGraph.NODE_TITLE_HEIGHT,
-      low_quality = false,
-    } = options
-
-    const fgcolor = this.renderingColor
-    const shape = this.renderingShape
-    const size = this.size
-
-    if (this.onDrawTitleBar) {
-      this.onDrawTitleBar(ctx, title_height, size, scale, fgcolor)
-      return
-    }
-
-    if (this.title_mode === TitleMode.TRANSPARENT_TITLE) {
-      return
-    }
-
-    if (this.collapsed) {
-      ctx.shadowColor = LiteGraph.DEFAULT_SHADOW_COLOR
-    }
-
-    ctx.fillStyle = this.constructor.title_color || fgcolor
-    ctx.beginPath()
-
-    if (shape == RenderShape.BOX || low_quality) {
-      ctx.rect(0, -title_height, size[0], title_height)
-    } else if (shape == RenderShape.ROUND || shape == RenderShape.CARD) {
-      ctx.roundRect(
-        0,
-        -title_height,
-        size[0],
-        title_height,
-        this.collapsed
-          ? [LiteGraph.ROUND_RADIUS]
-          : [LiteGraph.ROUND_RADIUS, LiteGraph.ROUND_RADIUS, 0, 0],
-      )
-    }
-    ctx.fill()
-    ctx.shadowColor = "transparent"
-  }
-
-  /**
    * Attempts to gracefully bypass this node in all of its connections by reconnecting all links.
    *
    * Each input is checked against each output.  This is done on a matching index basis, i.e. input 3 -> output 3.


### PR DESCRIPTION
Reverts Comfy-Org/litegraph.js#452

Reason:
Fails playwright test

Expected:
![image](https://github.com/user-attachments/assets/faa6a872-5d80-40cb-9c43-0352de5b933f)

Actual:
![image](https://github.com/user-attachments/assets/13149777-4f08-4bc7-9ca5-1268afc323c7)
