### PR TITLE
[CI] Pin third party action to SHA

### DIFF
--- a/.github/workflows/release-version.yml
+++ b/.github/workflows/release-version.yml
@@ -42,7 +42,7 @@ jobs:
           echo "capitalised=$CAPITALISED_TYPE" >> $GITHUB_OUTPUT
 
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e
         with:
           token: ${{ secrets.PR_GH_TOKEN }}
           commit-message: "[Release] Increment version to ${{ steps.bump-version.outputs.NEW_VERSION }}"


### PR DESCRIPTION
Pins third party GitHub action to specific SHA.  This will need to be updated, but removes the possibility of any unexpected surprises (new bugs / security concerns).