### PR TITLE
Export enum

### DIFF
--- a/src/litegraph.ts
+++ b/src/litegraph.ts
@@ -80,7 +80,7 @@ export {
 export { IWidget }
 export { LGraphBadge, BadgePosition }
 export { SlotShape, LabelPosition, SlotDirection, SlotType }
-export { EaseFunction, LinkMarkerShape, LGraphEventMode } from "./types/globalEnums"
+export { CanvasItem, EaseFunction, LinkMarkerShape, LGraphEventMode, RenderShape, TitleMode } from "./types/globalEnums"
 export type {
   SerialisableGraph,
   SerialisableLLink,


### PR DESCRIPTION
- Follow-up on #587 
- Restores type-only import for legacy interface definition
- Uses export-only syntax for enums