### PR TITLE
[chore] Clean up ignores after strict mode enabled

### DIFF
--- a/src/ContextMenu.ts
+++ b/src/ContextMenu.ts
@@ -129,7 +129,6 @@ export class ContextMenu<TValue = unknown> {
           : name
       }
 
-      // @ts-ignore https://github.com/Comfy-Org/litegraph.js/issues/578
       this.addItem(name, value, options)
     }
 

--- a/src/LGraph.ts
+++ b/src/LGraph.ts
@@ -666,7 +666,7 @@ export class LGraph implements LinkNetwork, Serialisable<SerialisableGraph> {
     }
 
     ancestors.sort(function (a, b) {
-      // @ts-ignore deprecated
+      // @ts-expect-error deprecated
       return a.order - b.order
     })
     return ancestors
@@ -753,16 +753,16 @@ export class LGraph implements LinkNetwork, Serialisable<SerialisableGraph> {
     if (!nodes) return
 
     for (const node of nodes) {
-      // @ts-ignore deprecated
+      // @ts-expect-error deprecated
       if (!node[eventname] || node.mode != mode) continue
       if (params === undefined) {
-        // @ts-ignore deprecated
+        // @ts-expect-error deprecated
         node[eventname]()
       } else if (params && params.constructor === Array) {
-        // @ts-ignore deprecated
+        // @ts-expect-error deprecated
         node[eventname].apply(node, params)
       } else {
-        // @ts-ignore deprecated
+        // @ts-expect-error deprecated
         node[eventname](params)
       }
     }
@@ -1113,12 +1113,12 @@ export class LGraph implements LinkNetwork, Serialisable<SerialisableGraph> {
   checkNodeTypes() {
     const { _nodes } = this
     for (const [i, node] of _nodes.entries()) {
-      // @ts-ignore deprecated
+      // @ts-expect-error deprecated
       const ctor = LiteGraph.registered_node_types[node.type]
       if (node.constructor == ctor) continue
 
       console.log("node being replaced by newer version:", node.type)
-      // @ts-ignore deprecated
+      // @ts-expect-error deprecated
       const newnode = LiteGraph.createNode(node.type)
       if (!newnode) continue
       _nodes[i] = newnode
@@ -1626,7 +1626,7 @@ export class LGraph implements LinkNetwork, Serialisable<SerialisableGraph> {
       ) {
         continue
       }
-      // @ts-ignore #574 Legacy property assignment
+      // @ts-expect-error #574 Legacy property assignment
       this[i] = data[i]
     }
 

--- a/src/LGraphCanvas.ts
+++ b/src/LGraphCanvas.ts
@@ -1204,7 +1204,7 @@ export class LGraphCanvas implements ConnectionColorContext {
     if (typeof values === "object") {
       let desc_value = ""
       for (const k in values) {
-        // @ts-ignore deprecated #578
+        // @ts-expect-error deprecated #578
         if (values[k] != value) continue
 
         desc_value = k
@@ -2406,17 +2406,17 @@ export class LGraphCanvas implements ConnectionColorContext {
     const x = pos[0] - node.pos[0]
     const y = pos[1] - node.pos[1]
 
-    // @ts-ignore https://github.com/Comfy-Org/litegraph.js/issues/616
+    // @ts-expect-error https://github.com/Comfy-Org/litegraph.js/issues/616
     const WidgetClass = WIDGET_TYPE_MAP[widget.type]
     if (WidgetClass) {
       const widgetInstance = toClass(WidgetClass, widget)
-      // @ts-ignore https://github.com/Comfy-Org/litegraph.js/issues/616
+      // @ts-expect-error https://github.com/Comfy-Org/litegraph.js/issues/616
       pointer.onClick = () => widgetInstance.onClick({
         e,
         node,
         canvas: this,
       })
-      // @ts-ignore https://github.com/Comfy-Org/litegraph.js/issues/616
+      // @ts-expect-error https://github.com/Comfy-Org/litegraph.js/issues/616
       pointer.onDrag = eMove => widgetInstance.onDrag?.({
         e: eMove,
         node,
@@ -5434,7 +5434,7 @@ export class LGraphCanvas implements ConnectionColorContext {
     node.drawWidgets(ctx, {
       colorContext: this,
       linkOverWidget: this.link_over_widget,
-      // @ts-ignore https://github.com/Comfy-Org/litegraph.js/issues/616
+      // @ts-expect-error https://github.com/Comfy-Org/litegraph.js/issues/616
       linkOverWidgetType: this.link_over_widget_type,
       lowQuality: this.low_quality,
       editorAlpha: this.editor_alpha,

--- a/src/LGraphNode.ts
+++ b/src/LGraphNode.ts
@@ -609,22 +609,22 @@ export class LGraphNode implements Positionable, IPinnable, IColorable {
         continue
       }
 
-      // @ts-ignore #594
+      // @ts-expect-error #594
       if (info[j] == null) {
         continue
-      // @ts-ignore #594
+      // @ts-expect-error #594
       } else if (typeof info[j] == "object") {
-        // @ts-ignore #594
+        // @ts-expect-error #594
         if (this[j]?.configure) {
-          // @ts-ignore #594
+          // @ts-expect-error #594
           this[j]?.configure(info[j])
         } else {
-          // @ts-ignore #594
+          // @ts-expect-error #594
           this[j] = LiteGraph.cloneObject(info[j], this[j])
         }
       } else {
         // value
-        // @ts-ignore #594
+        // @ts-expect-error #594
         this[j] = info[j]
       }
     }
@@ -713,7 +713,7 @@ export class LGraphNode implements Positionable, IPinnable, IColorable {
     if (widgets && this.serialize_widgets) {
       o.widgets_values = []
       for (const [i, widget] of widgets.entries()) {
-        // @ts-ignore #595 No-null
+        // @ts-expect-error #595 No-null
         o.widgets_values[i] = widget ? widget.value : null
       }
     }
@@ -753,7 +753,7 @@ export class LGraphNode implements Positionable, IPinnable, IColorable {
       }
     }
 
-    // @ts-ignore Exceptional case: id is removed so that the graph can assign a new one on add.
+    // @ts-expect-error Exceptional case: id is removed so that the graph can assign a new one on add.
     delete data.id
 
     if (LiteGraph.use_uuids) data.id = LiteGraph.uuidv4()
@@ -1140,17 +1140,17 @@ export class LGraphNode implements Positionable, IPinnable, IColorable {
       options.action_call ||= `${this.id}_exec_${Math.floor(Math.random() * 9999)}`
       if (!this.graph) throw new NullGraphError()
 
-      // @ts-ignore Technically it works when id is a string. Array gets props.
+      // @ts-expect-error Technically it works when id is a string. Array gets props.
       this.graph.nodes_executing[this.id] = true
       this.onExecute(param, options)
-      // @ts-ignore deprecated
+      // @ts-expect-error deprecated
       this.graph.nodes_executing[this.id] = false
 
       // save execution/action ref
       this.exec_version = this.graph.iteration
       if (options?.action_call) {
         this.action_call = options.action_call
-        // @ts-ignore deprecated
+        // @ts-expect-error deprecated
         this.graph.nodes_executedAction[this.id] = options.action_call
       }
     }
@@ -1174,16 +1174,16 @@ export class LGraphNode implements Positionable, IPinnable, IColorable {
       options.action_call ||= `${this.id}_${action || "action"}_${Math.floor(Math.random() * 9999)}`
       if (!this.graph) throw new NullGraphError()
 
-      // @ts-ignore deprecated
+      // @ts-expect-error deprecated
       this.graph.nodes_actioning[this.id] = action || "actioning"
       this.onAction(action, param, options)
-      // @ts-ignore deprecated
+      // @ts-expect-error deprecated
       this.graph.nodes_actioning[this.id] = false
 
       // save execution/action ref
       if (options?.action_call) {
         this.action_call = options.action_call
-        // @ts-ignore deprecated
+        // @ts-expect-error deprecated
         this.graph.nodes_executedAction[this.id] = options.action_call
       }
     }
@@ -1628,7 +1628,7 @@ export class LGraphNode implements Positionable, IPinnable, IColorable {
       }
     }
     // litescene mode using the constructor
-    // @ts-ignore deprecated https://github.com/Comfy-Org/litegraph.js/issues/639
+    // @ts-expect-error deprecated https://github.com/Comfy-Org/litegraph.js/issues/639
     if (this.constructor[`@${property}`]) info = this.constructor[`@${property}`]
 
     if (this.constructor.widgets_info?.[property])
@@ -1707,7 +1707,7 @@ export class LGraphNode implements Positionable, IPinnable, IColorable {
 
   addCustomWidget<T extends IWidget>(custom_widget: T): T {
     this.widgets ||= []
-    // @ts-ignore https://github.com/Comfy-Org/litegraph.js/issues/616
+    // @ts-expect-error https://github.com/Comfy-Org/litegraph.js/issues/616
     const WidgetClass = WIDGET_TYPE_MAP[custom_widget.type]
     const widget = WidgetClass ? new WidgetClass(custom_widget) as IWidget : custom_widget
     this.widgets.push(widget)
@@ -2733,7 +2733,7 @@ export class LGraphNode implements Positionable, IPinnable, IColorable {
   trace(msg: string): void {
     this.console ||= []
     this.console.push(msg)
-    // @ts-ignore deprecated
+    // @ts-expect-error deprecated
     if (this.console.length > LGraphNode.MAX_CONSOLE)
       this.console.shift()
   }
@@ -2769,7 +2769,6 @@ export class LGraphNode implements Positionable, IPinnable, IColorable {
       if (!v && c.node_capturing_input != this) continue
 
       // change
-      // @ts-ignore Strict mode plugin detects an error that doesn't exist.
       c.node_capturing_input = v ? this : null
     }
   }
@@ -3178,7 +3177,7 @@ export class LGraphNode implements Positionable, IPinnable, IColorable {
           name: "",
           type: linkOverWidgetType,
           link: 0,
-          // @ts-ignore https://github.com/Comfy-Org/litegraph.js/issues/616
+          // @ts-expect-error https://github.com/Comfy-Org/litegraph.js/issues/616
         }).draw(ctx, { pos: [10, y + 10], colorContext })
       }
 
@@ -3189,13 +3188,13 @@ export class LGraphNode implements Positionable, IPinnable, IColorable {
       if (w.disabled) ctx.globalAlpha *= 0.5
       const widget_width = w.width || width
 
-      // @ts-ignore https://github.com/Comfy-Org/litegraph.js/issues/616
+      // @ts-expect-error https://github.com/Comfy-Org/litegraph.js/issues/616
       const WidgetClass: typeof WIDGET_TYPE_MAP[string] = WIDGET_TYPE_MAP[w.type]
       if (WidgetClass) {
-        // @ts-ignore https://github.com/Comfy-Org/litegraph.js/issues/616
+        // @ts-expect-error https://github.com/Comfy-Org/litegraph.js/issues/616
         toClass(WidgetClass, w).drawWidget(ctx, { y, width: widget_width, show_text, margin })
       } else {
-        // @ts-ignore https://github.com/Comfy-Org/litegraph.js/issues/616
+        // @ts-expect-error https://github.com/Comfy-Org/litegraph.js/issues/616
         w.draw?.(ctx, this, widget_width, y, H)
       }
       ctx.globalAlpha = editorAlpha
@@ -3239,7 +3238,7 @@ export class LGraphNode implements Positionable, IPinnable, IColorable {
       const x = this._collapsed_width
       const y = LiteGraph.NODE_TITLE_HEIGHT * -0.5
       toClass(NodeOutputSlot, output_slot).drawCollapsed(ctx, {
-        // @ts-ignore8 https://github.com/Comfy-Org/litegraph.js/issues/616
+        // @ts-expect-error8 https://github.com/Comfy-Org/litegraph.js/issues/616
         pos: [x, y],
       })
     }
@@ -3283,14 +3282,14 @@ export class LGraphNode implements Positionable, IPinnable, IColorable {
       this.layoutSlot(slot, {
         slotIndex: i,
       })
-      // @ts-ignore https://github.com/Comfy-Org/litegraph.js/issues/616
+      // @ts-expect-error https://github.com/Comfy-Org/litegraph.js/issues/616
       slots.push(slot._layoutElement)
     }
     for (const [i, slot] of this.outputs.entries()) {
       this.layoutSlot(slot, {
         slotIndex: i,
       })
-      // @ts-ignore https://github.com/Comfy-Org/litegraph.js/issues/616
+      // @ts-expect-error https://github.com/Comfy-Org/litegraph.js/issues/616
       slots.push(slot._layoutElement)
     }
 
@@ -3333,7 +3332,7 @@ export class LGraphNode implements Positionable, IPinnable, IColorable {
       ctx.globalAlpha = isValid ? editorAlpha : 0.4 * editorAlpha
 
       slotInstance.draw(ctx, {
-      // @ts-ignore https://github.com/Comfy-Org/litegraph.js/issues/616
+      // @ts-expect-error https://github.com/Comfy-Org/litegraph.js/issues/616
         pos: layoutElement.center,
         colorContext,
         labelColor,
@@ -3377,7 +3376,7 @@ export class LGraphNode implements Positionable, IPinnable, IColorable {
         const { minHeight, maxHeight } = w.computeLayoutSize(this)
         growableWidgets.push({
           minHeight,
-          // @ts-ignore https://github.com/Comfy-Org/litegraph.js/issues/616
+          // @ts-expect-error https://github.com/Comfy-Org/litegraph.js/issues/616
           prefHeight: maxHeight,
           w,
         })
@@ -3410,7 +3409,7 @@ export class LGraphNode implements Positionable, IPinnable, IColorable {
     let y = widgetStartY
     for (const w of this.widgets) {
       w.y = y
-      // @ts-ignore https://github.com/Comfy-Org/litegraph.js/issues/616
+      // @ts-expect-error https://github.com/Comfy-Org/litegraph.js/issues/616
       y += w.computedHeight
     }
 
@@ -3447,7 +3446,7 @@ export class LGraphNode implements Positionable, IPinnable, IColorable {
 
       const actualSlot = this.inputs[slot.index]
       const offset = LiteGraph.NODE_SLOT_HEIGHT * 0.5
-      // @ts-ignore https://github.com/Comfy-Org/litegraph.js/issues/616
+      // @ts-expect-error https://github.com/Comfy-Org/litegraph.js/issues/616
       actualSlot.pos = [offset, widget.y + offset]
       this.layoutSlot(actualSlot, { slotIndex: slot.index })
     }

--- a/src/LiteGraphGlobal.ts
+++ b/src/LiteGraphGlobal.ts
@@ -323,7 +323,7 @@ export class LiteGraphGlobal {
 
     // extend class
     for (const i in LGraphNode.prototype) {
-      // @ts-ignore #576 This functionality is deprecated and should be removed.
+      // @ts-expect-error #576 This functionality is deprecated and should be removed.
       base_class.prototype[i] ||= LGraphNode.prototype[i]
     }
 
@@ -468,7 +468,7 @@ export class LiteGraphGlobal {
     // extra options
     if (options) {
       for (const i in options) {
-        // @ts-ignore #577 Requires interface
+        // @ts-expect-error #577 Requires interface
         node[i] = options[i]
       }
     }
@@ -572,7 +572,7 @@ export class LiteGraphGlobal {
     if (!target) return r
 
     for (const i in r) {
-      // @ts-ignore deprecated
+      // @ts-expect-error deprecated
       target[i] = r[i]
     }
     return target
@@ -582,7 +582,7 @@ export class LiteGraphGlobal {
    * https://gist.github.com/jed/982883?permalink_comment_id=852670#gistcomment-852670
    */
   uuidv4(): string {
-    // @ts-ignore
+    // @ts-expect-error
     return ([1e7] + -1e3 + -4e3 + -8e3 + -1e11).replaceAll(/[018]/g, a =>
       (a ^ ((Math.random() * 16) >> (a / 4))).toString(16))
   }

--- a/src/widgets/ComboWidget.ts
+++ b/src/widgets/ComboWidget.ts
@@ -157,7 +157,7 @@ export class ComboWidget extends BaseWidget implements IComboWidget {
       // @ts-expect-error handle () => string[] type that is not typed in IWidgetOptions
       values = values(this, node)
     }
-    // @ts-ignore Record<string, string> is not typed in IWidgetOptions
+    // @ts-expect-error Record<string, string> is not typed in IWidgetOptions
     const values_list = Array.isArray(values) ? values : Object.keys(values)
 
     // Handle left/right arrow clicks
@@ -187,7 +187,7 @@ export class ComboWidget extends BaseWidget implements IComboWidget {
     }
 
     // Handle center click - show dropdown menu
-    // @ts-ignore Record<string, string> is not typed in IWidgetOptions
+    // @ts-expect-error Record<string, string> is not typed in IWidgetOptions
     const text_values = values != values_list ? Object.values(values) : values
     new LiteGraph.ContextMenu(text_values, {
       scale: Math.max(1, canvas.ds.scale),

--- a/src/widgets/widgetMap.ts
+++ b/src/widgets/widgetMap.ts
@@ -14,20 +14,20 @@ type WidgetConstructor = {
 }
 
 export const WIDGET_TYPE_MAP: Record<string, WidgetConstructor> = {
-  // @ts-ignore https://github.com/Comfy-Org/litegraph.js/issues/616
+  // @ts-expect-error https://github.com/Comfy-Org/litegraph.js/issues/616
   button: ButtonWidget,
-  // @ts-ignore #616
+  // @ts-expect-error #616
   toggle: BooleanWidget,
-  // @ts-ignore #616
+  // @ts-expect-error #616
   slider: SliderWidget,
-  // @ts-ignore #616
+  // @ts-expect-error #616
   knob: KnobWidget,
-  // @ts-ignore #616
+  // @ts-expect-error #616
   combo: ComboWidget,
-  // @ts-ignore #616
+  // @ts-expect-error #616
   number: NumberWidget,
-  // @ts-ignore #616
+  // @ts-expect-error #616
   string: TextWidget,
-  // @ts-ignore #616
+  // @ts-expect-error #616
   text: TextWidget,
 }


### PR DESCRIPTION
- Replaces all `ts-ignore` with `ts-expect-error`
- Resolves https://github.com/Comfy-Org/litegraph.js/issues/578