### PR TITLE
Enforce curly braces in multi-line if statements

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -224,6 +224,7 @@ export default tseslint.config(
     rules: {
       "antfu/consistent-chaining": "error",
       "antfu/consistent-list-newline": "error",
+      "antfu/curly": "error",
     },
   },
 

--- a/src/CurveEditor.ts
+++ b/src/CurveEditor.ts
@@ -77,7 +77,7 @@ export class CurveEditor {
     }
     ctx.stroke()
     ctx.globalAlpha = 1
-    if (!inactive)
+    if (!inactive) {
       for (const [i, p] of points.entries()) {
         ctx.fillStyle = this.selected == i
           ? "#FFF"
@@ -86,6 +86,7 @@ export class CurveEditor {
         ctx.arc(p[0] * w, (1.0 - p[1]) * h, 2, 0, Math.PI * 2)
         ctx.fill()
       }
+    }
     ctx.restore()
   }
 

--- a/src/LGraph.ts
+++ b/src/LGraph.ts
@@ -1625,8 +1625,9 @@ export class LGraph implements LinkNetwork, Serialisable<SerialisableGraph> {
         i == "links" ||
         i === "state" ||
         i === "reroutes"
-      )
+      ) {
         continue
+      }
       // @ts-ignore #574 Legacy property assignment
       this[i] = data[i]
     }

