### PR TITLE
Early return in LGraphCanvas.deselectAll

### DIFF
--- a/src/LGraphCanvas.ts
+++ b/src/LGraphCanvas.ts
@@ -3436,6 +3436,8 @@ export class LGraphCanvas implements ConnectionColorContext {
     if (!this.graph) return
 
     const selected = this.selectedItems
+    if (!selected.size) return
+
     let wasSelected: Positionable | undefined
     for (const sel of selected) {
       if (sel === keepSelected) {


### PR DESCRIPTION
Avoid trigger `onSelectionChange` when nothing is selected.