### PR TITLE
[Bug] Fix slot link state corruption on moving link between sockets

### DIFF
--- a/src/canvas/MovingInputLink.ts
+++ b/src/canvas/MovingInputLink.ts
@@ -42,6 +42,7 @@ export class MovingInputLink extends MovingLinkBase {
   connectToInput(inputNode: LGraphNode, input: INodeInputSlot, events: LinkConnectorEventTarget): LLink | null | undefined {
     if (input === this.inputSlot) return
 
+    this.inputNode.disconnectInput(this.inputIndex, true)
     const link = this.outputNode.connectSlots(this.outputSlot, inputNode, input, this.fromReroute?.id)
     if (link) events.dispatch("input-moved", this)
     return link

--- a/test/LinkConnector.integration.test.ts
+++ b/test/LinkConnector.integration.test.ts
@@ -165,9 +165,7 @@ describe("LinkConnector Integration", () => {
   })
 
   describe("Moving input links", () => {
-    // Fails link integrity check. Original link is not properly removed.
-    // https://github.com/Comfy-Org/litegraph.js/issues/881
-    test.skip("Should move input links", ({ graph, connector }) => {
+    test("Should move input links", ({ graph, connector }) => {
       const nextLinkId = graph.last_link_id + 1
 
       const hasInputNode = graph.getNodeById(2)!
@@ -190,6 +188,7 @@ describe("LinkConnector Integration", () => {
       expect(connector.inputLinks.length).toBe(0)
 
       expect(disconnectedNode.inputs[0].link).toBe(nextLinkId)
+      expect(hasInputNode.inputs[0].link).toBeNull()
 
       const reroutesAfter = LLink.getReroutes(graph, graph.links.get(disconnectedNode.inputs[0].link!)!)
       expect(reroutesAfter).toEqual(reroutesBefore)


### PR DESCRIPTION
Ref: https://github.com/Comfy-Org/litegraph.js/issues/881

This PR fixes the corrupted link state when moving link from one input socket to another.