### PR TITLE
[Perf] Fix unnecessary canvas redraw (null vs undefined)

### DIFF
--- a/src/LGraphCanvas.ts
+++ b/src/LGraphCanvas.ts
@@ -678,7 +678,6 @@ export class LGraphCanvas implements ConnectionColorContext {
 
     this.current_node = null
     this.node_widget = null
-    this.over_link_center = null
     this.last_mouse_position = [0, 0]
     this.visible_area = this.ds.visible_area
     this.visible_links = []


### PR DESCRIPTION
Fixes regression added in TS strict conversion.  A fallback to `null` added to match the TS type, however value being stored was actually uncaught use of `undefined`.

`null` !== `undefined` -> redraw every frame the pointer moves