### PR TITLE
[TS] Use strict mode in LiteGraphGlobal

### DIFF
--- a/src/LiteGraphGlobal.ts
+++ b/src/LiteGraphGlobal.ts
@@ -321,7 +321,7 @@ export class LiteGraphGlobal {
 
     // extend class
     for (const i in LGraphNode.prototype) {
-      // @ts-expect-error #576 This functionality is deprecated and should be removed.
+      // @ts-ignore #576 This functionality is deprecated and should be removed.
       base_class.prototype[i] ||= LGraphNode.prototype[i]
     }
 
@@ -466,7 +466,7 @@ export class LiteGraphGlobal {
     // extra options
     if (options) {
       for (const i in options) {
-        // @ts-expect-error #577 Requires interface
+        // @ts-ignore #577 Requires interface
         node[i] = options[i]
       }
     }
@@ -570,7 +570,7 @@ export class LiteGraphGlobal {
     if (!target) return r
 
     for (const i in r) {
-      // @ts-expect-error deprecated
+      // @ts-ignore deprecated
       target[i] = r[i]
     }
     return target


### PR DESCRIPTION
- Adds minor type coercions to resolve type errors
- Adds ts-ignore that must be removed later
  * [x] #578