### PR TITLE
[TS] Strict initializers - LGraph

### DIFF
--- a/src/LGraph.ts
+++ b/src/LGraph.ts
@@ -106,8 +106,8 @@ export class LGraph implements LinkNetwork, Serialisable<SerialisableGraph> {
   last_update_time: number = 0
   starttime: number = 0
   catch_errors: boolean = true
-  execution_timer_id: number | null = null
-  errors_in_execution: boolean = false
+  execution_timer_id?: number | null
+  errors_in_execution?: boolean
   /** @deprecated Unused */
   execution_time!: number
   _last_trigger_time?: number


### PR DESCRIPTION
Duplicates values from clear() to property initializers.