### PR TITLE
Add ESLint rules to enforce existing lib style

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -226,6 +226,9 @@ export default tseslint.config(
       "antfu/consistent-list-newline": "error",
       "antfu/curly": "error",
       "antfu/import-dedupe": "error",
+      "antfu/no-import-dist": "error",
+      "antfu/no-ts-export-equal": "error",
+      "antfu/top-level-function": "error",
     },
   },
 

--- a/src/utils/type.ts
+++ b/src/utils/type.ts
@@ -13,6 +13,6 @@ export function toClass<P, C>(cls: new (plain: P) => C, obj: P | C): C {
 /**
  * Checks if an object is an instance of {@link IColorable}.
  */
-export const isColorable = (obj: unknown): obj is IColorable => {
+export function isColorable(obj: unknown): obj is IColorable {
   return typeof obj === "object" && obj !== null && "setColorOption" in obj && "getColorOption" in obj
 }


### PR DESCRIPTION
Adds a few rules that enforce consistency across the repo.

Only change is one top-level const arrow function is now a function definition.