### PR TITLE
[API] Add customisation of reroute bezier controls

### DIFF
--- a/src/LGraphCanvas.ts
+++ b/src/LGraphCanvas.ts
@@ -4757,7 +4757,7 @@ export class LGraphCanvas implements ConnectionColorContext {
         } else {
           // Calculate start control for the next iter control point
           const nextPos = reroutes[j + 1]?.pos ?? endPos
-          const dist = Math.min(80, distance(reroute.pos, nextPos) * 0.25)
+          const dist = Math.min(Reroute.maxSplineOffset, distance(reroute.pos, nextPos) * 0.25)
           startControl = [dist * reroute.cos, dist * reroute.sin]
         }
       }

--- a/src/Reroute.ts
+++ b/src/Reroute.ts
@@ -33,6 +33,8 @@ export interface FloatingRerouteSlot {
  */
 export class Reroute implements Positionable, LinkSegment, Serialisable<SerialisableReroute> {
   static radius: number = 10
+  /** Maximum distance from reroutes to their bezier curve control points. */
+  static maxSplineOffset: number = 80
   static drawIdBadge: boolean = false
 
   #malloc = new Float32Array(8)
@@ -417,7 +419,7 @@ export class Reroute implements Positionable, LinkSegment, Serialisable<Serialis
     )
     let diff = (originToReroute - sum) * 0.5
     if (Math.abs(diff) > Math.PI * 0.5) diff += Math.PI
-    const dist = Math.min(80, distance(linkStart, this.#pos) * 0.25)
+    const dist = Math.min(Reroute.maxSplineOffset, distance(linkStart, this.#pos) * 0.25)
 
     // Store results
     const originDiff = originToReroute - diff


### PR DESCRIPTION
Allows globally setting the bezier control point offset from the reroute centre point.  This can be increased to allow larger curves on longer links, or set to 0 to completely disable the spline on inter-reroute link segments.

```ts
// Setting this to zero only affects inter-reroute link segments, as shown below
LiteGraph.Reroute.maxSplineOffset = 0
```

![image](https://github.com/user-attachments/assets/f6556f6c-34a5-4dfe-baba-7a143b187fd7)
