### PR TITLE
[Type] Mark LGraphGroup.color as optional

### DIFF
--- a/src/LGraphGroup.ts
+++ b/src/LGraphGroup.ts
@@ -33,7 +33,7 @@ export class LGraphGroup implements Positionable, IPinnable {
   static defaultColour = "#335"
 
   id: number
-  color: string
+  color?: string
   title: string
   font?: string
   font_size: number = LiteGraph.DEFAULT_GROUP_FONT || 24

--- a/src/LGraphGroup.ts
+++ b/src/LGraphGroup.ts
@@ -153,18 +153,19 @@ export class LGraphGroup implements Positionable, IPinnable {
 
     const [x, y] = this._pos
     const [width, height] = this._size
+    const color = this.color || defaultColour
 
     // Titlebar
     ctx.globalAlpha = 0.25 * graphCanvas.editor_alpha
-    ctx.fillStyle = this.color || defaultColour
-    ctx.strokeStyle = this.color || defaultColour
+    ctx.fillStyle = color
+    ctx.strokeStyle = color
     ctx.beginPath()
     ctx.rect(x + 0.5, y + 0.5, width, font_size * 1.4)
     ctx.fill()
 
     // Group background, border
-    ctx.fillStyle = this.color
-    ctx.strokeStyle = this.color
+    ctx.fillStyle = color
+    ctx.strokeStyle = color
     ctx.beginPath()
     ctx.rect(x + 0.5, y + 0.5, width, height)
     ctx.fill()


### PR DESCRIPTION
The `LGraphGroup.color` can be deleted here. Marking it as optional. 

https://github.com/Comfy-Org/litegraph.js/blob/aafd7202c2db569113a355fd89a35ad685efcc2c/src/LGraphCanvas.ts#L1436-L1448

