### PR TITLE
[Cleanup] Remove lint bypass, remove unused vars

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -63,7 +63,6 @@ export default tseslint.config(
       "@typescript-eslint/no-empty-object-type": "off",
 
       // "@typescript-eslint/prefer-readonly-parameter-types": "error",
-      "@typescript-eslint/no-unused-vars": "off",
       // "@typescript-eslint/no-unsafe-function-type": "off",
 
       "@stylistic/max-len": [
@@ -167,10 +166,9 @@ export default tseslint.config(
       "unused-imports": unusedImports,
     },
     rules: {
-      "@typescript-eslint/no-explicit-any": "off",
       "@typescript-eslint/no-unused-vars": "off",
-      "@typescript-eslint/prefer-as-const": "off",
       "unused-imports/no-unused-imports": "error",
+      "unused-imports/no-unused-vars": "warn",
     },
   },
 )

--- a/src/ContextMenu.ts
+++ b/src/ContextMenu.ts
@@ -346,7 +346,6 @@ export class ContextMenu {
     element: HTMLDivElement,
     event_name: string,
     params: MouseEvent,
-    origin?: unknown,
   ): CustomEvent {
     const evt = document.createEvent("CustomEvent")
     evt.initCustomEvent(event_name, true, true, params) // canBubble, cancelable, detail

--- a/src/LGraph.ts
+++ b/src/LGraph.ts
@@ -584,8 +584,6 @@ export class LGraph implements LinkNetwork, Serialisable<SerialisableGraph> {
     if (L.length != this._nodes.length && LiteGraph.debug)
       console.warn("something went wrong, nodes missing")
 
-    const l = L.length
-
     /** Ensure type is set */
     type OrderedLGraphNode = LGraphNode & { order: number }
 

--- a/src/LGraphCanvas.ts
+++ b/src/LGraphCanvas.ts
@@ -785,7 +785,6 @@ export class LGraphCanvas implements ConnectionColorContext {
     options: IContextMenuOptions,
     event: MouseEvent,
     prev_menu: ContextMenu,
-    node: LGraphNode,
   ): void {
     new LiteGraph.ContextMenu(["Vertically", "Horizontally"], {
       event,
@@ -1347,13 +1346,7 @@ export class LGraphCanvas implements ConnectionColorContext {
     node.graph.afterChange(/* ? */)
   }
 
-  static onMenuNodePin(
-    value: IContextMenuValue,
-    options: IContextMenuOptions,
-    e: MouseEvent,
-    menu: ContextMenu,
-    node: LGraphNode,
-  ): void {}
+  static onMenuNodePin(): void {}
 
   static onMenuNodeMode(
     value: IContextMenuValue,
@@ -2367,7 +2360,7 @@ export class LGraphCanvas implements ConnectionColorContext {
           this.#dirty()
         }
 
-        pointer.onDragEnd = (upEvent) => {
+        pointer.onDragEnd = () => {
           this.#dirty()
           graph.afterChange(this.resizing_node)
         }
@@ -3158,7 +3151,7 @@ export class LGraphCanvas implements ConnectionColorContext {
     this.updateMouseOverNodes(null, e)
   }
 
-  processMouseCancel(e: PointerEvent): void {
+  processMouseCancel(): void {
     console.warn("Pointer cancel!")
     this.pointer.reset()
   }
@@ -5881,7 +5874,7 @@ export class LGraphCanvas implements ConnectionColorContext {
       default: {
         // check for defaults nodes for this slottype
 
-        const nodeCreated = that.createDefaultNodeForSlot(Object.assign<ICreateNodeOptions, ICreateNodeOptions>(opts, {
+        that.createDefaultNodeForSlot(Object.assign<ICreateNodeOptions, ICreateNodeOptions>(opts, {
           position: [opts.e.canvasX, opts.e.canvasY],
           nodeType: v,
           afterRerouteId,

--- a/src/LGraphNode.ts
+++ b/src/LGraphNode.ts
@@ -1064,7 +1064,7 @@ export class LGraphNode implements Positionable, IPinnable, IColorable {
     const trigS = this.findInputSlot("onTrigger")
     // !trigS ||
     if (trigS == -1) {
-      const input = this.addInput("onTrigger", LiteGraph.EVENT, {
+      this.addInput("onTrigger", LiteGraph.EVENT, {
         optional: true,
         nameLocked: true,
       })
@@ -1077,7 +1077,7 @@ export class LGraphNode implements Positionable, IPinnable, IColorable {
     const trigS = this.findOutputSlot("onExecuted")
     // !trigS ||
     if (trigS == -1) {
-      const output = this.addOutput("onExecuted", LiteGraph.ACTION, {
+      this.addOutput("onExecuted", LiteGraph.ACTION, {
         optional: true,
         nameLocked: true,
       })

--- a/src/widgets/BaseWidget.ts
+++ b/src/widgets/BaseWidget.ts
@@ -83,21 +83,21 @@ export abstract class BaseWidget implements IBaseWidget {
    * Handles the click event for the widget
    * @param options - The options for handling the click event
    */
-  onClick(options: {
+  abstract onClick(options: {
     e: CanvasMouseEvent
     node: LGraphNode
     canvas: LGraphCanvas
-  }): void {}
+  }): void
 
   /**
    * Handles the drag event for the widget
    * @param options - The options for handling the drag event
    */
-  onDrag(options: {
+  onDrag?(options: {
     e: CanvasMouseEvent
     node: LGraphNode
     canvas: LGraphCanvas
-  }): void {}
+  }): void
 
   /**
    * Sets the value of the widget


### PR DESCRIPTION
Removes bypasses:
- [prefer-as-const](https://typescript-eslint.io/rules/prefer-as-const/)
- [no-explicit-any](https://typescript-eslint.io/rules/no-explicit-any/)

* Follow up on #493
  Adds `no-unused-vars` from `eslint-plugin-unused-imports`