### PR TITLE
Reverse computeSize and computeLayoutSize priority

### DIFF
--- a/src/LGraphNode.ts
+++ b/src/LGraphNode.ts
@@ -1529,10 +1529,10 @@ export class LGraphNode implements Positionable, IPinnable {
         if (widget.hidden || (widget.advanced && !this.showAdvanced)) continue
 
         let widget_height = 0
-        if (widget.computeLayoutSize) {
-          widget_height += widget.computeLayoutSize(this).minHeight
-        } else if (widget.computeSize) {
+        if (widget.computeSize) {
           widget_height += widget.computeSize(size[0])[1]
+        } else if (widget.computeLayoutSize) {
+          widget_height += widget.computeLayoutSize(this).minHeight
         } else {
           widget_height += LiteGraph.NODE_WIDGET_HEIGHT
         }
@@ -3302,17 +3302,17 @@ export class LGraphNode implements Positionable, IPinnable {
     }[] = []
 
     for (const w of this.widgets) {
-      if (w.computeLayoutSize) {
+      if (w.computeSize) {
+        const height = w.computeSize()[1] + 4
+        w.computedHeight = height
+        fixedWidgetHeight += height
+      } else if (w.computeLayoutSize) {
         const { minHeight, maxHeight } = w.computeLayoutSize(this)
         growableWidgets.push({
           minHeight,
           prefHeight: maxHeight,
           w,
         })
-      } else if (w.computeSize) {
-        const height = w.computeSize()[1] + 4
-        w.computedHeight = height
-        fixedWidgetHeight += height
       } else {
         const height = LiteGraph.NODE_WIDGET_HEIGHT + 4
         w.computedHeight = height

--- a/src/types/widgets.ts
+++ b/src/types/widgets.ts
@@ -178,7 +178,7 @@ export interface IBaseWidget<TElement extends HTMLElement = HTMLElement> {
   ): void
 
   /**
-   * Compute the size of the widget.
+   * Compute the size of the widget. Overrides {@link IBaseWidget.computeSize}.
    * @param width The width of the widget.
    * @deprecated Use {@link IBaseWidget.computeLayoutSize} instead.
    * @returns The size of the widget.
@@ -186,7 +186,7 @@ export interface IBaseWidget<TElement extends HTMLElement = HTMLElement> {
   computeSize?(width?: number): Size
 
   /**
-   * Compute the layout size of the widget. Overrides {@link IBaseWidget.computeSize}.
+   * Compute the layout size of the widget.
    * @param node The node this widget belongs to.
    * @returns The layout size of the widget.
    */


### PR DESCRIPTION
Ref: https://github.com/Comfy-Org/ComfyUI_frontend/issues/2567

Reverse the priority of computeSize and computeLayoutSize. Allow custom nodes which overrides the `computeSize` of the widget to still take effect even on DOMWidget instance the `computeLayoutSize` is used.