### PR TITLE
[Major] Split layout and draw of LGraphNode (Part1)

### DIFF
--- a/src/LGraphCanvas.ts
+++ b/src/LGraphCanvas.ts
@@ -68,6 +68,7 @@ import { CanvasPointer } from "./CanvasPointer"
 import { toClass } from "./utils/type"
 import { type ConnectionColorContext } from "./NodeSlot"
 import { WIDGET_TYPE_MAP } from "./widgets/widgetMap"
+import type { NodeLayout } from "./types/layout"
 
 interface IShowSearchOptions {
   node_to?: LGraphNode
@@ -4698,17 +4699,25 @@ export class LGraphCanvas implements ConnectionColorContext {
 
     // render inputs and outputs
     if (!node.collapsed) {
-      const max_y = node.drawSlots(ctx, {
-        colorContext: this,
+      const layout = node.computeLayout({
         connectingLink: this.connecting_links?.[0],
+      })
+      node.drawSlots(ctx, {
+        layoutSlots: layout.inputSlots,
+        colorContext: this,
         editorAlpha: this.editor_alpha,
         lowQuality: this.low_quality,
       })
-
+      node.drawSlots(ctx, {
+        layoutSlots: layout.outputSlots,
+        colorContext: this,
+        editorAlpha: this.editor_alpha,
+        lowQuality: this.low_quality,
+      })
       ctx.textAlign = "left"
       ctx.globalAlpha = 1
 
-      this.drawNodeWidgets(node, max_y, ctx)
+      this.drawNodeWidgets(node, 0, ctx, layout.widgets)
     } else if (this.render_collapsed_slots) {
       node.drawCollapsedSlots(ctx)
     }
@@ -5555,9 +5564,10 @@ export class LGraphCanvas implements ConnectionColorContext {
     node: LGraphNode,
     posY: number,
     ctx: CanvasRenderingContext2D,
+    layoutWidgets: NodeLayout["widgets"],
   ): void {
     node.drawWidgets(ctx, {
-      y: posY,
+      layoutWidgets,
       colorContext: this,
       linkOverWidget: this.link_over_widget,
       linkOverWidgetType: this.link_over_widget_type,

--- a/src/types/layout.ts
+++ b/src/types/layout.ts
@@ -1,0 +1,60 @@
+import type { IWidget } from "@/types/widgets"
+import type { NodeInputSlot, NodeOutputSlot } from "@/NodeSlot"
+
+export interface LayoutPoint {
+  x: number
+  y: number
+}
+
+export interface LayoutSize {
+  width: number
+  height: number
+}
+
+export interface LayoutRect extends LayoutPoint, LayoutSize { }
+
+/** Represents the visual state of an element */
+export interface VisualState {
+  invalid?: boolean
+  highlight?: boolean
+  selected?: boolean
+  active?: boolean
+  visible?: boolean
+  alpha?: number
+  disabled?: boolean
+}
+
+/** Represents a single visual element's layout information */
+export interface ElementLayout<T = any> extends LayoutRect, VisualState {
+  /** Identifies the type of element (e.g., 'slot', 'widget', 'title') */
+  type: string
+  /** Optional identifier for the element */
+  id?: string | number
+  /** Additional element-specific data */
+  data?: T
+}
+
+/** Collection of layouts for a group of related elements */
+export interface ElementGroupLayout<T = any> {
+  elements: ElementLayout<T>[]
+  /** Bounding box containing all elements in the group */
+  bounds: LayoutRect
+}
+
+/** Complete layout information for a node */
+export interface NodeLayout {
+  // Core elements
+  /** Overall bounding box of the node */
+  bounds: LayoutRect
+
+  // Grouped elements
+  /** Input slots of the node */
+  inputSlots: ElementGroupLayout<NodeInputSlot>
+  /** Output slots of the node */
+  outputSlots: ElementGroupLayout<NodeOutputSlot>
+  /** Widgets of the node */
+  widgets: ElementGroupLayout<IWidget>
+
+  // Custom sections can be added as needed
+  [key: string]: ElementGroupLayout | ElementLayout | LayoutRect | undefined
+}

--- a/src/utils/layout.ts
+++ b/src/utils/layout.ts
@@ -1,0 +1,19 @@
+import type { LayoutRect } from "../types/layout"
+
+export function computeBounds(elements: LayoutRect[]): LayoutRect {
+  if (elements.length === 0) {
+    return { x: 0, y: 0, width: 0, height: 0 }
+  }
+
+  const minX = Math.min(...elements.map(e => e.x))
+  const minY = Math.min(...elements.map(e => e.y))
+  const maxX = Math.max(...elements.map(e => e.x + e.width))
+  const maxY = Math.max(...elements.map(e => e.y + e.height))
+
+  return {
+    x: minX,
+    y: minY,
+    width: maxX - minX,
+    height: maxY - minY,
+  }
+}


### PR DESCRIPTION
Splits layout and draw of LGraphNode.

This PR splits the layout and draw of LGraphNode so we can perform layout operations easier. Also this would help us better handle which element should interact with the cursor.