### PR TITLE
Revert "Implement _.pick to simplify serialization (#763)"

### DIFF
--- a/src/NodeSlot.ts
+++ b/src/NodeSlot.ts
@@ -1,12 +1,12 @@
 import type { CanvasColour, Dictionary, INodeInputSlot, INodeOutputSlot, INodeSlot, ISlotType, IWidgetInputSlot, Point, SharedIntersection } from "./interfaces"
 import type { LinkId } from "./LLink"
-import type { ISerialisableNodeInput, ISerialisableNodeOutput } from "./types/serialisation"
 import type { IWidget } from "./types/widgets"
 
 import { LabelPosition, SlotShape, SlotType } from "./draw"
 import { LiteGraph } from "./litegraph"
 import { LinkDirection, RenderShape } from "./types/globalEnums"
-import { pick } from "./utils/object"
+import { ISerialisableNodeOutput } from "./types/serialisation"
+import { ISerialisableNodeInput } from "./types/serialisation"
 
 export interface ConnectionColorContext {
   default_connection_color: {
@@ -33,19 +33,8 @@ interface IDrawOptions {
 type CommonIoSlotProps = SharedIntersection<ISerialisableNodeInput, ISerialisableNodeOutput>
 
 export function shallowCloneCommonProps(slot: CommonIoSlotProps): CommonIoSlotProps {
-  return pick(slot, [
-    "color_off",
-    "color_on",
-    "dir",
-    "label",
-    "localized_name",
-    "locked",
-    "name",
-    "nameLocked",
-    "removable",
-    "shape",
-    "type",
-  ])
+  const { color_off, color_on, dir, label, localized_name, locked, name, nameLocked, removable, shape, type } = slot
+  return { color_off, color_on, dir, label, localized_name, locked, name, nameLocked, removable, shape, type }
 }
 
 export function inputAsSerialisable(slot: INodeInputSlot): ISerialisableNodeInput {

--- a/src/utils/object.ts
+++ b/src/utils/object.ts
@@ -3,21 +3,3 @@ export function omitBy<T extends object>(obj: T, predicate: (value: any) => bool
     Object.entries(obj).filter(([_key, value]) => !predicate(value)),
   ) as Partial<T>
 }
-
-/**
- * Creates an object composed of the picked object properties.
- * Similar to lodash's pick function.
- * @param obj The source object
- * @param keys The property names to pick
- * @returns A new object with just the picked properties
- */
-export function pick<T extends object, K extends keyof T>(obj: T, keys: K[]): Pick<T, K> {
-  // Assertion: Required to avoid verbose runtime guards
-  const picked = {} as Pick<T, K>
-  for (const key of keys) {
-    if (key in obj) {
-      picked[key] = obj[key]
-    }
-  }
-  return picked
-}


### PR DESCRIPTION
Reason: Performance

- 40x slower slot serialisation using randomised data
- Overall 2-3x slower `graph.serialize()` on a 600 node graph (translation / customisation increases this)

This reverts commit 77465113cd23e81ea0621bbc3df8e94595980679.