### PR TITLE
Type Widget.options.serialize

### DIFF
--- a/src/types/widgets.ts
+++ b/src/types/widgets.ts
@@ -16,6 +16,12 @@ export interface IWidgetOptions<TValue = unknown> extends Record<string, unknown
   multiline?: boolean
   // TODO: Confirm this
   property?: string
+  /**
+   * Controls whether the widget's value is included in the API workflow/prompt.
+   * - If false, the value will be excluded from the API workflow but still saved in the graph state
+   * - If true or undefined, the value will be included in both the API workflow and graph state
+   */
+  serialize?: boolean
 
   values?: TValue[]
   callback?: IWidget["callback"]


### PR DESCRIPTION
The `serialize` option is used by ComfyUI_Frontend in these places:

- [image upload widget](https://github.com/Comfy-Org/ComfyUI_frontend/blob/main/src/composables/widgets/useImageUploadWidget.ts#L84)
- [value control widget](https://github.com/Comfy-Org/ComfyUI_frontend/blob/main/src/scripts/widgets.ts#L124)

It is in need of documentation, since it's the behavior is not self-explanatory.