### PR TITLE
[Refactor] Clean up LGraphNode ahead of TS strict

### DIFF
--- a/src/LGraphNode.ts
+++ b/src/LGraphNode.ts
@@ -745,8 +745,8 @@ export class LGraphNode implements Positionable, IPinnable, IColorable {
 
     // remove links
     if (inputs) {
-      for (const element of inputs) {
-        element.link = null
+      for (const input of inputs) {
+        input.link = null
       }
     }
 


### PR DESCRIPTION
Preparation for TS strict conversion.  Simplifies code & improves readability.