### PR TITLE
Fix cannot shift-drag new link from first link segment

### DIFF
--- a/src/canvas/LinkConnector.ts
+++ b/src/canvas/LinkConnector.ts
@@ -294,8 +294,6 @@ export class LinkConnector {
     if (!slot) return
 
     const reroute = network.getReroute(linkSegment.parentId)
-    if (!reroute) return
-
     const renderLink = new ToInputRenderLink(network, node, slot, reroute)
     renderLink.fromDirection = LinkDirection.NONE
     this.renderLinks.push(renderLink)


### PR DESCRIPTION
Fixes issue where new links can only be shift-click dragged from the link line on link segments *after* a native reroute.