### PR TITLE
Remove redundant code - onGetInputs / onGetOutputs

### DIFF
--- a/src/LGraphNode.ts
+++ b/src/LGraphNode.ts
@@ -522,8 +522,6 @@ export class LGraphNode implements Positionable, IPinnable, IColorable {
     this: LGraphNode,
     entries: (IContextMenuValue<INodeSlotContextItem> | null)[],
   ): (IContextMenuValue<INodeSlotContextItem> | null)[]
-  onGetInputs?(this: LGraphNode): INodeSlotContextItem[]
-  onGetOutputs?(this: LGraphNode): INodeSlotContextItem[]
   onMouseUp?(this: LGraphNode, e: CanvasMouseEvent, pos: Point): void
   onMouseEnter?(this: LGraphNode, e: CanvasMouseEvent): void
   /** Blocks drag if return value is truthy. @param pos Offset from {@link LGraphNode.pos}. */


### PR DESCRIPTION
- Removes unused context menu for optional in/outputs
  - At the top of the node context menu, greyed out `Inputs` and `Outputs`
- API does not fit with current design
- If required, rewrite would be simpler

![Image](https://github.com/user-attachments/assets/4319776c-550b-4b5a-8889-4190c3c3c9fa)

n.b. The actual context menu entries have been left in; clean up requires cross-repo effort and can be done separately.  Effectively, this PR should result in no change for frontend.

- Comfy-Org/ComfyUI_frontend#4729