### PR TITLE
[TS] Use strict mode in LGraphGroup

### DIFF
--- a/src/LGraph.ts
+++ b/src/LGraph.ts
@@ -869,7 +869,7 @@ export class LGraph implements LinkNetwork, Serialisable<SerialisableGraph> {
       if (index != -1) {
         this._groups.splice(index, 1)
       }
-      node.graph = null
+      node.graph = undefined
       this._version++
       this.setDirtyCanvas(true, true)
       this.change()

--- a/src/LGraphGroup.ts
+++ b/src/LGraphGroup.ts
@@ -22,6 +22,7 @@ import {
 } from "./measure"
 import { LGraphNode } from "./LGraphNode"
 import { strokeShape } from "./draw"
+import { NullGraphError } from "@/infrastructure/NullGraphError"
 
 export interface IGraphGroupFlags extends Record<string, unknown> {
   pinned?: true
@@ -51,7 +52,7 @@ export class LGraphGroup implements Positionable, IPinnable, IColorable {
   /** @deprecated See {@link _children} */
   _nodes: LGraphNode[] = []
   _children: Set<Positionable> = new Set()
-  graph: LGraph | null = null
+  graph?: LGraph
   flags: IGraphGroupFlags = {}
   selected?: boolean
 
@@ -236,6 +237,7 @@ export class LGraphGroup implements Positionable, IPinnable, IColorable {
   }
 
   recomputeInsideNodes(): void {
+    if (!this.graph) throw new NullGraphError()
     const { nodes, reroutes, groups } = this.graph
     const children = this._children
     this._nodes.length = 0

--- a/src/infrastructure/NullGraphError.ts
+++ b/src/infrastructure/NullGraphError.ts
@@ -1,0 +1,6 @@
+export class NullGraphError extends Error {
+  constructor(message: string = "Attempted to access LGraph reference that was null or undefined.", cause?: Error) {
+    super(message, { cause })
+    this.name = "NullGraphError"
+  }
+}


### PR DESCRIPTION
- Adds `NullGraphError` to reduce boilerplate null check code
- Prefer optional `undefined` to explicit `null`
  - Related: https://github.com/Comfy-Org/ComfyUI_frontend/issues/4737
- Adds strict types