### PR TITLE
[TS] Properly type slot widget

### DIFF
--- a/src/NodeSlot.ts
+++ b/src/NodeSlot.ts
@@ -1,4 +1,4 @@
-import type { CanvasColour, Dictionary, INodeInputSlot, INodeOutputSlot, INodeSlot, ISlotType, IWidgetInputSlot, Point, SharedIntersection, WidgetLocator } from "./interfaces"
+import type { CanvasColour, Dictionary, INodeInputSlot, INodeOutputSlot, INodeSlot, ISlotType, IWidgetInputSlot, IWidgetLocator, Point, SharedIntersection } from "./interfaces"
 import type { LinkId } from "./LLink"
 import type { IWidget } from "./types/widgets"
 
@@ -96,7 +96,7 @@ export abstract class NodeSlot implements INodeSlot {
   locked?: boolean
   nameLocked?: boolean
   pos?: Point
-  widget?: WidgetLocator
+  widget?: IWidgetLocator
   hasErrors?: boolean
 
   constructor(slot: INodeSlot) {

--- a/src/NodeSlot.ts
+++ b/src/NodeSlot.ts
@@ -1,4 +1,4 @@
-import type { CanvasColour, Dictionary, INodeInputSlot, INodeOutputSlot, INodeSlot, ISlotType, IWidgetInputSlot, Point, SharedIntersection } from "./interfaces"
+import type { CanvasColour, Dictionary, INodeInputSlot, INodeOutputSlot, INodeSlot, ISlotType, IWidgetInputSlot, Point, SharedIntersection, WidgetLocator } from "./interfaces"
 import type { LinkId } from "./LLink"
 import type { IWidget } from "./types/widgets"
 
@@ -96,7 +96,7 @@ export abstract class NodeSlot implements INodeSlot {
   locked?: boolean
   nameLocked?: boolean
   pos?: Point
-  widget?: IWidget
+  widget?: WidgetLocator
   hasErrors?: boolean
 
   constructor(slot: INodeSlot) {

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -311,7 +311,7 @@ export interface INodeFlags {
  * This is set by the ComfyUI_frontend logic. See
  * https://github.com/Comfy-Org/ComfyUI_frontend/blob/b80e0e1a3c74040f328c4e344326c969c97f67e0/src/extensions/core/widgetInputs.ts#L659
  */
-export interface WidgetLocator {
+export interface IWidgetLocator {
   name: string
   [key: string | symbol]: unknown
 }
@@ -319,11 +319,11 @@ export interface WidgetLocator {
 export interface INodeInputSlot extends INodeSlot {
   link: LinkId | null
   _layoutElement?: LayoutElement<INodeInputSlot>
-  widget?: WidgetLocator
+  widget?: IWidgetLocator
 }
 
 export interface IWidgetInputSlot extends INodeInputSlot {
-  widget: WidgetLocator
+  widget: IWidgetLocator
 }
 
 export interface INodeOutputSlot extends INodeSlot {

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -3,7 +3,6 @@ import type { LGraphNode, NodeId } from "./LGraphNode"
 import type { LinkId, LLink } from "./LLink"
 import type { Reroute, RerouteId } from "./Reroute"
 import type { LinkDirection, RenderShape } from "./types/globalEnums"
-import type { IWidget } from "./types/widgets"
 import type { LayoutElement } from "./utils/layout"
 
 export type Dictionary<T> = { [key: string]: T }
@@ -306,17 +305,25 @@ export interface INodeFlags {
   keepAllLinksOnBypass?: boolean
 }
 
+/**
+ * A widget that is linked to a slot.
+ *
+ * This is set by the ComfyUI_frontend logic. See
+ * https://github.com/Comfy-Org/ComfyUI_frontend/blob/b80e0e1a3c74040f328c4e344326c969c97f67e0/src/extensions/core/widgetInputs.ts#L659
+ */
+export interface WidgetLocator {
+  name: string
+  [key: string | symbol]: unknown
+}
+
 export interface INodeInputSlot extends INodeSlot {
   link: LinkId | null
   _layoutElement?: LayoutElement<INodeInputSlot>
-  /**
-   * A widget that is linked to this input slot.
-   */
-  widget?: IWidget
+  widget?: WidgetLocator
 }
 
 export interface IWidgetInputSlot extends INodeInputSlot {
-  widget: IWidget
+  widget: WidgetLocator
 }
 
 export interface INodeOutputSlot extends INodeSlot {


### PR DESCRIPTION
INodeSlot.widget is not real widget references at runtime. This PR narrows the type so that we don't run into unexpected issues.