### PR TITLE
[Bug] Fix node empty space on converted widget

### DIFF
--- a/src/LGraphNode.ts
+++ b/src/LGraphNode.ts
@@ -1517,7 +1517,7 @@ export class LGraphNode implements Positionable, IPinnable, IColorable {
 
     const { inputs, outputs } = this
     let rows = Math.max(
-      inputs ? inputs.length : 1,
+      inputs ? inputs.filter(input => !isWidgetInputSlot(input)).length : 1,
       outputs ? outputs.length : 1,
     )
     const size = out || new Float32Array([0, 0])


### PR DESCRIPTION
Resolves https://github.com/Comfy-Org/litegraph.js/issues/739

This is a temporary measurement to fix the issue. We should probably consider build a more robust layout mechanism later.