### PR TITLE
[API] Remove unused LGraph.onNodeConnectionChange

### DIFF
--- a/src/LGraph.ts
+++ b/src/LGraph.ts
@@ -1,7 +1,6 @@
 import type {
   Dictionary,
   IContextMenuValue,
-  ISlotType,
   LinkNetwork,
   LinkSegment,
   MethodNames,
@@ -58,7 +57,6 @@ export interface LGraphConfig {
  * supported callbacks:
  * + onNodeAdded: when a new node is added to the graph
  * + onNodeRemoved: when a node inside this graph is removed
- * + onNodeConnectionChange: some connection has changed in the graph (connected or disconnected)
  */
 export class LGraph implements LinkNetwork, Serialisable<SerialisableGraph> {
   static serialisedSchemaVersion = 1 as const
@@ -206,13 +204,6 @@ export class LGraph implements LinkNetwork, Serialisable<SerialisableGraph> {
   onSerialize?(data: ISerialisedGraph | SerialisableGraph): void
   onConfigure?(data: ISerialisedGraph | SerialisableGraph): void
   onGetNodeMenuOptions?(options: (IContextMenuValue<unknown> | null)[], node: LGraphNode): void
-  onNodeConnectionChange?(
-    nodeSlotType: ISlotType,
-    targetNode: LGraphNode | null | undefined,
-    slotIndex: number,
-    sourceNode?: LGraphNode,
-    sourceSlotIndex?: number,
-  ): void
 
   private _input_nodes?: LGraphNode[]
 

--- a/src/LGraphNode.ts
+++ b/src/LGraphNode.ts
@@ -2444,20 +2444,6 @@ export class LGraphNode implements Positionable, IPinnable, IColorable {
       link_info,
       input,
     )
-    graph.onNodeConnectionChange?.(
-      NodeSlotType.INPUT,
-      target_node,
-      targetIndex,
-      this,
-      slot,
-    )
-    graph.onNodeConnectionChange?.(
-      NodeSlotType.OUTPUT,
-      this,
-      slot,
-      target_node,
-      targetIndex,
-    )
 
     this.setDirtyCanvas(false, true)
     graph.afterChange()
@@ -2531,8 +2517,6 @@ export class LGraphNode implements Positionable, IPinnable, IColorable {
             output,
           )
 
-          graph.onNodeConnectionChange?.(NodeSlotType.OUTPUT, this, slot)
-          graph.onNodeConnectionChange?.(NodeSlotType.INPUT, target, link_info.target_slot)
           break
         }
       }
@@ -2570,8 +2554,6 @@ export class LGraphNode implements Positionable, IPinnable, IColorable {
           link_info,
           output,
         )
-        graph.onNodeConnectionChange?.(NodeSlotType.OUTPUT, this, slot)
-        graph.onNodeConnectionChange?.(NodeSlotType.INPUT, target, link_info.target_slot)
       }
       output.links = null
     }
@@ -2646,8 +2628,6 @@ export class LGraphNode implements Positionable, IPinnable, IColorable {
           link_info,
           output,
         )
-        this.graph?.onNodeConnectionChange?.(NodeSlotType.OUTPUT, target_node, i)
-        this.graph?.onNodeConnectionChange?.(NodeSlotType.INPUT, this, slot)
       }
     }
 


### PR DESCRIPTION
Confirmed unused via code search.

N.B.: This API is not a bad idea, but the implementation is undesirable.  It is better to remove this now and implement a solution that is properly implemented.  The work required to do this would be minimal.