### PR TITLE
Widget Knob

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@comfyorg/litegraph",
-  "version": "0.8.94",
+  "version": "0.8.95",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@comfyorg/litegraph",
-      "version": "0.8.94",
+      "version": "0.8.95",
       "license": "MIT",
       "devDependencies": {
         "@eslint/js": "^9.14.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@comfyorg/litegraph",
-  "version": "0.8.95",
+  "version": "0.8.96",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@comfyorg/litegraph",
-      "version": "0.8.95",
+      "version": "0.8.96",
       "license": "MIT",
       "devDependencies": {
         "@eslint/js": "^9.14.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@comfyorg/litegraph",
-  "version": "0.8.95",
+  "version": "0.8.96",
   "type": "module",
   "description": "A graph node editor similar to PD or UDK Blueprints. It works in an HTML5 Canvas and allows to export graphs to be included in applications.",
   "main": "./dist/litegraph.umd.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@comfyorg/litegraph",
-  "version": "0.8.94",
+  "version": "0.8.95",
   "type": "module",
   "description": "A graph node editor similar to PD or UDK Blueprints. It works in an HTML5 Canvas and allows to export graphs to be included in applications.",
   "main": "./dist/litegraph.umd.js",

--- a/src/LGraphCanvas.ts
+++ b/src/LGraphCanvas.ts
@@ -1903,9 +1903,12 @@ export class LGraphCanvas implements ConnectionColorContext {
     for (const widget of node.widgets) {
       if (widget.hidden || (widget.advanced && !node.showAdvanced)) continue
 
-      let widgetWidth, widgetHeight
+      let widgetWidth: number, widgetHeight: number
       if (widget.computeSize) {
         ([widgetWidth, widgetHeight] = widget.computeSize(node.size[0]))
+      } else if (widget.computeLayoutSize) {
+        widgetWidth = widget.width
+        widgetHeight = widget.computedHeight
       } else {
         widgetWidth = widget.width || node.size[0]
         widgetHeight = LiteGraph.NODE_WIDGET_HEIGHT

--- a/src/LGraphNode.ts
+++ b/src/LGraphNode.ts
@@ -1063,10 +1063,8 @@ export class LGraphNode implements Positionable, IPinnable, IColorable {
 
   addOnTriggerInput(): number {
     const trigS = this.findInputSlot("onTrigger")
-    // !trigS ||
     if (trigS == -1) {
       this.addInput("onTrigger", LiteGraph.EVENT, {
-        optional: true,
         nameLocked: true,
       })
       return this.findInputSlot("onTrigger")
@@ -1076,10 +1074,8 @@ export class LGraphNode implements Positionable, IPinnable, IColorable {
 
   addOnExecutedOutput(): number {
     const trigS = this.findOutputSlot("onExecuted")
-    // !trigS ||
     if (trigS == -1) {
       this.addOutput("onExecuted", LiteGraph.ACTION, {
-        optional: true,
         nameLocked: true,
       })
       return this.findOutputSlot("onExecuted")
@@ -1349,7 +1345,7 @@ export class LGraphNode implements Positionable, IPinnable, IColorable {
   addOutput(
     name?: string,
     type?: ISlotType,
-    extra_info?: object,
+    extra_info?: Partial<INodeOutputSlot>,
   ): INodeOutputSlot {
     const output = new NodeOutputSlot({ name: name, type: type, links: null })
     if (extra_info) {
@@ -1374,7 +1370,7 @@ export class LGraphNode implements Positionable, IPinnable, IColorable {
    * add a new output slot to use in this node
    * @param array of triplets like [[name,type,extra_info],[...]]
    */
-  addOutputs(array: [string, ISlotType, Record<string, unknown>][]): void {
+  addOutputs(array: [string, ISlotType, Partial<INodeOutputSlot>][]): void {
     for (let i = 0; i < array.length; ++i) {
       const info = array[i]
       const o = new NodeOutputSlot({ name: info[0], type: info[1], links: null })
@@ -1423,7 +1419,7 @@ export class LGraphNode implements Positionable, IPinnable, IColorable {
    * @param type string defining the input type ("vec3","number",...), it its a generic one use 0
    * @param extra_info this can be used to have special properties of an input (label, color, position, etc)
    */
-  addInput(name: string, type: ISlotType, extra_info?: object): INodeInputSlot {
+  addInput(name: string, type: ISlotType, extra_info?: Partial<INodeInputSlot>): INodeInputSlot {
     type = type || 0
     const input: INodeInputSlot = new NodeInputSlot({ name: name, type: type, link: null })
     if (extra_info) {
@@ -1447,7 +1443,7 @@ export class LGraphNode implements Positionable, IPinnable, IColorable {
    * add several new input slots in this node
    * @param array of triplets like [[name,type,extra_info],[...]]
    */
-  addInputs(array: [string, ISlotType, Record<string, unknown>][]): void {
+  addInputs(array: [string, ISlotType, Partial<INodeInputSlot>][]): void {
     for (let i = 0; i < array.length; ++i) {
       const info = array[i]
       const o: INodeInputSlot = new NodeInputSlot({ name: info[0], type: info[1], link: null })

--- a/src/LGraphNode.ts
+++ b/src/LGraphNode.ts
@@ -1873,9 +1873,10 @@ export class LGraphNode implements Positionable, IPinnable, IColorable {
       )
         continue
 
-      const h = widget.computeSize
-        ? widget.computeSize(nodeWidth)[1]
-        : LiteGraph.NODE_WIDGET_HEIGHT
+      const h = widget.computedHeight ??
+        widget.computeSize?.(nodeWidth)[1] ??
+        LiteGraph.NODE_WIDGET_HEIGHT
+
       const w = widget.width || nodeWidth
       if (
         widget.last_y !== undefined &&
@@ -3362,6 +3363,9 @@ export class LGraphNode implements Positionable, IPinnable, IColorable {
     // Apply computed heights
     for (const [i, d] of growableWidgets.entries()) {
       d.w.computedHeight = allocations[i]
+      if (d.w.element) {
+        d.w.element.style.height = "" + 1000 + "px"
+      }
     }
 
     // Position widgets

--- a/src/LGraphNode.ts
+++ b/src/LGraphNode.ts
@@ -3363,9 +3363,6 @@ export class LGraphNode implements Positionable, IPinnable, IColorable {
     // Apply computed heights
     for (const [i, d] of growableWidgets.entries()) {
       d.w.computedHeight = allocations[i]
-      if (d.w.element) {
-        d.w.element.style.height = "" + 1000 + "px"
-      }
     }
 
     // Position widgets

--- a/src/litegraph.ts
+++ b/src/litegraph.ts
@@ -25,7 +25,7 @@ import type {
 import { isColorable } from "./typeGuards"
 import type { SlotShape, LabelPosition, SlotDirection, SlotType } from "./draw"
 import type { IWidget } from "./types/widgets"
-import type { RenderShape, TitleMode } from "./types/globalEnums"
+import { RenderShape, TitleMode } from "./types/globalEnums"
 import type { CanvasEventDetail } from "./types/events"
 import { LiteGraphGlobal } from "./LiteGraphGlobal"
 import { loadPolyfills } from "./polyfills"
@@ -79,6 +79,7 @@ export {
 }
 export { IWidget }
 export { LGraphBadge, BadgePosition }
+export { RenderShape, TitleMode }
 export { SlotShape, LabelPosition, SlotDirection, SlotType }
 export { EaseFunction, LinkMarkerShape, LGraphEventMode } from "./types/globalEnums"
 export type {

--- a/src/litegraph.ts
+++ b/src/litegraph.ts
@@ -22,7 +22,6 @@ import type {
   ColorOption,
   IColorable,
 } from "./interfaces"
-import { isColorable } from "./typeGuards"
 import type { SlotShape, LabelPosition, SlotDirection, SlotType } from "./draw"
 import type { IWidget } from "./types/widgets"
 import type { RenderShape, TitleMode } from "./types/globalEnums"
@@ -75,8 +74,8 @@ export {
   Size,
   ColorOption,
   IColorable,
-  isColorable,
 }
+export { isColorable } from "./utils/type"
 export { IWidget }
 export { LGraphBadge, BadgePosition }
 export { SlotShape, LabelPosition, SlotDirection, SlotType }

--- a/src/litegraph.ts
+++ b/src/litegraph.ts
@@ -25,7 +25,7 @@ import type {
 import { isColorable } from "./typeGuards"
 import type { SlotShape, LabelPosition, SlotDirection, SlotType } from "./draw"
 import type { IWidget } from "./types/widgets"
-import { RenderShape, TitleMode } from "./types/globalEnums"
+import type { RenderShape, TitleMode } from "./types/globalEnums"
 import type { CanvasEventDetail } from "./types/events"
 import { LiteGraphGlobal } from "./LiteGraphGlobal"
 import { loadPolyfills } from "./polyfills"
@@ -79,9 +79,8 @@ export {
 }
 export { IWidget }
 export { LGraphBadge, BadgePosition }
-export { RenderShape, TitleMode }
 export { SlotShape, LabelPosition, SlotDirection, SlotType }
-export { EaseFunction, LinkMarkerShape, LGraphEventMode } from "./types/globalEnums"
+export { CanvasItem, EaseFunction, LinkMarkerShape, LGraphEventMode, RenderShape, TitleMode } from "./types/globalEnums"
 export type {
   SerialisableGraph,
   SerialisableLLink,

--- a/src/typeGuards.ts
+++ b/src/typeGuards.ts
@@ -1,8 +1,0 @@
-import { IColorable } from "@/interfaces"
-
-/**
- * Checks if an object is an instance of {@link IColorable}.
- */
-export const isColorable = (obj: unknown): obj is IColorable => {
-  return typeof obj === "object" && obj !== null && "setColorOption" in obj && "getColorOption" in obj
-}

--- a/src/types/widgets.ts
+++ b/src/types/widgets.ts
@@ -73,10 +73,11 @@ export interface ISliderWidget extends IBaseWidget {
   options: IWidgetSliderOptions
 }
 
-export interface IKnobWidget extends IBaseWidget {
+export interface IKnobWidget<TElement extends HTMLElement = HTMLElement> extends IBaseWidget {
   type?: "knob"
   value: number
   options: IWidgetKnobOptions
+  element?: TElement
 }
 
 /** A combo-box widget (dropdown, select, etc) */

--- a/src/types/widgets.ts
+++ b/src/types/widgets.ts
@@ -29,6 +29,14 @@ export interface IWidgetSliderOptions extends IWidgetOptions<number> {
   marker_color?: CanvasColour
 }
 
+export interface IWidgetKnobOptions extends IWidgetOptions<number> {
+  min: number
+  max: number
+  step: number
+  slider_color?: CanvasColour // TODO: Replace with knob color
+  marker_color?: CanvasColour
+}
+
 /**
  * A widget for a node.
  * All types are based on IBaseWidget - additions can be made there or directly on individual types.
@@ -46,6 +54,7 @@ export type IWidget =
   | ICustomWidget
   | ISliderWidget
   | IButtonWidget
+  | IKnobWidget
 
 export interface IBooleanWidget extends IBaseWidget {
   type?: "toggle"
@@ -62,6 +71,12 @@ export interface ISliderWidget extends IBaseWidget {
   type?: "slider"
   value: number
   options: IWidgetSliderOptions
+}
+
+export interface IKnobWidget extends IBaseWidget {
+  type?: "knob"
+  value: number
+  options: IWidgetKnobOptions
 }
 
 /** A combo-box widget (dropdown, select, etc) */

--- a/src/types/widgets.ts
+++ b/src/types/widgets.ts
@@ -72,6 +72,7 @@ export interface ISliderWidget extends IBaseWidget {
   type?: "slider"
   value: number
   options: IWidgetSliderOptions
+  marker?: number
 }
 
 export interface IKnobWidget<TElement extends HTMLElement = HTMLElement> extends IBaseWidget {
@@ -139,7 +140,6 @@ export interface IBaseWidget<TElement extends HTMLElement = HTMLElement> {
   linkedWidgets?: IWidget[]
 
   options: IWidgetOptions
-  marker?: number
   label?: string
   name?: string
   /** Widget type (see {@link TWidgetType}) */

--- a/src/types/widgets.ts
+++ b/src/types/widgets.ts
@@ -35,6 +35,7 @@ export interface IWidgetKnobOptions extends IWidgetOptions<number> {
   step: number
   slider_color?: CanvasColour // TODO: Replace with knob color
   marker_color?: CanvasColour
+  gradient_stops?: string
 }
 
 /**

--- a/src/utils/type.ts
+++ b/src/utils/type.ts
@@ -1,3 +1,5 @@
+import type { IColorable } from "@/interfaces"
+
 /**
  * Converts a plain object to a class instance if it is not already an instance of the class.
  * @param cls The class to convert to
@@ -6,4 +8,11 @@
  */
 export function toClass<P, C>(cls: new (plain: P) => C, obj: P | C): C {
   return obj instanceof cls ? obj : new cls(obj as P)
+}
+
+/**
+ * Checks if an object is an instance of {@link IColorable}.
+ */
+export const isColorable = (obj: unknown): obj is IColorable => {
+  return typeof obj === "object" && obj !== null && "setColorOption" in obj && "getColorOption" in obj
 }

--- a/src/widgets/BaseWidget.ts
+++ b/src/widgets/BaseWidget.ts
@@ -7,9 +7,7 @@ import type { IBaseWidget, IWidget, IWidgetOptions, TWidgetType, TWidgetValue } 
 export abstract class BaseWidget implements IBaseWidget {
   linkedWidgets?: IWidget[]
   options: IWidgetOptions<unknown>
-  marker?: number
   label?: string
-  clicked?: boolean
   name?: string
   type?: TWidgetType
   value?: TWidgetValue

--- a/src/widgets/KnobWidget.ts
+++ b/src/widgets/KnobWidget.ts
@@ -5,16 +5,36 @@ import { LGraphCanvas } from "@/LGraphCanvas"
 import { CanvasMouseEvent } from "@/types/events"
 import { clamp } from "@/litegraph"
 
-export class KnobWidget extends BaseWidget implements IKnobWidget {
+export class KnobWidget extends BaseWidget implements IKnobWidget<HTMLElement> {
   declare type: "knob"
   declare value: number
   declare options: IWidgetKnobOptions
 
-  constructor(widget: IKnobWidget) {
+  constructor(widget: IKnobWidget<HTMLElement>) {
     super(widget)
     this.type = "knob"
     this.value = widget.value
     this.options = widget.options
+  }
+
+  computedHeight?: number
+  /**
+   * Compute the layout size of the widget.
+   * @param node The node this widget belongs to.
+   * @returns The layout size of the widget.
+   */
+  computeLayoutSize(): {
+    minHeight: number
+    maxHeight?: number
+    minWidth: number
+    maxWidth?: number
+  } {
+    return {
+      minHeight: 60,
+      minWidth: 20,
+      maxHeight: 1000000,
+      maxWidth: 1000000,
+    }
   }
 
   drawWidget(
@@ -32,39 +52,132 @@ export class KnobWidget extends BaseWidget implements IKnobWidget {
     const originalFillStyle = ctx.fillStyle
 
     const { y, width: widget_width, show_text = true, margin = 15 } = options
-    const H = this.height
+    const effective_height = this.computedHeight || this.height
 
     // Draw background
-    ctx.fillStyle = this.background_color
-    ctx.fillRect(margin, y, widget_width - margin * 2, H)
+    const size_modifier = Math.min(
+      this.computedHeight || this.height,
+      this.width || 20,
+    ) / 20 // TODO: replace magic numbers
+    const arc_center = { x: widget_width / 2, y: effective_height / 2 + y }
+    ctx.lineWidth = (Math.min(widget_width, effective_height) - (margin * size_modifier)) / 6
+    const arc_size = (Math.min(widget_width, effective_height) - (margin * size_modifier) - ctx.lineWidth) / 2
+    {
+      const gradient = ctx.createRadialGradient(
+        arc_center.x,
+        arc_center.y,
+        arc_size + ctx.lineWidth,
+        0,
+        0,
+        arc_size + ctx.lineWidth,
+      )
+      gradient.addColorStop(0, "rgb(29, 29, 29)")
+      gradient.addColorStop(1, "rgb(116, 116, 116)")
+      ctx.fillStyle = gradient
+    }
+    ctx.beginPath()
 
-    // Calculate normalized value
+    {
+      ctx.arc(
+        arc_center.x,
+        arc_center.y,
+        arc_size + ctx.lineWidth / 2,
+        0,
+        Math.PI * 2,
+        false,
+      )
+      ctx.fill()
+      ctx.closePath()
+    }
+
+    // Draw knob's background
+    const arc = {
+      start_angle: Math.PI * 0.6,
+      end_angle: Math.PI * 2.4,
+    }
+    ctx.beginPath()
+    {
+      const gradient = ctx.createRadialGradient(
+        arc_center.x,
+        arc_center.y,
+        arc_size + ctx.lineWidth,
+        0,
+        0,
+        arc_size + ctx.lineWidth,
+      )
+      gradient.addColorStop(0, "rgb(99, 99, 99)")
+      gradient.addColorStop(1, "rgb(36, 36, 36)")
+      ctx.strokeStyle = gradient
+    }
+    ctx.arc(
+      arc_center.x,
+      arc_center.y,
+      arc_size,
+      arc.start_angle,
+      arc.end_angle,
+      false,
+    )
+    ctx.stroke()
+    ctx.closePath()
+
     const range = this.options.max - this.options.min
     let nvalue = (this.value - this.options.min) / range
     nvalue = clamp(nvalue, 0, 1)
 
-    // Draw slider bar
-    ctx.fillStyle = this.options.slider_color ?? "#678"
-    ctx.fillRect(margin, y, nvalue * (widget_width - margin * 2), H)
+    // Draw value
+    ctx.beginPath()
+    const gradient = ctx.createConicGradient(
+      arc.start_angle,
+      arc_center.x,
+      arc_center.y,
+    )
+    gradient.addColorStop(0, "rgb(14, 182, 201)") // TODO: Parametrize these
+    gradient.addColorStop(1, "rgb(0, 216, 72)")
+    ctx.strokeStyle = gradient
+    const value_end_angle =
+      (arc.end_angle - arc.start_angle) * nvalue + arc.start_angle
+    ctx.arc(
+      arc_center.x,
+      arc_center.y,
+      arc_size,
+      arc.start_angle,
+      value_end_angle,
+      false,
+    )
+    ctx.stroke()
+    ctx.closePath()
 
     // Draw outline if not disabled
     if (show_text && !this.disabled) {
       ctx.strokeStyle = this.outline_color
-      ctx.strokeRect(margin, y, widget_width - margin * 2, H)
+      // Draw value
+      ctx.beginPath()
+      ctx.strokeStyle = this.outline_color
+      ctx.arc(
+        arc_center.x,
+        arc_center.y,
+        arc_size + ctx.lineWidth / 2,
+        0,
+        Math.PI * 2,
+        false,
+      )
+      ctx.lineWidth = 1
+      ctx.stroke()
+      ctx.closePath()
     }
 
-    // Draw marker if present
-    if (this.marker != null) {
-      let marker_nvalue = (this.marker - this.options.min) / range
-      marker_nvalue = clamp(marker_nvalue, 0, 1)
-      ctx.fillStyle = this.options.marker_color ?? "#AA9"
-      ctx.fillRect(
-        margin + marker_nvalue * (widget_width - margin * 2),
-        y,
-        2,
-        H,
-      )
-    }
+    // // Draw marker if present
+    // if (this.marker != null) {
+    //   let marker_nvalue = (this.marker - this.options.min) / range
+    //   marker_nvalue = clamp(marker_nvalue, 0, 1)
+    //   ctx.fillStyle = this.options.marker_color ?? "#AA9"
+    //   ctx.fillRect(
+    //     margin + marker_nvalue * (widget_width - margin * 2),
+    //     y,
+    //     2,
+    //     H,
+    //   )
+    // }
 
     // Draw text
     if (show_text) {
@@ -77,7 +190,7 @@ export class KnobWidget extends BaseWidget implements IKnobWidget {
             this.options.precision != null ? this.options.precision : 3,
           ),
         widget_width * 0.5,
-        y + H * 0.7,
+        y + effective_height * 0.5,
       )
     }
 
@@ -92,20 +205,7 @@ export class KnobWidget extends BaseWidget implements IKnobWidget {
     node: LGraphNode
     canvas: LGraphCanvas
   }): void {
-    if (this.options.read_only) return
-
-    const { e, node } = options
-    const width = this.width || node.size[0]
-    const x = e.canvasX - node.pos[0]
-
-    // Calculate new value based on click position
-    const slideFactor = clamp((x - 15) / (width - 30), 0, 1)
-    const newValue =
-      this.options.min + (this.options.max - this.options.min) * slideFactor
-
-    if (newValue !== this.value) {
-      this.setValue(newValue, options)
-    }
+    return
   }
 
   override onDrag(options: {
@@ -114,16 +214,23 @@ export class KnobWidget extends BaseWidget implements IKnobWidget {
     canvas: LGraphCanvas
   }): void {
     if (this.options.read_only) return
-
-    const { e, node } = options
-    const width = this.width || node.size[0]
-    const x = e.canvasX - node.pos[0]
-
-    // Calculate new value based on drag position
-    const slideFactor = clamp((x - 15) / (width - 30), 0, 1)
-    const newValue =
-      this.options.min + (this.options.max - this.options.min) * slideFactor
-
+    const { e } = options
+    const size_modifier = Math.min(
+      this.computedHeight || this.height,
+      this.width || 20,
+    )
+    const shift_modifier = e.shiftKey ? 0.5 : 1.0 // Consider this for other widgets
+    const deltaX = (e.movementX / size_modifier) * shift_modifier
+    const step = this.options.step
+    // Calculate new value based on drag movement
+    // HACK: For some reason, the front-end multiplies step by 10, this brings it down to the advertised value
+    // see src/utils/mathUtil.ts@getNumberDefaults
+    const deltaValue = (deltaX * step) / 10
+    const newValue = clamp(
+      this.value + deltaValue,
+      this.options.min,
+      this.options.max,
+    )
     if (newValue !== this.value) {
       this.setValue(newValue, options)
     }

--- a/src/widgets/KnobWidget.ts
+++ b/src/widgets/KnobWidget.ts
@@ -37,6 +37,10 @@ export class KnobWidget extends BaseWidget implements IKnobWidget<HTMLElement> {
     }
   }
 
+  get height(): number {
+    return this.computedHeight || super.height
+  }
+
   drawWidget(
     ctx: CanvasRenderingContext2D,
     options: {
@@ -53,15 +57,16 @@ export class KnobWidget extends BaseWidget implements IKnobWidget<HTMLElement> {
 
     const { y, width: widget_width, show_text = true, margin = 15 } = options
     const effective_height = this.computedHeight || this.height
-
     // Draw background
-    const size_modifier = Math.min(
-      this.computedHeight || this.height,
-      this.width || 20,
-    ) / 20 // TODO: replace magic numbers
+    const size_modifier =
+      Math.min(this.computedHeight || this.height, this.width || 20) / 20 // TODO: replace magic numbers
     const arc_center = { x: widget_width / 2, y: effective_height / 2 + y }
-    ctx.lineWidth = (Math.min(widget_width, effective_height) - (margin * size_modifier)) / 6
-    const arc_size = (Math.min(widget_width, effective_height) - (margin * size_modifier) - ctx.lineWidth) / 2
+    ctx.lineWidth =
+      (Math.min(widget_width, effective_height) - margin * size_modifier) / 6
+    const arc_size =
+      (Math.min(widget_width, effective_height) -
+        margin * size_modifier -
+        ctx.lineWidth) / 2
     {
       const gradient = ctx.createRadialGradient(
         arc_center.x,
@@ -185,10 +190,10 @@ export class KnobWidget extends BaseWidget implements IKnobWidget<HTMLElement> {
       ctx.fillStyle = this.text_color
       ctx.fillText(
         (this.label || this.name) +
-          "  " +
-          Number(this.value).toFixed(
-            this.options.precision != null ? this.options.precision : 3,
-          ),
+        "\n" +
+        Number(this.value).toFixed(
+          this.options.precision != null ? this.options.precision : 3,
+        ),
         widget_width * 0.5,
         y + effective_height * 0.5,
       )
@@ -200,11 +205,7 @@ export class KnobWidget extends BaseWidget implements IKnobWidget<HTMLElement> {
     ctx.fillStyle = originalFillStyle
   }
 
-  onClick(options: {
-    e: CanvasMouseEvent
-    node: LGraphNode
-    canvas: LGraphCanvas
-  }): void {
+  onClick(): void {
     return
   }
 

--- a/src/widgets/KnobWidget.ts
+++ b/src/widgets/KnobWidget.ts
@@ -1,0 +1,131 @@
+import type { IKnobWidget, IWidgetKnobOptions } from "@/types/widgets"
+import { BaseWidget } from "./BaseWidget"
+import type { LGraphNode } from "@/LGraphNode"
+import { LGraphCanvas } from "@/LGraphCanvas"
+import { CanvasMouseEvent } from "@/types/events"
+import { clamp } from "@/litegraph"
+
+export class KnobWidget extends BaseWidget implements IKnobWidget {
+  declare type: "knob"
+  declare value: number
+  declare options: IWidgetKnobOptions
+
+  constructor(widget: IKnobWidget) {
+    super(widget)
+    this.type = "knob"
+    this.value = widget.value
+    this.options = widget.options
+  }
+
+  drawWidget(
+    ctx: CanvasRenderingContext2D,
+    options: {
+      y: number
+      width: number
+      show_text?: boolean
+      margin?: number
+    },
+  ): void {
+    // Store original context attributes
+    const originalTextAlign = ctx.textAlign
+    const originalStrokeStyle = ctx.strokeStyle
+    const originalFillStyle = ctx.fillStyle
+
+    const { y, width: widget_width, show_text = true, margin = 15 } = options
+    const H = this.height
+
+    // Draw background
+    ctx.fillStyle = this.background_color
+    ctx.fillRect(margin, y, widget_width - margin * 2, H)
+
+    // Calculate normalized value
+    const range = this.options.max - this.options.min
+    let nvalue = (this.value - this.options.min) / range
+    nvalue = clamp(nvalue, 0, 1)
+
+    // Draw slider bar
+    ctx.fillStyle = this.options.slider_color ?? "#678"
+    ctx.fillRect(margin, y, nvalue * (widget_width - margin * 2), H)
+
+    // Draw outline if not disabled
+    if (show_text && !this.disabled) {
+      ctx.strokeStyle = this.outline_color
+      ctx.strokeRect(margin, y, widget_width - margin * 2, H)
+    }
+
+    // Draw marker if present
+    if (this.marker != null) {
+      let marker_nvalue = (this.marker - this.options.min) / range
+      marker_nvalue = clamp(marker_nvalue, 0, 1)
+      ctx.fillStyle = this.options.marker_color ?? "#AA9"
+      ctx.fillRect(
+        margin + marker_nvalue * (widget_width - margin * 2),
+        y,
+        2,
+        H,
+      )
+    }
+
+    // Draw text
+    if (show_text) {
+      ctx.textAlign = "center"
+      ctx.fillStyle = this.text_color
+      ctx.fillText(
+        (this.label || this.name) +
+          "  " +
+          Number(this.value).toFixed(
+            this.options.precision != null ? this.options.precision : 3,
+          ),
+        widget_width * 0.5,
+        y + H * 0.7,
+      )
+    }
+
+    // Restore original context attributes
+    ctx.textAlign = originalTextAlign
+    ctx.strokeStyle = originalStrokeStyle
+    ctx.fillStyle = originalFillStyle
+  }
+
+  onClick(options: {
+    e: CanvasMouseEvent
+    node: LGraphNode
+    canvas: LGraphCanvas
+  }): void {
+    if (this.options.read_only) return
+
+    const { e, node } = options
+    const width = this.width || node.size[0]
+    const x = e.canvasX - node.pos[0]
+
+    // Calculate new value based on click position
+    const slideFactor = clamp((x - 15) / (width - 30), 0, 1)
+    const newValue =
+      this.options.min + (this.options.max - this.options.min) * slideFactor
+
+    if (newValue !== this.value) {
+      this.setValue(newValue, options)
+    }
+  }
+
+  override onDrag(options: {
+    e: CanvasMouseEvent
+    node: LGraphNode
+    canvas: LGraphCanvas
+  }): void {
+    if (this.options.read_only) return
+
+    const { e, node } = options
+    const width = this.width || node.size[0]
+    const x = e.canvasX - node.pos[0]
+
+    // Calculate new value based on drag position
+    const slideFactor = clamp((x - 15) / (width - 30), 0, 1)
+    const newValue =
+      this.options.min + (this.options.max - this.options.min) * slideFactor
+
+    if (newValue !== this.value) {
+      this.setValue(newValue, options)
+    }
+  }
+}

--- a/src/widgets/SliderWidget.ts
+++ b/src/widgets/SliderWidget.ts
@@ -10,12 +10,14 @@ export class SliderWidget extends BaseWidget implements ISliderWidget {
   declare type: "slider"
   declare value: number
   declare options: IWidgetSliderOptions
+  marker?: number
 
   constructor(widget: ISliderWidget) {
     super(widget)
     this.type = "slider"
     this.value = widget.value
     this.options = widget.options
+    this.marker = widget.marker
   }
 
   /**

--- a/src/widgets/widgetMap.ts
+++ b/src/widgets/widgetMap.ts
@@ -7,6 +7,7 @@ import { NumberWidget } from "./NumberWidget"
 import { SliderWidget } from "./SliderWidget"
 import { TextWidget } from "./TextWidget"
 import { BaseWidget } from "./BaseWidget"
+import { KnobWidget } from "./KnobWidget"
 
 type WidgetConstructor = {
   new (plain: IBaseWidget): BaseWidget
@@ -16,6 +17,7 @@ export const WIDGET_TYPE_MAP: Record<string, WidgetConstructor> = {
   button: ButtonWidget,
   toggle: BooleanWidget,
   slider: SliderWidget,
+  knob: KnobWidget,
   combo: ComboWidget,
   number: NumberWidget,
   string: TextWidget,


### PR DESCRIPTION
Work in progress of:
A more visual widget that the usual number/slider. Differentiates itself from the functionality of a slider by not setting the value on click, only stepping, emulating an actual knob.

- Left/Right takes 1 step at a time
- Up/Down moves 1% or 1 step, whichever is larger
- Move + Shift moves by 10% or 1 step, whichever is larger

This also includes a fix to some size logic, see 970320854aa0d16f2e38caeeaf648bd25ad8baf0 and also (5abb27041ee5ea3b22a901e9cc657afa66166a93)
- [x] ~~Still missing being able to drag the knob itself, as the clicking of the widget is not recognized if it's outside of where a normal height widget would be.~~
![knob-node](https://github.com/user-attachments/assets/9d0ce70d-a220-49d0-987f-8dcef2b1d299)

