### PR TITLE
[Cleanup] Remove LGraphCanvas.adjustNodesSize

### DIFF
--- a/src/LGraphCanvas.ts
+++ b/src/LGraphCanvas.ts
@@ -5574,14 +5574,6 @@ export class LGraphCanvas implements ConnectionColorContext {
     ctx.restore()
   }
 
-  adjustNodesSize(): void {
-    const nodes = this.graph._nodes
-    for (let i = 0; i < nodes.length; ++i) {
-      nodes[i].size = nodes[i].computeSize()
-    }
-    this.setDirty(true, true)
-  }
-
   /**
    * resizes the canvas to a given size, if no size is passed, then it tries to fill the parentNode
    * @todo Remove or rewrite


### PR DESCRIPTION
The function is unused according to https://cs.comfy.org/search?q=context:global+%22adjustNodesSize%22&patternType=keyword&sm=0&filters=%5B%5B%22lang%22%2C%22JavaScript%22%2C%22lang%3Ajavascript%22%5D%5D