### PR TITLE
Increase slot context menu hit box

### DIFF
--- a/src/LGraphNode.ts
+++ b/src/LGraphNode.ts
@@ -1863,7 +1863,7 @@ export class LGraphNode implements Positionable, IPinnable, IColorable {
     if (inputs) {
       for (const [i, input] of inputs.entries()) {
         const pos = this.getInputPos(i)
-        if (isInRectangle(x, y, pos[0] - 10, pos[1] - 5, 20, 10)) {
+        if (isInRectangle(x, y, pos[0] - 10, pos[1] - 10, 20, 20)) {
           return { input, slot: i, link_pos: pos }
         }
       }
@@ -1872,7 +1872,7 @@ export class LGraphNode implements Positionable, IPinnable, IColorable {
     if (outputs) {
       for (const [i, output] of outputs.entries()) {
         const pos = this.getOutputPos(i)
-        if (isInRectangle(x, y, pos[0] - 10, pos[1] - 5, 20, 10)) {
+        if (isInRectangle(x, y, pos[0] - 10, pos[1] - 10, 20, 20)) {
           return { output, slot: i, link_pos: pos }
         }
       }


### PR DESCRIPTION
Previously, gap between slots was the same height as the slot itself.

Gap is now entirely removed, bringing it inline with the previously-modified snap and link connection hit boxes.