### PR TITLE
[API] Remove LiteGraph.searchbox_extras

### DIFF
--- a/src/LGraphCanvas.ts
+++ b/src/LGraphCanvas.ts
@@ -6251,46 +6251,11 @@ export class LGraphCanvas implements ConnectionColorContext {
         if (that.onSearchBoxSelection) {
           that.onSearchBoxSelection(name, event, graphcanvas)
         } else {
-          const extra = LiteGraph.searchbox_extras[name.toLowerCase()]
-          if (extra) name = extra.type
-
           graphcanvas.graph.beforeChange()
           const node = LiteGraph.createNode(name)
           if (node) {
             node.pos = graphcanvas.convertEventToCanvasOffset(event)
             graphcanvas.graph.add(node, false)
-          }
-
-          if (extra?.data) {
-            if (extra.data.properties) {
-              for (const i in extra.data.properties) {
-                node.addProperty(i, extra.data.properties[i])
-              }
-            }
-            if (extra.data.inputs) {
-              node.inputs = []
-              for (const i in extra.data.inputs) {
-                node.addOutput(
-                  extra.data.inputs[i][0],
-                  extra.data.inputs[i][1],
-                )
-              }
-            }
-            if (extra.data.outputs) {
-              node.outputs = []
-              for (const i in extra.data.outputs) {
-                node.addOutput(
-                  extra.data.outputs[i][0],
-                  extra.data.outputs[i][1],
-                )
-              }
-            }
-            if (extra.data.title) {
-              node.title = extra.data.title
-            }
-            if (extra.data.json) {
-              node.configure(extra.data.json)
-            }
           }
 
           // join node after inserting
@@ -6405,24 +6370,6 @@ export class LGraphCanvas implements ConnectionColorContext {
         if (options.do_type_filter && that.search_box) {
           sIn = that.search_box.querySelector(".slot_in_type_filter")
           sOut = that.search_box.querySelector(".slot_out_type_filter")
-        }
-
-        // extras
-        for (const i in LiteGraph.searchbox_extras) {
-          const extra = LiteGraph.searchbox_extras[i]
-          if (
-            (!options.show_all_if_empty || str) &&
-            extra.desc.toLowerCase().indexOf(str) === -1
-          )
-            continue
-          const ctor = LiteGraph.registered_node_types[extra.type]
-          if (ctor && ctor.filter != filter) continue
-          if (!inner_test_filter(extra.type)) continue
-
-          addResult(extra.desc, "searchbox_extra")
-          if (LGraphCanvas.search_limit !== -1 && c++ > LGraphCanvas.search_limit) {
-            break
-          }
         }
 
         let filtered = null

--- a/src/LiteGraphGlobal.ts
+++ b/src/LiteGraphGlobal.ts
@@ -145,7 +145,7 @@ export class LiteGraphGlobal {
   /** used to store vars between graphs */
   Globals = {}
 
-  /** used to add extra features to the search box */
+  /** @deprecated Unused and will be deleted. */
   searchbox_extras = {}
 
   /** [true!] this make the nodes box (top left circle) coloured when triggered (execute/action), visual feedback */
@@ -621,20 +621,6 @@ export class LiteGraphGlobal {
     }
 
     return false
-  }
-
-  /**
-   * Register a string in the search box so when the user types it it will recommend this node
-   * @param node_type the node recommended
-   * @param description text to show next to it
-   * @param data it could contain info of how the node should be configured
-   */
-  registerSearchboxExtra(node_type: any, description: string, data: any): void {
-    this.searchbox_extras[description.toLowerCase()] = {
-      type: node_type,
-      desc: description,
-      data: data,
-    }
   }
 
   // used to create nodes from wrapping functions


### PR DESCRIPTION
- Unused, loose typing
- Code search shows usage is limited to code copy & paste of litegraph code
- So long as the `searchbox_extras` property exists and is empty, there is no change to downstream consumers