### PR TITLE
[Cleanup] Remove use_legacy_node_error_indicator

### DIFF
--- a/src/LGraphCanvas.ts
+++ b/src/LGraphCanvas.ts
@@ -4402,7 +4402,7 @@ export class LGraphCanvas implements ConnectionColorContext {
   ): void {
     // Rendering options
     ctx.strokeStyle = fgcolor
-    ctx.fillStyle = LiteGraph.use_legacy_node_error_indicator ? "#F00" : bgcolor
+    ctx.fillStyle = bgcolor
 
     const title_height = LiteGraph.NODE_TITLE_HEIGHT
     const { low_quality } = this
@@ -4442,7 +4442,7 @@ export class LGraphCanvas implements ConnectionColorContext {
     }
     ctx.fill()
 
-    if (node.has_errors && !LiteGraph.use_legacy_node_error_indicator) {
+    if (node.has_errors) {
       strokeShape(ctx, area, {
         shape,
         title_mode,
@@ -4495,7 +4495,7 @@ export class LGraphCanvas implements ConnectionColorContext {
     if (selected) {
       node.onBounding?.(area)
 
-      const padding = node.has_errors && !LiteGraph.use_legacy_node_error_indicator ? 20 : undefined
+      const padding = node.has_errors ? 20 : undefined
 
       strokeShape(ctx, area, {
         shape,

--- a/src/LiteGraphGlobal.ts
+++ b/src/LiteGraphGlobal.ts
@@ -255,9 +255,6 @@ export class LiteGraphGlobal {
   // Whether to highlight the bounding box of selected groups
   highlight_selected_group = true
 
-  /** If `true`, the old "eye-melting-red" error indicator will be used for nodes */
-  use_legacy_node_error_indicator = false
-
   /** Whether to scale context with the graph when zooming in.  Zooming out never makes context menus smaller. */
   context_menu_scaling = false
 

--- a/test/__snapshots__/litegraph.test.ts.snap
+++ b/test/__snapshots__/litegraph.test.ts.snap
@@ -178,7 +178,6 @@ LiteGraphGlobal {
   "snap_highlights_node": true,
   "snaps_for_comfy": true,
   "throw_errors": true,
-  "use_legacy_node_error_indicator": false,
   "use_uuids": false,
   "uuidv4": [Function],
 }


### PR DESCRIPTION
The fallback option was added in https://github.com/Comfy-Org/litegraph.js/pull/358. So far no code is using this legacy fallback option. Removing it now.