### PR TITLE
Fix bypass links on delete gives up after corrupt link

### DIFF
--- a/src/LGraphNode.ts
+++ b/src/LGraphNode.ts
@@ -3319,7 +3319,7 @@ export class LGraphNode implements Positionable, IPinnable, IColorable {
 
       for (const outLink of outLinks) {
         const outNode = graph.getNodeById(outLink.target_id)
-        if (!outNode) return
+        if (!outNode) continue
 
         const result = inNode.connect(
           inLink.origin_slot,


### PR DESCRIPTION
Bypass links will now continue to attempt to connect other links, instead of silently giving up on the first corrupt link it finds.