### PR TITLE
Remove NodeSlot.pos when serializing WidgetInputSlot

### DIFF
--- a/src/NodeSlot.ts
+++ b/src/NodeSlot.ts
@@ -1,4 +1,4 @@
-import type { CanvasColour, ConnectingLink, Dictionary, INodeInputSlot, INodeOutputSlot, INodeSlot, ISlotType, Point } from "./interfaces"
+import type { CanvasColour, ConnectingLink, Dictionary, INodeInputSlot, INodeOutputSlot, INodeSlot, ISlotType, IWidgetInputSlot, Point } from "./interfaces"
 import type { IWidget } from "./types/widgets"
 import type { LinkId } from "./LLink"
 import { LinkDirection, RenderShape } from "./types/globalEnums"
@@ -33,6 +33,10 @@ export function serializeSlot<T extends INodeSlot>(slot: T): T {
   if ("_data" in serialized) {
     delete serialized._data
   }
+  // Widget input slots' pos is calculated during layout, so we don't need to serialize it.
+  if (isWidgetInputSlot(slot) && "pos" in serialized) {
+    delete serialized.pos
+  }
   return serialized
 }
 
@@ -49,7 +53,7 @@ export function toNodeSlotClass(slot: INodeSlot): NodeSlot {
  * Whether this slot is an input slot and attached to a widget.
  * @param slot - The slot to check.
  */
-export function isWidgetInputSlot(slot: INodeSlot): boolean {
+export function isWidgetInputSlot(slot: INodeSlot): slot is IWidgetInputSlot {
   return isINodeInputSlot(slot) && !!slot.widget
 }
 

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -266,6 +266,10 @@ export interface INodeInputSlot extends INodeSlot {
   _layoutElement?: LayoutElement<INodeInputSlot>
 }
 
+export interface IWidgetInputSlot extends INodeInputSlot {
+  widget: IWidget
+}
+
 export interface INodeOutputSlot extends INodeSlot {
   links: LinkId[] | null
   _data?: unknown

--- a/test/NodeSlot.test.ts
+++ b/test/NodeSlot.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from "vitest"
+import { serializeSlot } from "@/NodeSlot"
+import { INodeInputSlot, INodeOutputSlot } from "@/interfaces"
+
+describe("NodeSlot", () => {
+  describe("serializeSlot", () => {
+    it("removes _data from serialized slot", () => {
+      const slot: INodeOutputSlot = {
+        _data: "test data",
+        name: "test-id",
+        type: "STRING",
+        links: [],
+      }
+      const serialized = serializeSlot(slot)
+      expect(serialized).not.toHaveProperty("_data")
+    })
+
+    it("removes pos from widget input slots", () => {
+      const widgetInputSlot: INodeInputSlot = {
+        name: "test-id",
+        pos: [10, 20],
+        type: "STRING",
+        link: null,
+        widget: {
+          name: "test-widget",
+          type: "combo",
+          value: "test-value-1",
+          options: {
+            values: ["test-value-1", "test-value-2"],
+          },
+        },
+      }
+
+      const serialized = serializeSlot(widgetInputSlot)
+      expect(serialized).not.toHaveProperty("pos")
+    })
+
+    it("preserves pos for non-widget input slots", () => {
+      const normalSlot: INodeInputSlot = {
+        name: "test-id",
+        type: "STRING",
+        pos: [10, 20],
+        link: null,
+      }
+      const serialized = serializeSlot(normalSlot)
+      expect(serialized).toHaveProperty("pos")
+    })
+  })
+})


### PR DESCRIPTION
`pos` is dynamically calculated during layout. So it should not be persisted to workflow.