--- a/src/LGraphCanvas.ts
+++ b/src/LGraphCanvas.ts
@@ -1267,16 +1267,19 @@ export class LGraphCanvas implements ConnectionColorContext {
 
     let dialogCloseTimer = null
     dialog.addEventListener("mouseleave", function () {
-      if (LiteGraph.dialog_close_on_mouse_leave)
-        if (!dialog.is_modified && LiteGraph.dialog_close_on_mouse_leave)
+      if (LiteGraph.dialog_close_on_mouse_leave) {
+        if (!dialog.is_modified && LiteGraph.dialog_close_on_mouse_leave) {
           dialogCloseTimer = setTimeout(
             dialog.close,
             LiteGraph.dialog_close_on_mouse_leave_delay,
           )
+        }
+      }
     })
     dialog.addEventListener("mouseenter", function () {
-      if (LiteGraph.dialog_close_on_mouse_leave)
+      if (LiteGraph.dialog_close_on_mouse_leave) {
         if (dialogCloseTimer) clearTimeout(dialogCloseTimer)
+      }
     })
 
     function inner() {
@@ -1381,9 +1384,9 @@ export class LGraphCanvas implements ConnectionColorContext {
 
       const kV = Object.values(LiteGraph.NODE_MODES).indexOf(v)
       const fApplyMultiNode = function (node) {
-        if (kV >= 0 && LiteGraph.NODE_MODES[kV])
+        if (kV >= 0 && LiteGraph.NODE_MODES[kV]) {
           node.changeMode(kV)
-        else {
+        } else {
           console.warn("unexpected mode: " + v)
           node.changeMode(LGraphEventMode.ALWAYS)
         }
@@ -5120,8 +5123,9 @@ export class LGraphCanvas implements ConnectionColorContext {
         this.#snapToGrid &&
         this.isDragging &&
         this.selectedItems.has(reroute)
-      )
+      ) {
         this.drawSnapGuide(ctx, reroute, RenderShape.CIRCLE)
+      }
       reroute.draw(ctx)
     }
     ctx.globalAlpha = 1
@@ -5931,12 +5935,14 @@ export class LGraphCanvas implements ConnectionColorContext {
     let prevent_timeout = 0
     LiteGraph.pointerListenerAdd(dialog, "leave", function () {
       if (prevent_timeout) return
-      if (LiteGraph.dialog_close_on_mouse_leave)
-        if (!dialog.is_modified && LiteGraph.dialog_close_on_mouse_leave)
+      if (LiteGraph.dialog_close_on_mouse_leave) {
+        if (!dialog.is_modified && LiteGraph.dialog_close_on_mouse_leave) {
           dialogCloseTimer = setTimeout(
             dialog.close,
             LiteGraph.dialog_close_on_mouse_leave_delay,
           )
+        }
+      }
     })
     LiteGraph.pointerListenerAdd(dialog, "enter", function () {
       if (LiteGraph.dialog_close_on_mouse_leave && dialogCloseTimer)
@@ -6069,9 +6075,9 @@ export class LGraphCanvas implements ConnectionColorContext {
     }
     dialog.innerHTML += "<div class='helper'></div>"
 
-    if (root_document.fullscreenElement)
+    if (root_document.fullscreenElement) {
       root_document.fullscreenElement.appendChild(dialog)
-    else {
+    } else {
       root_document.body.appendChild(dialog)
       root_document.body.style.overflow = "hidden"
     }
@@ -6203,8 +6209,9 @@ export class LGraphCanvas implements ConnectionColorContext {
         if (
           options.type_filter_in == LiteGraph.EVENT ||
           options.type_filter_in == LiteGraph.ACTION
-        )
+        ) {
           options.type_filter_in = "_event_"
+        }
         /* this will filter on * .. but better do it manually in case
                 else if(options.type_filter_in === "" || options.type_filter_in === 0)
                     options.type_filter_in = "*"; */
@@ -6238,8 +6245,9 @@ export class LGraphCanvas implements ConnectionColorContext {
         if (
           options.type_filter_out == LiteGraph.EVENT ||
           options.type_filter_out == LiteGraph.ACTION
-        )
+        ) {
           options.type_filter_out = "_event_"
+        }
         /* this will filter on * .. but better do it manually in case
                 else if(options.type_filter_out === "" || options.type_filter_out === 0)
                     options.type_filter_out = "*"; */
@@ -6252,8 +6260,9 @@ export class LGraphCanvas implements ConnectionColorContext {
             options.type_filter_out !== false &&
             (options.type_filter_out + "").toLowerCase() ==
             (aSlots[iK] + "").toLowerCase()
-          )
+          ) {
             opt.selected = true
+          }
         }
         selOut.addEventListener("change", function () {
           refreshHelper()
@@ -6440,9 +6449,10 @@ export class LGraphCanvas implements ConnectionColorContext {
                 inTypeOverride: sIn && sIn.value ? "*" : false,
                 outTypeOverride: sOut && sOut.value ? "*" : false,
               })
-            )
+            ) {
               // @ts-expect-error
               filtered_extra.push(i)
+            }
           }
           // @ts-expect-error
           for (const extraItem of filtered_extra) {
@@ -6496,8 +6506,9 @@ export class LGraphCanvas implements ConnectionColorContext {
             (!options.show_all_if_empty || str) &&
             type.toLowerCase().indexOf(str) === -1 &&
             (!ctor.title || ctor.title.toLowerCase().indexOf(str) === -1)
-          )
+          ) {
             return false
+          }
 
           // filter by slot IN, OUT types
           if (options.do_type_filter && !opts.skipFilter) {
@@ -6670,8 +6681,9 @@ export class LGraphCanvas implements ConnectionColorContext {
         info?.values &&
         typeof info.values === "object" &&
         info.values[value] != undefined
-      )
+      ) {
         value = info.values[value]
+      }
 
       if (typeof node.properties[property] == "number") {
         value = Number(value)
@@ -6765,15 +6777,17 @@ export class LGraphCanvas implements ConnectionColorContext {
     dialog.addEventListener("mouseleave", function () {
       if (prevent_timeout) return
 
-      if (!dialog.is_modified && LiteGraph.dialog_close_on_mouse_leave)
+      if (!dialog.is_modified && LiteGraph.dialog_close_on_mouse_leave) {
         dialogCloseTimer = setTimeout(
           dialog.close,
           LiteGraph.dialog_close_on_mouse_leave_delay,
         )
+      }
     })
     dialog.addEventListener("mouseenter", function () {
-      if (options.closeOnLeave || LiteGraph.dialog_close_on_mouse_leave)
+      if (options.closeOnLeave || LiteGraph.dialog_close_on_mouse_leave) {
         if (dialogCloseTimer) clearTimeout(dialogCloseTimer)
+      }
     })
     const selInDia = dialog.querySelectorAll("select")
     // if filtering, check focus changed to comboboxes and prevent closing
@@ -6905,11 +6919,11 @@ export class LGraphCanvas implements ConnectionColorContext {
       elem.options = options
       elem.value = value
 
-      if (type == "code")
+      if (type == "code") {
         elem.addEventListener("click", function () {
           root.inner_showCodePad(this.dataset["property"])
         })
-      else if (type == "boolean") {
+      } else if (type == "boolean") {
         elem.classList.add("boolean")
         if (value) elem.classList.add("bool-on")
         elem.addEventListener("click", function () {

--- a/src/LGraphNode.ts
+++ b/src/LGraphNode.ts
@@ -1213,8 +1213,9 @@ export class LGraphNode implements Positionable, IPinnable, IColorable {
         !output ||
         output.type !== LiteGraph.EVENT ||
         (action && output.name != action)
-      )
+      ) {
         continue
+      }
       this.triggerSlot(i, param, null, options)
     }
   }
@@ -1893,8 +1894,9 @@ export class LGraphNode implements Positionable, IPinnable, IColorable {
         (widget.disabled && !includeDisabled) ||
         widget.hidden ||
         (widget.advanced && !this.showAdvanced)
-      )
+      ) {
         continue
+      }
 
       const h = widget.computeSize
         ? widget.computeSize(nodeWidth)[1]
@@ -1903,8 +1905,9 @@ export class LGraphNode implements Positionable, IPinnable, IColorable {
       if (
         widget.last_y !== undefined &&
         isInRectangle(x, y, 6, widget.last_y, w - 12, h)
-      )
+      ) {
         return widget
+      }
     }
     return null
   }
@@ -2972,14 +2975,14 @@ export class LGraphNode implements Positionable, IPinnable, IColorable {
       }
 
       ctx.fillStyle = this.renderingBoxColor
-      if (low_quality)
+      if (low_quality) {
         ctx.fillRect(
           title_height * 0.5 - box_size * 0.5,
           title_height * -0.5 - box_size * 0.5,
           box_size,
           box_size,
         )
-      else {
+      } else {
         ctx.beginPath()
         ctx.arc(
           title_height * 0.5,

--- a/src/LiteGraphGlobal.ts
+++ b/src/LiteGraphGlobal.ts
@@ -602,8 +602,9 @@ export class LiteGraphGlobal {
       !type_b ||
       type_a == type_b ||
       (type_a == this.EVENT && type_b == this.ACTION)
-    )
+    ) {
       return true
+    }
 
     // Enforce string type to handle toLowerCase call (-1 number not ok)
     type_a = String(type_a)

--- a/src/MapProxyHandler.ts
+++ b/src/MapProxyHandler.ts
@@ -8,10 +8,12 @@ export class MapProxyHandler<V> implements ProxyHandler<Map<number | string, V>>
     p: string | symbol,
   ): PropertyDescriptor | undefined {
     const value = this.get(target, p)
-    if (value) return {
-      configurable: true,
-      enumerable: true,
-      value,
+    if (value) {
+      return {
+        configurable: true,
+        enumerable: true,
+        value,
+      }
     }
   }
 

--- a/src/polyfills.ts
+++ b/src/polyfills.ts
@@ -29,9 +29,9 @@ export function loadPolyfills() {
 
       // make it compatible with official one
       if (Array.isArray(radius)) {
-        if (radius.length == 1)
+        if (radius.length == 1) {
           top_left_radius = top_right_radius = bottom_left_radius = bottom_right_radius = radius[0]
-        else if (radius.length == 2) {
+        } else if (radius.length == 2) {
           top_left_radius = bottom_right_radius = radius[0]
           top_right_radius = bottom_left_radius = radius[1]
         } else if (radius.length == 4) {


### PR DESCRIPTION
Removes formatters' ability to print code that goes to a new line, but uses no braces to delineate.

It becomes more difficult to follow when using JS-style indents (two spaces).

No effort required - braces added by auto-fixer.