### PR TITLE
Fix minor render issues with links / reroutes

### DIFF
--- a/src/LGraphCanvas.ts
+++ b/src/LGraphCanvas.ts
@@ -4617,7 +4617,8 @@ export class LGraphCanvas implements ConnectionColorContext {
       this.#renderFloatingLinks(ctx, graph, visibleReroutes, now)
     }
 
-    // Render the reroute circles
+    // Render reroutes, ordered by number of non-floating links
+    visibleReroutes.sort((a, b) => a.linkIds.size - b.linkIds.size)
     for (const reroute of visibleReroutes) {
       if (
         this.#snapToGrid &&


### PR DESCRIPTION
- Fixes link centre marker highlight drawn over dragged items
- Fixes arrow-style link centre marker drawn twice
- Adds missing centre markers for output floating links
- Adds render sort order for reroutes (more links rendered on top)