### PR TITLE
[API] Add reroute convenience methods

### DIFF
--- a/src/LGraph.ts
+++ b/src/LGraph.ts
@@ -1400,6 +1400,17 @@ export class LGraph implements LinkNetwork, Serialisable<SerialisableGraph> {
   }
 
   /**
+   * Returns a reroute by ID, or `undefined` if the ID is `null` or `undefined`.
+   * @param id ID of reroute to return
+   * @returns The reroute with the provided {@link id}, otherwise `undefined`. Always returns `undefined` if `id` is `null` or `undefined`.
+   */
+  getReroute(id: null | undefined): undefined
+  getReroute(id: RerouteId | null | undefined): Reroute | undefined
+  getReroute(id: RerouteId | null | undefined): Reroute | undefined {
+    return id == null ? undefined : this.reroutes.get(id)
+  }
+
+  /**
    * Configures a reroute on the graph where ID is already known (probably deserialisation).
    * Creates the object if it does not exist.
    * @param serialisedReroute See {@link SerialisableReroute}

--- a/src/Reroute.ts
+++ b/src/Reroute.ts
@@ -49,6 +49,10 @@ export class Reroute implements Positionable, LinkSegment, Serialisable<Serialis
     this.#parentId = value
   }
 
+  public get parent(): Reroute | undefined {
+    return this.#network.deref()?.getReroute(this.#parentId)
+  }
+
   /** This property is only defined on the last reroute of a floating reroute chain (closest to input end). */
   floating?: FloatingRerouteSlot
 

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -116,6 +116,8 @@ export interface ReadonlyLinkNetwork {
   readonly reroutes: ReadonlyMap<RerouteId, Reroute>
   readonly floatingLinks: ReadonlyMap<LinkId, LLink>
   getNodeById(id: NodeId): LGraphNode | null
+  getReroute(parentId: null | undefined): undefined
+  getReroute(parentId: RerouteId | null | undefined): Reroute | undefined
 }
 
 /**
@@ -126,6 +128,7 @@ export interface LinkNetwork extends ReadonlyLinkNetwork {
   readonly reroutes: Map<RerouteId, Reroute>
   addFloatingLink(link: LLink): LLink
   removeReroute(id: number): unknown
+  removeFloatingLink(link: LLink): void
 }
 
 /**


### PR DESCRIPTION
Adds `LGraph.getReroute`, which accepts null & undefined IDs.  Interface overloads result in `never` when given a _known_ `undefined` or `null` value.