### PR TITLE
add input fields to NumberWidget

### DIFF
--- a/src/types/widgets.ts
+++ b/src/types/widgets.ts
@@ -73,7 +73,14 @@ export interface IBooleanWidget extends IBaseWidget {
 /** Any widget that uses a numeric backing */
 export interface INumericWidget extends IBaseWidget {
   type: "number"
-  value: number
+  value: number | number[] // Allow array of numbers
+  options: IWidgetOptions<number> & {
+    fields?: {
+      labels?: string[] // Labels for each field
+      count?: number // Number of fields (2-4)
+      separator?: string // Optional separator between values
+    }
+  }
 }
 
 export interface ISliderWidget extends IBaseWidget {

--- a/src/widgets/NumberWidget.ts
+++ b/src/widgets/NumberWidget.ts
@@ -102,11 +102,16 @@ export class NumberWidget extends BaseWidget implements INumericWidget {
     // Handle multi-field drawing
     if (this.options?.fields?.count && Array.isArray(this.value)) {
       const count = this.value.length
-      const fieldWidth = (width - margin * 2) / count
+      const outerMargin = 10  // Fixed outer margin
+      const fieldMargin = 2   // Small gap between fields
+      const totalWidth = width - (outerMargin * 2)  // Available width for all fields
+      const fieldWidth = totalWidth / count    // Width per field including margins
       const labels = this.options.fields.labels || []
 
       for (let i = 0; i < count; i++) {
-        const fieldX = margin + (fieldWidth * i)
+        const fieldX = outerMargin + (fieldWidth * i)  // Start from left margin
+        const fieldRectX = fieldX + fieldMargin
+        const fieldRectWidth = fieldWidth - (fieldMargin * 2)
 
         // Draw field background
         ctx.textAlign = "left"
@@ -115,9 +120,9 @@ export class NumberWidget extends BaseWidget implements INumericWidget {
         ctx.beginPath()
 
         if (show_text) {
-          ctx.roundRect(fieldX, y, fieldWidth - margin, height, [height * 0.5])
+          ctx.roundRect(fieldRectX, y, fieldRectWidth, height, [height * 0.5])
         } else {
-          ctx.rect(fieldX, y, fieldWidth - margin, height)
+          ctx.rect(fieldRectX, y, fieldRectWidth, height)
         }
         ctx.fill()
 
@@ -128,22 +133,23 @@ export class NumberWidget extends BaseWidget implements INumericWidget {
             ctx.fillStyle = this.text_color
             // Left arrow
             ctx.beginPath()
-            ctx.moveTo(fieldX + 16, y + 5)
-            ctx.lineTo(fieldX + 6, y + height * 0.5)
-            ctx.lineTo(fieldX + 16, y + height - 5)
+            ctx.moveTo(fieldRectX + 16, y + 5)
+            ctx.lineTo(fieldRectX + 6, y + height * 0.5)
+            ctx.lineTo(fieldRectX + 16, y + height - 5)
             ctx.fill()
             // Right arrow
             ctx.beginPath()
-            ctx.moveTo(fieldX + fieldWidth - margin - 16, y + 5)
-            ctx.lineTo(fieldX + fieldWidth - margin - 6, y + height * 0.5)
-            ctx.lineTo(fieldX + fieldWidth - margin - 16, y + height - 5)
+            ctx.moveTo(fieldRectX + fieldRectWidth - 16, y + 5)
+            ctx.lineTo(fieldRectX + fieldRectWidth - 6, y + height * 0.5)
+            ctx.lineTo(fieldRectX + fieldRectWidth - 16, y + height - 5)
             ctx.fill()
           }
 
           // Draw label
           ctx.fillStyle = this.secondary_text_color
+          ctx.textAlign = "left"
           const label = labels[i] || `${this.label || this.name}${i + 1}`
-          const labelX = fieldX + margin + 5
+          const labelX = fieldRectX + 20
           ctx.fillText(label, labelX, y + height * 0.7)
 
           // Draw value
@@ -153,7 +159,7 @@ export class NumberWidget extends BaseWidget implements INumericWidget {
             Number(this.value[i]).toFixed(
               this.options.precision !== undefined ? this.options.precision : 3,
             ),
-            fieldX + fieldWidth - margin - 20,
+            fieldRectX + fieldRectWidth - 20,
             y + height * 0.7,
           )
         }

--- a/src/widgets/NumberWidget.ts
+++ b/src/widgets/NumberWidget.ts
@@ -10,13 +10,77 @@ import { BaseWidget, type DrawWidgetOptions } from "./BaseWidget"
 export class NumberWidget extends BaseWidget implements INumericWidget {
   // INumberWidget properties
   declare type: "number"
-  declare value: number
-  declare options: IWidgetOptions<number>
+  declare value: number | number[]
+  declare options: IWidgetOptions<number> & {
+    fields?: {
+      labels?: string[]
+      count?: number
+      separator?: string
+    }
+  }
 
   constructor(widget: INumericWidget) {
     super(widget)
     this.type = "number"
-    this.value = widget.value
+
+    // Initialize multiple values if fields option is present
+    if (widget.options?.fields?.count) {
+      const count = Math.min(Math.max(2, widget.options.fields.count), 4)
+      this.value = Array.isArray(widget.value)
+        ? widget.value.slice(0, count)
+        : new Array(count).fill(widget.value || 0)
+    } else {
+      this.value = widget.value
+    }
+  }
+
+  override setValue(v: number | number[], options?: {
+    e: CanvasMouseEvent
+    node: LGraphNode
+    canvas: LGraphCanvas
+  }) {
+    const oldValue = this.value
+
+    // Preserve multi-field state when setting values
+    if (this.options?.fields?.count) {
+      const count = this.options.fields.count
+      if (Array.isArray(v)) {
+        this.value = v.slice(0, count)
+      } else {
+        // If setting a single value but we're in multi-field mode,
+        // preserve the array structure
+        if (Array.isArray(this.value)) {
+          const newValues = [...this.value]
+          newValues[0] = v
+          this.value = newValues
+        } else {
+          this.value = new Array(count).fill(v)
+        }
+      }
+    } else {
+      this.value = Array.isArray(v) ? v[0] : v
+    }
+
+    // Handle property binding
+    if (
+      options?.node &&
+      this.options?.property &&
+      options.node.properties[this.options.property] !== undefined
+    ) {
+      options.node.setProperty(this.options.property, this.value)
+    }
+
+    // Call callback if exists
+    if (options?.canvas) {
+      const pos = options.canvas.graph_mouse
+      this.callback?.(this.value, options.canvas, options.node, pos, options.e)
+    }
+
+    // Notify widget change
+    if (options?.node) {
+      options.node.onWidgetChanged?.(this.name ?? "", this.value, oldValue, this)
+      if (options.node.graph) options.node.graph._version++
+    }
   }
 
   /**
@@ -30,61 +94,121 @@ export class NumberWidget extends BaseWidget implements INumericWidget {
     show_text = true,
     margin = 15,
   }: DrawWidgetOptions) {
-    // Store original context attributes
     const originalTextAlign = ctx.textAlign
     const originalStrokeStyle = ctx.strokeStyle
     const originalFillStyle = ctx.fillStyle
-
     const { height } = this
 
-    ctx.textAlign = "left"
-    ctx.strokeStyle = this.outline_color
-    ctx.fillStyle = this.background_color
-    ctx.beginPath()
+    // Handle multi-field drawing
+    if (this.options?.fields?.count && Array.isArray(this.value)) {
+      const count = this.value.length
+      const fieldWidth = (width - margin * 2) / count
+      const labels = this.options.fields.labels || []
 
-    if (show_text)
-      ctx.roundRect(margin, y, width - margin * 2, height, [height * 0.5])
-    else
-      ctx.rect(margin, y, width - margin * 2, height)
-    ctx.fill()
+      for (let i = 0; i < count; i++) {
+        const fieldX = margin + (fieldWidth * i)
 
-    if (show_text) {
-      if (!this.disabled) {
-        ctx.stroke()
-        // Draw left arrow
+        // Draw field background
+        ctx.textAlign = "left"
+        ctx.strokeStyle = this.outline_color
+        ctx.fillStyle = this.background_color
+        ctx.beginPath()
+
+        if (show_text) {
+          ctx.roundRect(fieldX, y, fieldWidth - margin, height, [height * 0.5])
+        } else {
+          ctx.rect(fieldX, y, fieldWidth - margin, height)
+        }
+        ctx.fill()
+
+        if (show_text) {
+          if (!this.disabled) {
+            ctx.stroke()
+            // Draw arrows for each field
+            ctx.fillStyle = this.text_color
+            // Left arrow
+            ctx.beginPath()
+            ctx.moveTo(fieldX + 16, y + 5)
+            ctx.lineTo(fieldX + 6, y + height * 0.5)
+            ctx.lineTo(fieldX + 16, y + height - 5)
+            ctx.fill()
+            // Right arrow
+            ctx.beginPath()
+            ctx.moveTo(fieldX + fieldWidth - margin - 16, y + 5)
+            ctx.lineTo(fieldX + fieldWidth - margin - 6, y + height * 0.5)
+            ctx.lineTo(fieldX + fieldWidth - margin - 16, y + height - 5)
+            ctx.fill()
+          }
+
+          // Draw label
+          ctx.fillStyle = this.secondary_text_color
+          const label = labels[i] || `${this.label || this.name}${i + 1}`
+          const labelX = fieldX + margin + 5
+          ctx.fillText(label, labelX, y + height * 0.7)
+
+          // Draw value
+          ctx.fillStyle = this.text_color
+          ctx.textAlign = "right"
+          ctx.fillText(
+            Number(this.value[i]).toFixed(
+              this.options.precision !== undefined ? this.options.precision : 3,
+            ),
+            fieldX + fieldWidth - margin - 20,
+            y + height * 0.7,
+          )
+        }
+      }
+    } else {
+      // Original single field drawing code
+      ctx.textAlign = "left"
+      ctx.strokeStyle = this.outline_color
+      ctx.fillStyle = this.background_color
+      ctx.beginPath()
+
+      if (show_text)
+        ctx.roundRect(margin, y, width - margin * 2, height, [height * 0.5])
+      else
+        ctx.rect(margin, y, width - margin * 2, height)
+      ctx.fill()
+
+      if (show_text) {
+        if (!this.disabled) {
+          ctx.stroke()
+          // Draw left arrow
+          ctx.fillStyle = this.text_color
+          ctx.beginPath()
+          ctx.moveTo(margin + 16, y + 5)
+          ctx.lineTo(margin + 6, y + height * 0.5)
+          ctx.lineTo(margin + 16, y + height - 5)
+          ctx.fill()
+          // Draw right arrow
+          ctx.beginPath()
+          ctx.moveTo(width - margin - 16, y + 5)
+          ctx.lineTo(width - margin - 6, y + height * 0.5)
+          ctx.lineTo(width - margin - 16, y + height - 5)
+          ctx.fill()
+        }
+
+        // Draw label
+        ctx.fillStyle = this.secondary_text_color
+        const label = this.label || this.name
+        if (label != null) {
+          ctx.fillText(label, margin * 2 + 5, y + height * 0.7)
+        }
+
+        // Draw value
         ctx.fillStyle = this.text_color
-        ctx.beginPath()
-        ctx.moveTo(margin + 16, y + 5)
-        ctx.lineTo(margin + 6, y + height * 0.5)
-        ctx.lineTo(margin + 16, y + height - 5)
-        ctx.fill()
-        // Draw right arrow
-        ctx.beginPath()
-        ctx.moveTo(width - margin - 16, y + 5)
-        ctx.lineTo(width - margin - 6, y + height * 0.5)
-        ctx.lineTo(width - margin - 16, y + height - 5)
-        ctx.fill()
+        ctx.textAlign = "right"
+        ctx.fillText(
+          Number(this.value).toFixed(
+            this.options.precision !== undefined
+              ? this.options.precision
+              : 3,
+          ),
+          width - margin * 2 - 20,
+          y + height * 0.7,
+        )
       }
-
-      // Draw label
-      ctx.fillStyle = this.secondary_text_color
-      const label = this.label || this.name
-      if (label != null) {
-        ctx.fillText(label, margin * 2 + 5, y + height * 0.7)
-      }
-
-      // Draw value
-      ctx.fillStyle = this.text_color
-      ctx.textAlign = "right"
-      ctx.fillText(
-        Number(this.value).toFixed(
-          this.options.precision !== undefined
-            ? this.options.precision
-            : 3,
-        ),
-        width - margin * 2 - 20,
-        y + height * 0.7,
-      )
     }
 
     // Restore original context attributes
@@ -102,42 +226,75 @@ export class NumberWidget extends BaseWidget implements INumericWidget {
     const x = e.canvasX - node.pos[0]
     const width = this.width || node.size[0]
 
-    // Determine if clicked on left/right arrows
-    const delta = x < 40
-      ? -1
-      : (x > width - 40
-        ? 1
-        : 0)
+    if (this.options?.fields?.count && Array.isArray(this.value)) {
+      const count = this.value.length
+      const fieldWidth = (width - 30) / count
+      const fieldIndex = Math.floor((x - 15) / fieldWidth)
 
-    if (delta) {
-      // Handle left/right arrow clicks
-      let newValue = this.value + delta * getWidgetStep(this.options)
-      if (this.options.min != null && newValue < this.options.min) {
-        newValue = this.options.min
+      if (fieldIndex >= 0 && fieldIndex < count) {
+        const fieldX = x - (fieldWidth * fieldIndex + 15)
+        const delta = fieldX < 40 ? -1 : (fieldX > fieldWidth - 40 ? 1 : 0)
+
+        if (delta) {
+          // Handle arrow clicks for the specific field
+          const newValues = [...this.value]
+          let newValue = newValues[fieldIndex] + delta * getWidgetStep(this.options)
+
+          if (this.options.min != null && newValue < this.options.min) {
+            newValue = this.options.min
+          }
+          if (this.options.max != null && newValue > this.options.max) {
+            newValue = this.options.max
+          }
+
+          newValues[fieldIndex] = newValue
+          this.setValue(newValues, options)
+          return
+        }
+
+        // Handle center click - show prompt for specific field
+        canvas.prompt(`Value ${fieldIndex + 1}`, this.value[fieldIndex], (v: string) => {
+          if (/^[\d\s()*+/-]+|\d+\.\d+$/.test(v)) {
+            try {
+              v = eval(v)
+            } catch {}
+          }
+          const newValue = Number(v)
+          if (!isNaN(newValue)) {
+            const newValues = Array.isArray(this.value) ? [...this.value] : [this.value]
+            newValues[fieldIndex] = newValue
+            this.setValue(newValues, options)
+          }
+        }, e)
       }
-      if (this.options.max != null && newValue > this.options.max) {
-        newValue = this.options.max
+    } else {
+      // Original single field click handling code...
+      const delta = x < 40 ? -1 : (x > width - 40 ? 1 : 0)
+
+      if (delta) {
+        let newValue = Number(this.value) + delta * getWidgetStep(this.options)
+        if (this.options.min != null && newValue < this.options.min) {
+          newValue = this.options.min
+        }
+        if (this.options.max != null && newValue > this.options.max) {
+          newValue = this.options.max
+        }
+        this.setValue(newValue, options)
+        return
       }
-      if (newValue !== this.value) {
-        this.setValue(newValue, { e, node, canvas })
-      }
-      return
+
+      canvas.prompt("Value", this.value, (v: string) => {
+        if (/^[\d\s()*+/-]+|\d+\.\d+$/.test(v)) {
+          try {
+            v = eval(v)
+          } catch {}
+        }
+        const newValue = Number(v)
+        if (!isNaN(newValue)) {
+          this.setValue(newValue, options)
+        }
+      }, e)
     }
-
-    // Handle center click - show prompt
-    canvas.prompt("Value", this.value, (v: string) => {
-      // Check if v is a valid equation or a number
-      if (/^[\d\s()*+/-]+|\d+\.\d+$/.test(v)) {
-        // Solve the equation if possible
-        try {
-          v = eval(v)
-        } catch {}
-      }
-      const newValue = Number(v)
-      if (!isNaN(newValue)) {
-        this.setValue(newValue, { e, node, canvas })
-      }
-    }, e)
   }
 
   /**
@@ -152,25 +309,54 @@ export class NumberWidget extends BaseWidget implements INumericWidget {
     const { e, node, canvas } = options
     const width = this.width || node.width
     const x = e.canvasX - node.pos[0]
-    const delta = x < 40
-      ? -1
-      : (x > width - 40
-        ? 1
-        : 0)
 
-    if (delta && (x > -3 && x < width + 3)) return
+    if (Array.isArray(this.value)) {
+      const count = this.value.length
+      const fieldWidth = (width - 30) / count
+      const fieldIndex = Math.floor((x - 15) / fieldWidth)
 
-    let newValue = this.value
-    if (e.deltaX) newValue += e.deltaX * getWidgetStep(this.options)
+      if (fieldIndex >= 0 && fieldIndex < count) {
+        const fieldX = x - (fieldWidth * fieldIndex + 15)
+        const delta = fieldX < 40 ? -1 : (fieldX > fieldWidth - 40 ? 1 : 0)
 
-    if (this.options.min != null && newValue < this.options.min) {
-      newValue = this.options.min
-    }
-    if (this.options.max != null && newValue > this.options.max) {
-      newValue = this.options.max
-    }
-    if (newValue !== this.value) {
-      this.setValue(newValue, { e, node, canvas })
+        if (delta && (fieldX > -3 && fieldX < fieldWidth + 3)) return
+
+        const newValues = [...this.value]
+        if (e.deltaX) {
+          newValues[fieldIndex] += e.deltaX * getWidgetStep(this.options)
+        }
+
+        if (this.options.min != null) {
+          newValues[fieldIndex] = Math.max(newValues[fieldIndex], this.options.min)
+        }
+        if (this.options.max != null) {
+          newValues[fieldIndex] = Math.min(newValues[fieldIndex], this.options.max)
+        }
+
+        this.setValue(newValues, { e, node, canvas })
+      }
+    } else {
+      // Original single field drag handling
+      const delta = x < 40
+        ? -1
+        : (x > width - 40
+          ? 1
+          : 0)
+
+      if (delta && (x > -3 && x < width + 3)) return
+
+      let newValue = this.value
+      if (e.deltaX) newValue += e.deltaX * getWidgetStep(this.options)
+
+      if (this.options.min != null && newValue < this.options.min) {
+        newValue = this.options.min
+      }
+      if (this.options.max != null && newValue > this.options.max) {
+        newValue = this.options.max
+      }
+      if (newValue !== this.value) {
+        this.setValue(newValue, { e, node, canvas })
+      }
     }
   }
 }


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/53d52a1e-d7a3-4b8e-a16a-f0dc75e6931b)

I know I might not be the right person for this edits and I'm still missing a lot of things, but I hope it's a start, and someone can help improve it and make it more robust.
the ability to add fields to a widget will help reduce the node size so instead of adding 4 widget for a rgba color or 2 for a width and height we put them in the same row and use only one widget

```
class MyVectorNode extends LGraphNode {
    constructor() {
        super("Vector")
        
        // Add inputs/outputs
        this.addOutput("Vector", "vector")
        
        // Add the multi-number widget
        this.addWidget("number", "Vector", [0,0,0], {
            fields: {
                count: 3,
                labels: ["X", "Y", "Z"]
            },
            precision: 2,
            min: -100,
            max: 100
        })
    }

    onExecute() {
        // Get the widget value - it will be an array
        const vector = this.widgets[0].value
        this.setOutputData(0, vector)
    }
}
```

```
class MyAreaNode extends LGraphNode {
    constructor() {
        super("Area")
        
        // Add inputs/outputs
        this.addOutput("Area", "area")
        
        // Add the multi-number widget
        this.addWidget("number", "Vector", [0,0], {
            fields: {
                count: 2,
                labels: ["width", "height"]
            },
            precision: 2,
            min: -100,
            max: 100
        })
    }

    onExecute() {
        // Get the widget value - it will be an array
        const area= this.widgets[0].value
        this.setOutputData(0,area)
    }
}
```