### PR TITLE
Added missing optional chaining

### DIFF
--- a/src/ContextMenu.ts
+++ b/src/ContextMenu.ts
@@ -139,7 +139,7 @@ export class ContextMenu<TValue = unknown> {
     })
 
     // insert before checking position
-    const ownerDocument = (options.event?.target as Node).ownerDocument
+    const ownerDocument = (options.event?.target as Node)?.ownerDocument
     const root_document = ownerDocument || document
 
     if (root_document.fullscreenElement)


### PR DESCRIPTION
missing chaining optional, if `event` is `undefined` then `target` will be as well, but currently it assumes this is not
Either the original `?` is unnecessary or its missing the extra, the current way is definitely wrong.

This is specifically causing me an issue with rgthree where the context menu will not open because it crashes when no event is set