### PR TITLE
Simplify LGraphNode.onDrawBackground signature

### DIFF
--- a/src/LGraphCanvas.ts
+++ b/src/LGraphCanvas.ts
@@ -5174,7 +5174,7 @@ export class LGraphCanvas {
     }
     ctx.shadowColor = "transparent"
 
-    node.onDrawBackground?.(ctx, this, this.canvas, this.graph_mouse)
+    node.onDrawBackground?.(ctx)
 
     // Title bar background (remember, it is rendered ABOVE the node)
     if (render_title || title_mode == TitleMode.TRANSPARENT_TITLE) {

--- a/src/LGraphNode.ts
+++ b/src/LGraphNode.ts
@@ -411,9 +411,6 @@ export class LGraphNode implements Positionable, IPinnable {
   onDrawBackground?(
     this: LGraphNode,
     ctx: CanvasRenderingContext2D,
-    canvas: LGraphCanvas,
-    canvasElement: HTMLCanvasElement,
-    mousePosition: Point,
   ): void
   onNodeCreated?(this: LGraphNode): void
   /**


### PR DESCRIPTION
Based on codesearch result: https://cs.comfy.org/search?q=onDrawBackground+&patternType=keyword&sm=0&df=%5B%22lang%22%2C%22JavaScript%22%2C%22lang%3Ajavascript%22%5D&__cc=1, there is no real usage of extra params after the rendering context.