### PR TITLE
[Performance] Avoid double measure on node rendering

### DIFF
--- a/src/LGraphCanvas.ts
+++ b/src/LGraphCanvas.ts
@@ -4615,7 +4615,7 @@ export class LGraphCanvas implements ConnectionColorContext {
     // clip if required (mask)
     const shape = node._shape || RenderShape.BOX
     const size = LGraphCanvas.#temp_vec2
-    size.set(node.boundingRect, /* offset= */ 2)
+    size.set(node.boundingRect.slice(2, 4))
 
     if (node.collapsed) {
       ctx.font = this.inner_text_font

--- a/src/LGraphCanvas.ts
+++ b/src/LGraphCanvas.ts
@@ -4052,7 +4052,7 @@ export class LGraphCanvas implements ConnectionColorContext {
 
     const _nodes = nodes || this.graph._nodes
     for (const node of _nodes) {
-      node.updateArea()
+      node.updateArea(this.ctx)
       // Not in visible area
       if (!overlapBounding(this.visible_area, node.renderArea)) continue
 
@@ -4621,10 +4621,6 @@ export class LGraphCanvas implements ConnectionColorContext {
       ctx.font = this.inner_text_font
       const title = node.getTitle ? node.getTitle() : node.title
       if (title != null) {
-        node._collapsed_width = Math.min(
-          node.size[0],
-          ctx.measureText(title).width + LiteGraph.NODE_TITLE_HEIGHT * 2,
-        ) // LiteGraph.NODE_COLLAPSED_WIDTH;
         size[0] = node._collapsed_width
         size[1] = 0
       }

--- a/src/LGraphCanvas.ts
+++ b/src/LGraphCanvas.ts
@@ -4615,7 +4615,7 @@ export class LGraphCanvas implements ConnectionColorContext {
     // clip if required (mask)
     const shape = node._shape || RenderShape.BOX
     const size = LGraphCanvas.#temp_vec2
-    size.set(node.boundingRect.slice(2, 4))
+    size.set(node.renderingSize)
 
     if (node.collapsed) {
       ctx.font = this.inner_text_font

--- a/src/LGraphCanvas.ts
+++ b/src/LGraphCanvas.ts
@@ -4807,7 +4807,7 @@ export class LGraphCanvas implements ConnectionColorContext {
 
     // Normalised node dimensions
     const area = LGraphCanvas.#tmp_area
-    node.measure(area)
+    area.set(node.boundingRect)
     area[0] -= node.pos[0]
     area[1] -= node.pos[1]
 

--- a/src/LGraphCanvas.ts
+++ b/src/LGraphCanvas.ts
@@ -4615,15 +4615,10 @@ export class LGraphCanvas implements ConnectionColorContext {
     // clip if required (mask)
     const shape = node._shape || RenderShape.BOX
     const size = LGraphCanvas.#temp_vec2
-    LGraphCanvas.#temp_vec2.set(node.size)
+    size.set(node.boundingRect, /* offset= */ 2)
 
     if (node.flags.collapsed) {
       ctx.font = this.inner_text_font
-      const title = node.getTitle ? node.getTitle() : node.title
-      if (title != null) {
-        size[0] = node._collapsed_width
-        size[1] = 0
-      }
     }
 
     if (node.clip_area) {

--- a/src/LGraphCanvas.ts
+++ b/src/LGraphCanvas.ts
@@ -4617,7 +4617,7 @@ export class LGraphCanvas implements ConnectionColorContext {
     const size = LGraphCanvas.#temp_vec2
     size.set(node.boundingRect, /* offset= */ 2)
 
-    if (node.flags.collapsed) {
+    if (node.collapsed) {
       ctx.font = this.inner_text_font
     }
 

--- a/src/LGraphNode.ts
+++ b/src/LGraphNode.ts
@@ -161,6 +161,10 @@ export class LGraphNode implements Positionable, IPinnable {
     return `${LiteGraph.NODE_TEXT_SIZE}px Arial`
   }
 
+  get innerFontStyle(): string {
+    return `normal ${LiteGraph.NODE_SUBTEXT_SIZE}px Arial`
+  }
+
   graph: LGraph | null = null
   id: NodeId
   type: string | null = null
@@ -1699,6 +1703,7 @@ export class LGraphNode implements Positionable, IPinnable {
       out[2] = this.size[0]
       out[3] = this.size[1] + titleHeight
     } else {
+      ctx.font = this.innerFontStyle
       this._collapsed_width = Math.min(
         this.size[0],
         ctx.measureText(this.getTitle() ?? "").width + LiteGraph.NODE_TITLE_HEIGHT * 2,

--- a/src/LGraphNode.ts
+++ b/src/LGraphNode.ts
@@ -1701,7 +1701,7 @@ export class LGraphNode implements Positionable, IPinnable {
     } else {
       this._collapsed_width = Math.min(
         this.size[0],
-        ctx.measureText(this.getTitle()).width + LiteGraph.NODE_TITLE_HEIGHT * 2,
+        ctx.measureText(this.getTitle() ?? "").width + LiteGraph.NODE_TITLE_HEIGHT * 2,
       )
       out[2] = (this._collapsed_width || LiteGraph.NODE_COLLAPSED_WIDTH)
       out[3] = LiteGraph.NODE_TITLE_HEIGHT

--- a/src/LGraphNode.ts
+++ b/src/LGraphNode.ts
@@ -1681,25 +1681,30 @@ export class LGraphNode implements Positionable, IPinnable {
    * Internal method to measure the node for rendering.  Prefer {@link boundingRect} where possible.
    *
    * Populates {@link out} with the results in graph space.
+   * Populates {@link _collapsed_width} with the collapsed width if the node is collapsed.
    * Adjusts for title and collapsed status, but does not call {@link onBounding}.
    * @param out `x, y, width, height` are written to this array.
-   * @param pad Expands the area by this amount on each side.  Default: 0
+   * @param ctx The canvas context to use for measuring text.
    */
-  measure(out: Rect, pad = 0): void {
+  measure(out: Rect, ctx: CanvasRenderingContext2D): void {
     const titleMode = this.title_mode
     const renderTitle =
       titleMode != TitleMode.TRANSPARENT_TITLE &&
       titleMode != TitleMode.NO_TITLE
     const titleHeight = renderTitle ? LiteGraph.NODE_TITLE_HEIGHT : 0
 
-    out[0] = this.pos[0] - pad
-    out[1] = this.pos[1] + -titleHeight - pad
+    out[0] = this.pos[0]
+    out[1] = this.pos[1] + -titleHeight
     if (!this.flags?.collapsed) {
-      out[2] = this.size[0] + 2 * pad
-      out[3] = this.size[1] + titleHeight + 2 * pad
+      out[2] = this.size[0]
+      out[3] = this.size[1] + titleHeight
     } else {
-      out[2] = (this._collapsed_width || LiteGraph.NODE_COLLAPSED_WIDTH) + 2 * pad
-      out[3] = LiteGraph.NODE_TITLE_HEIGHT + 2 * pad
+      this._collapsed_width = Math.min(
+        this.size[0],
+        ctx.measureText(this.getTitle()).width + LiteGraph.NODE_TITLE_HEIGHT * 2,
+      )
+      out[2] = (this._collapsed_width || LiteGraph.NODE_COLLAPSED_WIDTH)
+      out[3] = LiteGraph.NODE_TITLE_HEIGHT
     }
   }
 
@@ -1726,9 +1731,9 @@ export class LGraphNode implements Positionable, IPinnable {
    * Calculates the render area of this node, populating both {@link boundingRect} and {@link renderArea}.
    * Called automatically at the start of every frame.
    */
-  updateArea(): void {
+  updateArea(ctx: CanvasRenderingContext2D): void {
     const bounds = this.#boundingRect
-    this.measure(bounds)
+    this.measure(bounds, ctx)
     this.onBounding?.(bounds)
 
     const renderArea = this.#renderArea


### PR DESCRIPTION
https://github.com/Comfy-Org/litegraph.js/blob/de10bf0c3a2a187fc0cd55bd72e1718a0ae5976f/src/LGraphCanvas.ts#L4049-L4062

already calls `LGraphNode.measure` for every LGraphNode visible. This PR removes the unnecessary call to `measure` and directly reuse the result on `LGraphNode.boundingRect`.

This PR also removes the node size change during drawing. The collapsed width measuring is moved to `LGraphNode.measure`.