### PR TITLE
[Cleanup] Removed unused convenience setter - reroutes

### DIFF
--- a/src/LGraph.ts
+++ b/src/LGraph.ts
@@ -144,23 +144,6 @@ export class LGraph implements LinkNetwork, Serialisable<SerialisableGraph> {
     return this.#reroutes
   }
 
-  public set reroutes(value: Map<RerouteId, Reroute>) {
-    if (!value) throw new TypeError("Attempted to set LGraph.reroutes to a falsy value.")
-
-    const reroutes = this.#reroutes
-    if (value.size === 0) {
-      reroutes.clear()
-      return
-    }
-
-    for (const rerouteId of reroutes.keys()) {
-      if (!value.has(rerouteId)) reroutes.delete(rerouteId)
-    }
-    for (const [id, reroute] of value) {
-      reroutes.set(id, reroute)
-    }
-  }
-
   /** @deprecated See {@link state}.{@link LGraphState.lastNodeId lastNodeId} */
   get last_node_id() {
     return this.state.lastNodeId


### PR DESCRIPTION
- New features are making the reroutes convenience setter unmanageable.
- Not currently in use.
- Prefer `configure()`, as it includes validation.