### PR TITLE
Implement _.pick to simplify serialization

### DIFF
--- a/src/NodeSlot.ts
+++ b/src/NodeSlot.ts
@@ -1,12 +1,12 @@
 import type { CanvasColour, Dictionary, INodeInputSlot, INodeOutputSlot, INodeSlot, ISlotType, IWidgetInputSlot, Point, SharedIntersection } from "./interfaces"
 import type { LinkId } from "./LLink"
+import type { ISerialisableNodeInput, ISerialisableNodeOutput } from "./types/serialisation"
 import type { IWidget } from "./types/widgets"
 
 import { LabelPosition, SlotShape, SlotType } from "./draw"
 import { LiteGraph } from "./litegraph"
 import { LinkDirection, RenderShape } from "./types/globalEnums"
-import { ISerialisableNodeOutput } from "./types/serialisation"
-import { ISerialisableNodeInput } from "./types/serialisation"
+import { pick } from "./utils/object"
 
 export interface ConnectionColorContext {
   default_connection_color: {
@@ -33,8 +33,19 @@ interface IDrawOptions {
 type CommonIoSlotProps = SharedIntersection<ISerialisableNodeInput, ISerialisableNodeOutput>
 
 export function shallowCloneCommonProps(slot: CommonIoSlotProps): CommonIoSlotProps {
-  const { color_off, color_on, dir, label, localized_name, locked, name, nameLocked, removable, shape, type } = slot
-  return { color_off, color_on, dir, label, localized_name, locked, name, nameLocked, removable, shape, type }
+  return pick(slot, [
+    "color_off",
+    "color_on",
+    "dir",
+    "label",
+    "localized_name",
+    "locked",
+    "name",
+    "nameLocked",
+    "removable",
+    "shape",
+    "type",
+  ])
 }
 
 export function inputAsSerialisable(slot: INodeInputSlot): ISerialisableNodeInput {

--- a/src/utils/object.ts
+++ b/src/utils/object.ts
@@ -3,3 +3,20 @@ export function omitBy<T extends object>(obj: T, predicate: (value: any) => bool
     Object.entries(obj).filter(([_key, value]) => !predicate(value)),
   ) as Partial<T>
 }
+
+/**
+ * Creates an object composed of the picked object properties.
+ * Similar to lodash's pick function.
+ * @param obj The source object
+ * @param keys The property names to pick
+ * @returns A new object with just the picked properties
+ */
+export function pick<T extends object, K extends keyof T>(obj: T, keys: K[]): Pick<T, K> {
+  // eslint-disable-next-line unicorn/no-array-reduce
+  return keys.reduce((result, key) => {
+    if (key in obj) {
+      result[key] = obj[key]
+    }
+    return result
+  }, {} as Pick<T, K>)
+}


### PR DESCRIPTION
Simplify the serialization code, so that we only write each prop once.