### PR TITLE
Upstream render of slot error

### DIFF
--- a/src/NodeSlot.ts
+++ b/src/NodeSlot.ts
@@ -97,6 +97,7 @@ export abstract class NodeSlot implements INodeSlot {
   nameLocked?: boolean
   pos?: Point
   widget?: IWidget
+  hasErrors?: boolean
 
   constructor(slot: INodeSlot) {
     Object.assign(this, slot)
@@ -235,6 +236,15 @@ export abstract class NodeSlot implements INodeSlot {
           }
         }
       }
+    }
+
+    // Draw a red circle if the slot has errors.
+    if (this.hasErrors) {
+      ctx.lineWidth = 2
+      ctx.strokeStyle = "red"
+      ctx.beginPath()
+      ctx.arc(pos[0], pos[1], 12, 0, Math.PI * 2)
+      ctx.stroke()
     }
 
     // Restore the original fillStyle and strokeStyle

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -291,6 +291,10 @@ export interface INodeSlot {
    * This is calculated at runtime; it is **not** serialized.
    */
   _floatingLinks?: Set<LLink>
+  /**
+   * Whether the slot has errors. It is **not** serialized.
+   */
+  hasErrors?: boolean
 }
 
 export interface INodeFlags {


### PR DESCRIPTION
Upstream slot error rendering from ComfyUI_frontend.

![image](https://github.com/user-attachments/assets/d14b49a1-7943-4249-a20a-8b3d33df8ddb)
