### PR TITLE
Split layout and draw for slots

### DIFF
--- a/src/LGraphCanvas.ts
+++ b/src/LGraphCanvas.ts
@@ -4672,10 +4672,9 @@ export class LGraphCanvas implements ConnectionColorContext {
 
     // render inputs and outputs
     if (!node.collapsed) {
-      node.layoutSlots({
-        connectingLink: this.connecting_links?.[0],
-      })
+      node.layoutSlots()
       node.drawSlots(ctx, {
+        connectingLink: this.connecting_links?.[0],
         colorContext: this,
         editorAlpha: this.editor_alpha,
         lowQuality: this.low_quality,

--- a/src/LGraphCanvas.ts
+++ b/src/LGraphCanvas.ts
@@ -4672,9 +4672,11 @@ export class LGraphCanvas implements ConnectionColorContext {
 
     // render inputs and outputs
     if (!node.collapsed) {
-      const max_y = node.drawSlots(ctx, {
-        colorContext: this,
+      node.layoutSlots({
         connectingLink: this.connecting_links?.[0],
+      })
+      node.drawSlots(ctx, {
+        colorContext: this,
         editorAlpha: this.editor_alpha,
         lowQuality: this.low_quality,
       })
@@ -4682,6 +4684,11 @@ export class LGraphCanvas implements ConnectionColorContext {
       ctx.textAlign = "left"
       ctx.globalAlpha = 1
 
+      const slotsBounds = createBounds(
+        node.slots.map(slot => slot._layoutElement),
+        /** padding= */ 0,
+      )
+      const max_y = slotsBounds ? slotsBounds[1] + slotsBounds[3] : 0
       this.drawNodeWidgets(node, max_y, ctx)
     } else if (this.render_collapsed_slots) {
       node.drawCollapsedSlots(ctx)

--- a/src/LGraphNode.ts
+++ b/src/LGraphNode.ts
@@ -35,7 +35,7 @@ import { BadgePosition, LGraphBadge } from "./LGraphBadge"
 import { type LGraphNodeConstructor, LiteGraph } from "./litegraph"
 import { isInRectangle, isInRect, snapPoint } from "./measure"
 import { LLink } from "./LLink"
-import { ConnectionColorContext, isINodeInputSlot, NodeInputSlot, NodeOutputSlot, serializeSlot } from "./NodeSlot"
+import { ConnectionColorContext, isINodeInputSlot, NodeInputSlot, NodeOutputSlot, serializeSlot, toNodeSlotClass } from "./NodeSlot"
 import { WIDGET_TYPE_MAP } from "./widgets/widgetMap"
 import { toClass } from "./utils/type"
 import { LayoutElement } from "./utils/layout"
@@ -3184,12 +3184,10 @@ export class LGraphNode implements Positionable, IPinnable {
   }): void {
     const { slotIndex } = options
     const isInput = isINodeInputSlot(slot)
-
-    const slotInstance = isInput ? toClass(NodeInputSlot, slot) : toClass(NodeOutputSlot, slot as INodeOutputSlot)
     const pos = this.getConnectionPos(isInput, slotIndex)
 
     slot._layoutElement = new LayoutElement({
-      value: slotInstance,
+      value: slot,
       boundingRect: [
         pos[0] - this.pos[0] - LiteGraph.NODE_SLOT_HEIGHT * 0.5,
         pos[1] - this.pos[1] - LiteGraph.NODE_SLOT_HEIGHT * 0.5,
@@ -3239,14 +3237,15 @@ export class LGraphNode implements Positionable, IPinnable {
     for (const slot of this.slots) {
       // change opacity of incompatible slots when dragging a connection
       const layoutElement = slot._layoutElement
-      const isValid = layoutElement.value.isValidTarget(connectingLink)
+      const slotInstance = toNodeSlotClass(slot)
+      const isValid = slotInstance.isValidTarget(connectingLink)
       const highlight = isValid && this.#isMouseOverSlot(slot)
       const labelColor = highlight
         ? this.highlightColor
         : LiteGraph.NODE_TEXT_COLOR
       ctx.globalAlpha = isValid ? editorAlpha : 0.4 * editorAlpha
 
-      layoutElement.value.draw(ctx, {
+      slotInstance.draw(ctx, {
         pos: layoutElement.center,
         colorContext,
         labelColor,

--- a/src/LGraphNode.ts
+++ b/src/LGraphNode.ts
@@ -3214,8 +3214,8 @@ export class LGraphNode implements Positionable, IPinnable {
 
   #getMouseOverSlot(slot: INodeSlot): INodeSlot | null {
     const isInput = isINodeInputSlot(slot)
-    const mouseOverId = this.mouseOver?.[isInput ? "inputId" : "outputId"]
-    if (!mouseOverId) {
+    const mouseOverId = this.mouseOver?.[isInput ? "inputId" : "outputId"] ?? -1
+    if (mouseOverId === -1) {
       return null
     }
     return isInput ? this.inputs[mouseOverId] : this.outputs[mouseOverId]

--- a/src/LGraphNode.ts
+++ b/src/LGraphNode.ts
@@ -35,7 +35,7 @@ import { BadgePosition, LGraphBadge } from "./LGraphBadge"
 import { type LGraphNodeConstructor, LiteGraph } from "./litegraph"
 import { isInRectangle, isInRect, snapPoint } from "./measure"
 import { LLink } from "./LLink"
-import { ConnectionColorContext, isINodeInputSlot, NodeInputSlot, NodeOutputSlot } from "./NodeSlot"
+import { ConnectionColorContext, isINodeInputSlot, NodeInputSlot, NodeOutputSlot, serializeSlot } from "./NodeSlot"
 import { WIDGET_TYPE_MAP } from "./widgets/widgetMap"
 import { toClass } from "./utils/type"
 import { LayoutElement } from "./utils/layout"
@@ -668,15 +668,8 @@ export class LGraphNode implements Positionable, IPinnable {
     if (this.constructor === LGraphNode && this.last_serialization)
       return this.last_serialization
 
-    if (this.inputs) o.inputs = this.inputs
-
-    if (this.outputs) {
-      // clear outputs last data (because data in connections is never serialized but stored inside the outputs info)
-      for (let i = 0; i < this.outputs.length; i++) {
-        delete this.outputs[i]._data
-      }
-      o.outputs = this.outputs
-    }
+    if (this.inputs) o.inputs = this.inputs.map(serializeSlot)
+    if (this.outputs) o.outputs = this.outputs.map(serializeSlot)
 
     if (this.title && this.title != this.constructor.title) o.title = this.title
 

--- a/src/LGraphNode.ts
+++ b/src/LGraphNode.ts
@@ -3246,7 +3246,7 @@ export class LGraphNode implements Positionable, IPinnable {
       const layoutElement = slot._layoutElement
       const isValid = !layoutElement?.invalid
       const highlight = layoutElement?.highlight
-      const label_color = highlight
+      const labelColor = highlight
         ? this.highlightColor
         : LiteGraph.NODE_TEXT_COLOR
       ctx.globalAlpha = isValid ? editorAlpha : 0.4 * editorAlpha
@@ -3254,7 +3254,7 @@ export class LGraphNode implements Positionable, IPinnable {
       layoutElement.value.draw(ctx, {
         pos: layoutElement.center,
         colorContext,
-        labelColor: label_color,
+        labelColor,
         lowQuality,
         renderText: !lowQuality,
         highlight,

--- a/src/NodeSlot.ts
+++ b/src/NodeSlot.ts
@@ -222,6 +222,10 @@ export abstract class NodeSlot implements INodeSlot {
   }
 }
 
+export function isINodeInputSlot(slot: INodeSlot): slot is INodeInputSlot {
+  return "link" in slot
+}
+
 export class NodeInputSlot extends NodeSlot implements INodeInputSlot {
   link: LinkId | null
 
@@ -252,6 +256,10 @@ export class NodeInputSlot extends NodeSlot implements INodeInputSlot {
 
     ctx.textAlign = originalTextAlign
   }
+}
+
+export function isINodeOutputSlot(slot: INodeSlot): slot is INodeOutputSlot {
+  return "links" in slot
 }
 
 export class NodeOutputSlot extends NodeSlot implements INodeOutputSlot {

--- a/src/NodeSlot.ts
+++ b/src/NodeSlot.ts
@@ -36,6 +36,15 @@ export function serializeSlot<T extends INodeSlot>(slot: T): T {
   return serialized
 }
 
+export function toNodeSlotClass(slot: INodeSlot): NodeSlot {
+  if (isINodeInputSlot(slot)) {
+    return new NodeInputSlot(slot)
+  } else if (isINodeOutputSlot(slot)) {
+    return new NodeOutputSlot(slot)
+  }
+  throw new Error("Invalid slot type")
+}
+
 export abstract class NodeSlot implements INodeSlot {
   name: string
   localized_name?: string

--- a/src/NodeSlot.ts
+++ b/src/NodeSlot.ts
@@ -27,6 +27,14 @@ interface IDrawOptions {
   highlight?: boolean
 }
 
+export function serializeSlot<T extends INodeSlot>(slot: T): T {
+  return {
+    ...slot,
+    _layoutElement: undefined,
+    _data: undefined,
+  }
+}
+
 export abstract class NodeSlot implements INodeSlot {
   name: string
   localized_name?: string

--- a/src/NodeSlot.ts
+++ b/src/NodeSlot.ts
@@ -28,11 +28,12 @@ interface IDrawOptions {
 }
 
 export function serializeSlot<T extends INodeSlot>(slot: T): T {
-  return {
-    ...slot,
-    _layoutElement: undefined,
-    _data: undefined,
+  const serialized = { ...slot }
+  delete serialized._layoutElement
+  if ("_data" in serialized) {
+    delete serialized._data
   }
+  return serialized
 }
 
 export abstract class NodeSlot implements INodeSlot {

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -4,6 +4,8 @@ import type { LinkDirection, RenderShape } from "./types/globalEnums"
 import type { LinkId, LLink } from "./LLink"
 import type { Reroute, RerouteId } from "./Reroute"
 import type { IWidget } from "./types/widgets"
+import type { LayoutElement } from "./utils/layout"
+import type { NodeSlot, NodeInputSlot, NodeOutputSlot } from "./NodeSlot"
 
 export type Dictionary<T> = { [key: string]: T }
 
@@ -225,6 +227,12 @@ export interface INodeSlot {
    * for more information.
    */
   widget?: IWidget
+
+  /**
+   * A layout element that is used internally to position the slot.
+   * Set by {@link LGraphNode.#layoutSlots}.
+   */
+  _layoutElement?: LayoutElement<NodeSlot>
 }
 
 export interface INodeFlags {
@@ -238,12 +246,14 @@ export interface INodeFlags {
 
 export interface INodeInputSlot extends INodeSlot {
   link: LinkId | null
+  _layoutElement?: LayoutElement<NodeInputSlot>
 }
 
 export interface INodeOutputSlot extends INodeSlot {
   links: LinkId[] | null
   _data?: unknown
   slot_index?: number
+  _layoutElement?: LayoutElement<NodeOutputSlot>
 }
 
 /** Links */

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -5,7 +5,6 @@ import type { LinkId, LLink } from "./LLink"
 import type { Reroute, RerouteId } from "./Reroute"
 import type { IWidget } from "./types/widgets"
 import type { LayoutElement } from "./utils/layout"
-import type { NodeSlot, NodeInputSlot, NodeOutputSlot } from "./NodeSlot"
 
 export type Dictionary<T> = { [key: string]: T }
 
@@ -232,7 +231,7 @@ export interface INodeSlot {
    * A layout element that is used internally to position the slot.
    * Set by {@link LGraphNode.#layoutSlots}.
    */
-  _layoutElement?: LayoutElement<NodeSlot>
+  _layoutElement?: LayoutElement<INodeSlot>
 }
 
 export interface INodeFlags {
@@ -246,14 +245,14 @@ export interface INodeFlags {
 
 export interface INodeInputSlot extends INodeSlot {
   link: LinkId | null
-  _layoutElement?: LayoutElement<NodeInputSlot>
+  _layoutElement?: LayoutElement<INodeInputSlot>
 }
 
 export interface INodeOutputSlot extends INodeSlot {
   links: LinkId[] | null
   _data?: unknown
   slot_index?: number
-  _layoutElement?: LayoutElement<NodeOutputSlot>
+  _layoutElement?: LayoutElement<INodeOutputSlot>
 }
 
 /** Links */

--- a/src/measure.ts
+++ b/src/measure.ts
@@ -1,7 +1,6 @@
 // @ts-strict-ignore
 import type {
   Point,
-  Positionable,
   ReadOnlyPoint,
   ReadOnlyRect,
   Rect,
@@ -331,7 +330,7 @@ export function findPointOnCurve(
 }
 
 export function createBounds(
-  objects: Iterable<Positionable>,
+  objects: Iterable<{ boundingRect: ReadOnlyRect }>,
   padding: number = 10,
 ): ReadOnlyRect | null {
   const bounds = new Float32Array([Infinity, Infinity, -Infinity, -Infinity])

--- a/src/utils/layout.ts
+++ b/src/utils/layout.ts
@@ -1,0 +1,26 @@
+import { Point, ReadOnlyRect } from "@/interfaces"
+
+export class LayoutElement<T> {
+  public value: T
+  public boundingRect: ReadOnlyRect
+  public highlight?: boolean
+  public invalid?: boolean
+
+  constructor(o: {
+    value: T
+    boundingRect: ReadOnlyRect
+    highlight?: boolean
+    invalid?: boolean
+  }) {
+    Object.assign(this, o)
+    this.value = o.value
+    this.boundingRect = o.boundingRect
+  }
+
+  get center(): Point {
+    return [
+      this.boundingRect[0] + this.boundingRect[2] / 2,
+      this.boundingRect[1] + this.boundingRect[3] / 2,
+    ]
+  }
+}

--- a/src/utils/layout.ts
+++ b/src/utils/layout.ts
@@ -3,16 +3,11 @@ import { Point, ReadOnlyRect } from "@/interfaces"
 export class LayoutElement<T> {
   public readonly value: T
   public readonly boundingRect: ReadOnlyRect
-  public readonly highlight?: boolean
-  public readonly invalid?: boolean
 
   constructor(o: {
     value: T
     boundingRect: ReadOnlyRect
-    highlight?: boolean
-    invalid?: boolean
   }) {
-    Object.assign(this, o)
     this.value = o.value
     this.boundingRect = o.boundingRect
   }

--- a/src/utils/layout.ts
+++ b/src/utils/layout.ts
@@ -1,10 +1,10 @@
 import { Point, ReadOnlyRect } from "@/interfaces"
 
 export class LayoutElement<T> {
-  public value: T
-  public boundingRect: ReadOnlyRect
-  public highlight?: boolean
-  public invalid?: boolean
+  public readonly value: T
+  public readonly boundingRect: ReadOnlyRect
+  public readonly highlight?: boolean
+  public readonly invalid?: boolean
 
   constructor(o: {
     value: T


### PR DESCRIPTION
Replaces https://github.com/Comfy-Org/litegraph.js/pull/510

This PR handles a smaller scope that only rewrites the layout/draw of node slots.
Layout objects are stored directly on original slot refs as `_layoutElement`.