### PR TITLE
Fix widget sizing logic in LGraphCanvas and LGraphNode

### DIFF
--- a/src/LGraphCanvas.ts
+++ b/src/LGraphCanvas.ts
@@ -1905,9 +1905,12 @@ export class LGraphCanvas implements ConnectionColorContext {
     for (const widget of node.widgets) {
       if (widget.hidden || (widget.advanced && !node.showAdvanced)) continue
 
-      let widgetWidth, widgetHeight
+      let widgetWidth: number, widgetHeight: number
       if (widget.computeSize) {
         ([widgetWidth, widgetHeight] = widget.computeSize(node.size[0]))
+      } else if (widget.computeLayoutSize) {
+        widgetWidth = widget.width
+        widgetHeight = widget.computedHeight
       } else {
         widgetWidth = widget.width || node.size[0]
         widgetHeight = LiteGraph.NODE_WIDGET_HEIGHT

--- a/src/LGraphNode.ts
+++ b/src/LGraphNode.ts
@@ -1898,9 +1898,10 @@ export class LGraphNode implements Positionable, IPinnable, IColorable {
       )
         continue
 
-      const h = widget.computeSize
-        ? widget.computeSize(nodeWidth)[1]
-        : LiteGraph.NODE_WIDGET_HEIGHT
+      const h = widget.computedHeight ??
+        widget.computeSize?.(nodeWidth)[1] ??
+        LiteGraph.NODE_WIDGET_HEIGHT
+
       const w = widget.width || nodeWidth
       if (
         widget.last_y !== undefined &&


### PR DESCRIPTION
This fixes an issue with widget heights not coinciding with actual computed heights.
<img src="https://github.com/user-attachments/assets/50b4b86c-8de8-4844-9a17-6f18d32e7f5e" height="128" alt="old">old
<img src="https://github.com/user-attachments/assets/c34e432a-6941-469e-99cd-df15c0a527de" height="256" alt="new">new

