### PR TITLE
[Refactor] Prefer modern for..of loops 2

### DIFF
--- a/src/LGraph.ts
+++ b/src/LGraph.ts
@@ -500,8 +500,7 @@ export class LGraph implements LinkNetwork, Serialisable<SerialisableGraph> {
     const remaining_links: Record<NodeId, number> = {} // to a
 
     // search for the nodes without inputs (starting nodes)
-    for (let i = 0, l = this._nodes.length; i < l; ++i) {
-      const node = this._nodes[i]
+    for (const node of this._nodes) {
       if (only_onExecute && !node.onExecute) {
         continue
       }
@@ -539,8 +538,7 @@ export class LGraph implements LinkNetwork, Serialisable<SerialisableGraph> {
       if (!node.outputs) continue
 
       // for every output
-      for (let i = 0; i < node.outputs.length; i++) {
-        const output = node.outputs[i]
+      for (const output of node.outputs) {
         // not connected
         // TODO: Confirm functionality, clean condition
         if (output?.links == null || output.links.length == 0)

--- a/src/LGraph.ts
+++ b/src/LGraph.ts
@@ -248,8 +248,8 @@ export class LGraph implements LinkNetwork, Serialisable<SerialisableGraph> {
 
     // safe clear
     if (this._nodes) {
-      for (let i = 0; i < this._nodes.length; ++i) {
-        this._nodes[i].onRemoved?.()
+      for (const _node of this._nodes) {
+        _node.onRemoved?.()
       }
     }
 
@@ -481,9 +481,9 @@ export class LGraph implements LinkNetwork, Serialisable<SerialisableGraph> {
   updateExecutionOrder(): void {
     this._nodes_in_order = this.computeExecutionOrder(false)
     this._nodes_executable = []
-    for (let i = 0; i < this._nodes_in_order.length; ++i) {
-      if (this._nodes_in_order[i].onExecute) {
-        this._nodes_executable.push(this._nodes_in_order[i])
+    for (const node of this._nodes_in_order) {
+      if (node.onExecute) {
+        this._nodes_executable.push(node)
       }
     }
   }
@@ -509,8 +509,8 @@ export class LGraph implements LinkNetwork, Serialisable<SerialisableGraph> {
 
       let num = 0 // num of input connections
       if (node.inputs) {
-        for (let j = 0, l2 = node.inputs.length; j < l2; j++) {
-          if (node.inputs[j]?.link != null) {
+        for (const input of node.inputs) {
+          if (input?.link != null) {
             num += 1
           }
         }
@@ -545,8 +545,7 @@ export class LGraph implements LinkNetwork, Serialisable<SerialisableGraph> {
           continue
 
         // for every connection
-        for (let j = 0; j < output.links.length; j++) {
-          const link_id = output.links[j]
+        for (const link_id of output.links) {
           const link = this._links.get(link_id)
           if (!link) continue
 
@@ -727,9 +726,7 @@ export class LGraph implements LinkNetwork, Serialisable<SerialisableGraph> {
     const nodes = this._nodes_in_order ? this._nodes_in_order : this._nodes
     if (!nodes) return
 
-    for (let j = 0, l = nodes.length; j < l; ++j) {
-      const node = nodes[j]
-
+    for (const node of nodes) {
       if (!node[eventname] || node.mode != mode) continue
       if (params === undefined) {
         node[eventname]()
@@ -756,10 +753,10 @@ export class LGraph implements LinkNetwork, Serialisable<SerialisableGraph> {
     action: T,
     params?: ParamsArray<LGraphCanvas, T>,
   ): void {
-    if (!this.list_of_graphcanvas) return
+    const { list_of_graphcanvas } = this
+    if (!list_of_graphcanvas) return
 
-    for (let i = 0; i < this.list_of_graphcanvas.length; ++i) {
-      const c = this.list_of_graphcanvas[i]
+    for (const c of list_of_graphcanvas) {
       c[action]?.apply(c, params)
     }
   }
@@ -867,18 +864,18 @@ export class LGraph implements LinkNetwork, Serialisable<SerialisableGraph> {
 
     this.beforeChange() // sure? - almost sure is wrong
 
+    const { inputs, outputs } = node
+
     // disconnect inputs
-    if (node.inputs) {
-      for (let i = 0; i < node.inputs.length; i++) {
-        const slot = node.inputs[i]
+    if (inputs) {
+      for (const [i, slot] of inputs.entries()) {
         if (slot.link != null) node.disconnectInput(i)
       }
     }
 
     // disconnect outputs
-    if (node.outputs) {
-      for (let i = 0; i < node.outputs.length; i++) {
-        const slot = node.outputs[i]
+    if (outputs) {
+      for (const [i, slot] of outputs.entries()) {
         if (slot.links?.length) node.disconnectOutput(i)
       }
     }
@@ -890,9 +887,9 @@ export class LGraph implements LinkNetwork, Serialisable<SerialisableGraph> {
     this._version++
 
     // remove from canvas render
-    if (this.list_of_graphcanvas) {
-      for (let i = 0; i < this.list_of_graphcanvas.length; ++i) {
-        const canvas = this.list_of_graphcanvas[i]
+    const { list_of_graphcanvas } = this
+    if (list_of_graphcanvas) {
+      for (const canvas of list_of_graphcanvas) {
         if (canvas.selected_nodes[node.id])
           delete canvas.selected_nodes[node.id]
       }
@@ -934,9 +931,10 @@ export class LGraph implements LinkNetwork, Serialisable<SerialisableGraph> {
   findNodesByClass(classObject: Function, result?: LGraphNode[]): LGraphNode[] {
     result = result || []
     result.length = 0
-    for (let i = 0, l = this._nodes.length; i < l; ++i) {
-      if (this._nodes[i].constructor === classObject)
-        result.push(this._nodes[i])
+    const { _nodes } = this
+    for (const node of _nodes) {
+      if (node.constructor === classObject)
+        result.push(node)
     }
     return result
   }
@@ -950,9 +948,10 @@ export class LGraph implements LinkNetwork, Serialisable<SerialisableGraph> {
     const matchType = type.toLowerCase()
     result = result || []
     result.length = 0
-    for (let i = 0, l = this._nodes.length; i < l; ++i) {
-      if (this._nodes[i].type?.toLowerCase() == matchType)
-        result.push(this._nodes[i])
+    const { _nodes } = this
+    for (const node of _nodes) {
+      if (node.type?.toLowerCase() == matchType)
+        result.push(node)
     }
     return result
   }
@@ -963,9 +962,10 @@ export class LGraph implements LinkNetwork, Serialisable<SerialisableGraph> {
    * @returns the node or null
    */
   findNodeByTitle(title: string): LGraphNode | null {
-    for (let i = 0, l = this._nodes.length; i < l; ++i) {
-      if (this._nodes[i].title == title)
-        return this._nodes[i]
+    const { _nodes } = this
+    for (const node of _nodes) {
+      if (node.title == title)
+        return node
     }
     return null
   }
@@ -977,9 +977,10 @@ export class LGraph implements LinkNetwork, Serialisable<SerialisableGraph> {
    */
   findNodesByTitle(title: string): LGraphNode[] {
     const result: LGraphNode[] = []
-    for (let i = 0, l = this._nodes.length; i < l; ++i) {
-      if (this._nodes[i].title == title)
-        result.push(this._nodes[i])
+    const { _nodes } = this
+    for (const node of _nodes) {
+      if (node.title == title)
+        result.push(node)
     }
     return result
   }
@@ -1076,14 +1077,14 @@ export class LGraph implements LinkNetwork, Serialisable<SerialisableGraph> {
    * this replaces the ones using the old version with the new version
    */
   checkNodeTypes() {
-    for (let i = 0; i < this._nodes.length; i++) {
-      const node = this._nodes[i]
+    const { _nodes } = this
+    for (const [i, node] of _nodes.entries()) {
       const ctor = LiteGraph.registered_node_types[node.type]
       if (node.constructor == ctor) continue
 
       console.log("node being replaced by newer version: " + node.type)
       const newnode = LiteGraph.createNode(node.type)
-      this._nodes[i] = newnode
+      _nodes[i] = newnode
       newnode.configure(node.serialize())
       newnode.graph = this
       this._nodes_by_id[newnode.id] = newnode
@@ -1105,8 +1106,7 @@ export class LGraph implements LinkNetwork, Serialisable<SerialisableGraph> {
       LiteGraph.GraphInput,
       this._input_nodes,
     )
-    for (let i = 0; i < this._input_nodes.length; ++i) {
-      const node = this._input_nodes[i]
+    for (const node of this._input_nodes) {
       if (node.properties.name != action) continue
 
       // wrap node.onAction(action, param);
@@ -1596,8 +1596,8 @@ export class LGraph implements LinkNetwork, Serialisable<SerialisableGraph> {
     // create nodes
     this._nodes = []
     if (nodesData) {
-      for (let i = 0, l = nodesData.length; i < l; ++i) {
-        const n_info = nodesData[i] // stored info
+      for (const n_info of nodesData) {
+        // stored info
         let node = LiteGraph.createNode(n_info.type, n_info.title)
         if (!node) {
           if (LiteGraph.debug) console.log("Node not found or has errors: " + n_info.type)
@@ -1615,8 +1615,7 @@ export class LGraph implements LinkNetwork, Serialisable<SerialisableGraph> {
       }
 
       // configure nodes afterwards so they can reach each other
-      for (let i = 0, l = nodesData.length; i < l; ++i) {
-        const n_info = nodesData[i]
+      for (const n_info of nodesData) {
         const node = this.getNodeById(n_info.id)
         node?.configure(n_info)
       }
@@ -1624,11 +1623,12 @@ export class LGraph implements LinkNetwork, Serialisable<SerialisableGraph> {
 
     // groups
     this._groups.length = 0
-    if (data.groups) {
-      for (let i = 0; i < data.groups.length; ++i) {
+    const groupData = data.groups
+    if (groupData) {
+      for (const data of groupData) {
         // TODO: Search/remove these global object refs
         const group = new LiteGraph.LGraphGroup()
-        group.configure(data.groups[i])
+        group.configure(data)
         this.add(group)
       }
     }

--- a/src/LGraphCanvas.ts
+++ b/src/LGraphCanvas.ts
@@ -1934,11 +1934,10 @@ export class LGraphCanvas implements ConnectionColorContext {
    */
   updateMouseOverNodes(node: LGraphNode, e: CanvasMouseEvent): void {
     const nodes = this.graph._nodes
-    const l = nodes.length
-    for (let i = 0; i < l; ++i) {
-      if (nodes[i].mouseOver && node != nodes[i]) {
+    for (const otherNode of nodes) {
+      if (otherNode.mouseOver && node != otherNode) {
         // mouse leave
-        nodes[i].mouseOver = null
+        otherNode.mouseOver = null
         this._highlight_input = null
         this._highlight_pos = null
         this.link_over_widget = null
@@ -1946,7 +1945,7 @@ export class LGraphCanvas implements ConnectionColorContext {
         // Hover transitions
         // TODO: Implement single lerp ease factor for current progress on hover in/out.
         // In drawNode, multiply by ease factor and differential value (e.g. bg alpha +0.5).
-        nodes[i].lostFocusAt = LiteGraph.getTime()
+        otherNode.lostFocusAt = LiteGraph.getTime()
 
         this.node_over?.onMouseLeave?.(e)
         this.node_over = null
@@ -2340,10 +2339,11 @@ export class LGraphCanvas implements ConnectionColorContext {
         return
       }
 
+      const { inputs, outputs } = node
+
       // Outputs
-      if (node.outputs) {
-        for (let i = 0, l = node.outputs.length; i < l; ++i) {
-          const output = node.outputs[i]
+      if (outputs) {
+        for (const [i, output] of outputs.entries()) {
           const link_pos = node.getConnectionPos(false, i)
           if (isInRectangle(x, y, link_pos[0] - 15, link_pos[1] - 10, 30, 20)) {
             // Drag multiple output links
@@ -2400,9 +2400,8 @@ export class LGraphCanvas implements ConnectionColorContext {
       }
 
       // Inputs
-      if (node.inputs) {
-        for (let i = 0, l = node.inputs.length; i < l; ++i) {
-          const input = node.inputs[i]
+      if (inputs) {
+        for (const [i, input] of inputs.entries()) {
           const link_pos = node.getConnectionPos(true, i)
           if (isInRectangle(x, y, link_pos[0] - 15, link_pos[1] - 10, 30, 20)) {
             pointer.onDoubleClick = () => node.onInputDblClick?.(i, e)
@@ -2572,10 +2571,11 @@ export class LGraphCanvas implements ConnectionColorContext {
       let mClikSlot: INodeSlot | false = false
       let mClikSlot_index: number | false = false
       let mClikSlot_isOut: boolean = false
+      const { inputs, outputs } = node
+
       // search for outputs
-      if (node.outputs) {
-        for (let i = 0, l = node.outputs.length; i < l; ++i) {
-          const output = node.outputs[i]
+      if (outputs) {
+        for (const [i, output] of outputs.entries()) {
           const link_pos = node.getConnectionPos(false, i)
           if (isInRectangle(e.canvasX, e.canvasY, link_pos[0] - 15, link_pos[1] - 10, 30, 20)) {
             mClikSlot = output
@@ -2587,9 +2587,8 @@ export class LGraphCanvas implements ConnectionColorContext {
       }
 
       // search for inputs
-      if (node.inputs) {
-        for (let i = 0, l = node.inputs.length; i < l; ++i) {
-          const input = node.inputs[i]
+      if (inputs) {
+        for (const [i, input] of inputs.entries()) {
           const link_pos = node.getConnectionPos(true, i)
           if (isInRectangle(e.canvasX, e.canvasY, link_pos[0] - 15, link_pos[1] - 10, 30, 20)) {
             mClikSlot = input
@@ -2604,7 +2603,7 @@ export class LGraphCanvas implements ConnectionColorContext {
         const alphaPosY =
           0.5 -
           (mClikSlot_index + 1) /
-          (mClikSlot_isOut ? node.outputs.length : node.inputs.length)
+          (mClikSlot_isOut ? outputs.length : inputs.length)
         const node_bounding = node.getBounding()
         // estimate a position: this is a bad semi-bad-working mess .. REFACTOR with
         // a correct autoplacement that knows about the others slots and nodes
@@ -3164,9 +3163,9 @@ export class LGraphCanvas implements ConnectionColorContext {
     canvasy: number,
     slot_pos?: Point,
   ): number {
-    if (node.inputs) {
-      for (let i = 0, l = node.inputs.length; i < l; ++i) {
-        const input = node.inputs[i]
+    const { inputs } = node
+    if (inputs) {
+      for (const [i, input] of inputs.entries()) {
         const link_pos = node.getConnectionPos(true, i)
         let is_inside = false
         // TODO: Find a cheap way to measure text, and do it on node label change instead of here
@@ -3202,8 +3201,9 @@ export class LGraphCanvas implements ConnectionColorContext {
     canvasy: number,
     slot_pos?: Point,
   ): number {
-    if (node.outputs) {
-      for (let i = 0, l = node.outputs.length; i < l; ++i) {
+    const { outputs } = node
+    if (outputs) {
+      for (let i = 0; i < outputs.length; ++i) {
         const link_pos = node.getConnectionPos(false, i)
         const is_inside = isInRectangle(
           canvasx,

--- a/src/LGraphNode.ts
+++ b/src/LGraphNode.ts
@@ -667,9 +667,10 @@ export class LGraphNode implements Positionable, IPinnable, IColorable {
       }
 
       if (info.widgets_values) {
-        for (let i = 0; i < info.widgets_values.length; ++i) {
-          if (this.widgets[i]) {
-            this.widgets[i].value = info.widgets_values[i]
+        for (const [i, value] of info.widgets_values.entries()) {
+          const widget = this.widgets[i]
+          if (widget) {
+            widget.value = value
           }
         }
       }
@@ -2474,6 +2475,7 @@ export class LGraphNode implements Positionable, IPinnable, IColorable {
     // get output slot
     const output = this.outputs[slot]
     if (!output || !output.links || output.links.length == 0) return false
+    const { links } = output
 
     // one of the output links in this slot
     const graph = this.graph
@@ -2482,13 +2484,12 @@ export class LGraphNode implements Positionable, IPinnable, IColorable {
         target_node = graph.getNodeById(target_node)
       if (!target_node) throw "Target Node not found"
 
-      for (let i = 0, l = output.links.length; i < l; i++) {
-        const link_id = output.links[i]
+      for (const [i, link_id] of links.entries()) {
         const link_info = graph._links.get(link_id)
 
         // is the link we are searching for...
         if (link_info.target_id == target_node.id) {
-          output.links.splice(i, 1) // remove here
+          links.splice(i, 1) // remove here
           const input = target_node.inputs[link_info.target_slot]
           input.link = null // remove there
 
@@ -2519,8 +2520,7 @@ export class LGraphNode implements Positionable, IPinnable, IColorable {
       }
     } else {
       // all the links in this output slot
-      for (let i = 0, l = output.links.length; i < l; i++) {
-        const link_id = output.links[i]
+      for (const link_id of links) {
         const link_info = graph._links.get(link_id)
         // bug: it happens sometimes
         if (!link_info) continue

--- a/src/LGraphNode.ts
+++ b/src/LGraphNode.ts
@@ -667,10 +667,10 @@ export class LGraphNode implements Positionable, IPinnable, IColorable {
       }
 
       if (info.widgets_values) {
-        for (const [i, value] of info.widgets_values.entries()) {
+        for (let i = 0; i < info.widgets_values.length; ++i) {
           const widget = this.widgets[i]
           if (widget) {
-            widget.value = value
+            widget.value = info.widgets_values[i]
           }
         }
       }


### PR DESCRIPTION
- Replaces traditional incrementing `for` loops and `forEach()` calls with modern `for..of` syntax
- Improves readability
- Changes are type checked, but all refactors in this PR required minor refactoring to satisfy strict type checking
  - Issues were all related to dereferencing or the mutability of e.g. `.length`
  - Expect no impact for single-thread browser code
  - Low risk remains