### PR TITLE
Fix new link from reroute to canvas does nothing

### DIFF
--- a/src/canvas/LinkConnector.ts
+++ b/src/canvas/LinkConnector.ts
@@ -229,6 +229,8 @@ export class LinkConnector {
     this.renderLinks.push(renderLink)
 
     this.state.connectingTo = "input"
+
+    this.#setLegacyLinks(false)
   }
 
   dragFromLinkSegment(network: LinkNetwork, linkSegment: LinkSegment): void {


### PR DESCRIPTION
Resolves regression - now performs the same action as dropping a link from an output to canvas.