### PR TITLE
Add lowQuality param to IWidget.draw

### DIFF
--- a/src/LGraphNode.ts
+++ b/src/LGraphNode.ts
@@ -3376,7 +3376,7 @@ export class LGraphNode implements Positionable, IPinnable, IColorable {
       if (WidgetClass) {
         toClass(WidgetClass, w).drawWidget(ctx, { y, width: widget_width, show_text, margin })
       } else {
-        w.draw?.(ctx, this, widget_width, y, H)
+        w.draw?.(ctx, this, widget_width, y, H, lowQuality)
       }
       ctx.globalAlpha = editorAlpha
     }

--- a/src/types/widgets.ts
+++ b/src/types/widgets.ts
@@ -193,12 +193,22 @@ export interface IBaseWidget {
    * @todo Expose CanvasPointer API to custom widgets
    */
   mouse?(event: CanvasPointerEvent, pointerOffset: Point, node: LGraphNode): boolean
+  /**
+   * Draw the widget.
+   * @param ctx The canvas context to draw on.
+   * @param node The node this widget belongs to.
+   * @param widget_width The width of the widget.
+   * @param y The y position of the widget.
+   * @param H The height of the widget.
+   * @param lowQuality Whether to draw the widget in low quality.
+   */
   draw?(
     ctx: CanvasRenderingContext2D,
     node: LGraphNode,
     widget_width: number,
     y: number,
     H: number,
+    lowQuality?: boolean,
   ): void
 
   /**


### PR DESCRIPTION
Currently widget needs to get access to `LGraphCanvas` instance to know whether the canvas is rendering in low quality (Zoomed out). Usually canvas object is obtained from `ComfyApp` instance.

This PR passes the lowQuality value to `IWidget.draw` to decouple the dependency on `LGraphCanvas`.