### PR TITLE
[TS] Use strict mode in LGraphNode

### DIFF
--- a/src/LGraphNode.ts
+++ b/src/LGraphNode.ts
@@ -2771,6 +2771,7 @@ export class LGraphNode implements Positionable, IPinnable, IColorable {
       if (!v && c.node_capturing_input != this) continue
 
       // change
+      // @ts-ignore Strict mode plugin detects an error that doesn't exist.
       c.node_capturing_input = v ? this : null
     }
   }


### PR DESCRIPTION
- Adds minor type coercions to resolve type errors
- Deprecates unused public APIs
- 7a0336e3ad7239b7bb588bbbe7912322257e9ae2 works around a bug in the tsc strict plugin
- Adds ts-ignore that must be removed later
  * [x] #578