### PR TITLE
Fix Selection Marquee display is offset when DPI < 1

### DIFF
--- a/src/LGraphCanvas.ts
+++ b/src/LGraphCanvas.ts
@@ -4179,7 +4179,7 @@ export class LGraphCanvas implements ConnectionColorContext {
         if (eDown && eMove) {
           // Do not scale the selection box
           const transform = ctx.getTransform()
-          const ratio = window.devicePixelRatio
+          const ratio = Math.max(1, window.devicePixelRatio)
           ctx.setTransform(ratio, 0, 0, ratio, 0, 0)
 
           const x = eDown.safeOffsetX


### PR DESCRIPTION
Fixes https://github.com/Comfy-Org/ComfyUI_frontend/issues/2481. The canvas scaling is not consistent with DPI which is the source of many bugs. To verify, add console log somewhere:

```typescript
const transform = ctx.getTransform()
console.log("DPI ratio:", window.devicePixelRatio)
console.log("Canvas size:", this.canvas.width, "x", this.canvas.height)
console.log("CSS size:", this.canvas.clientWidth, "x", this.canvas.clientHeight)
console.log("Transform matrix:", transform.a, transform.b, transform.c, transform.d, transform.e, transform.f)
```

Then, adjust DPI and compare results:

```
DPI ratio: 1.5
Canvas size: 1922 x 1951
CSS size: 1281 x 1301
Transform matrix: 1.5 0 0 1.5 0 0

DPI ratio: 1.25
Canvas size: 1946 x 1966
CSS size: 1557 x 1573
Transform matrix: 1.25 0 0 1.25 0 0

DPI ratio: 1
Canvas size: 1970 x 1981
CSS size: 1970 x 1981
Transform matrix: 1 0 0 1 0 0

DPI ratio: 0.800000011920929
Canvas size: 2487 x 2491
CSS size: 2487 x 2491
Transform matrix: 1 0 0 1 -8 0

DPI ratio: 0.6666666865348816
Canvas size: 3003 x 3002
CSS size: 3003 x 3002
Transform matrix: 1 0 0 1 -8 -2.5
```
 
The canvas is already scaled to screen pixel when DPI < 1, so re-applying DPI adjustment leads to double scaling.

Related:

- https://github.com/Comfy-Org/ComfyUI_frontend/pull/544