### PR TITLE
Support associated socket for widgets

### DIFF
--- a/src/LGraphCanvas.ts
+++ b/src/LGraphCanvas.ts
@@ -5204,12 +5204,7 @@ export class LGraphCanvas implements ConnectionColorContext {
     posY: number,
     ctx: CanvasRenderingContext2D,
   ): void {
-    const { linkConnector } = this
-
     node.drawWidgets(ctx, {
-      colorContext: this,
-      linkOverWidget: linkConnector.overWidget,
-      linkOverWidgetType: linkConnector.overWidgetType,
       lowQuality: this.low_quality,
       editorAlpha: this.editor_alpha,
     })

--- a/src/LGraphCanvas.ts
+++ b/src/LGraphCanvas.ts
@@ -576,11 +576,6 @@ export class LGraphCanvas implements ConnectionColorContext {
   onNodeSelected?: (node: LGraphNode) => void
   onNodeDeselected?: (node: LGraphNode) => void
   onRender?: (canvas: HTMLCanvasElement, ctx: CanvasRenderingContext2D) => void
-  /** Implement this function to allow conversion of widget types to input types, e.g. number -> INT or FLOAT for widget link validation checks */
-  getWidgetLinkType?: (
-    widget: IWidget,
-    node: LGraphNode,
-  ) => string | null | undefined
 
   /**
    * Creates a new instance of LGraphCanvas.
@@ -2601,20 +2596,6 @@ export class LGraphCanvas implements ConnectionColorContext {
               // No link, or none of the dragged links may be dropped here
             } else if (linkConnector.state.connectingTo === "input") {
               if (inputId === -1 && outputId === -1) {
-                // Allow support for linking to widgets, handled externally to LiteGraph
-                if (this.getWidgetLinkType && overWidget) {
-                  const widgetLinkType = this.getWidgetLinkType(overWidget, node)
-                  if (
-                    widgetLinkType &&
-                    LiteGraph.isValidConnection(linkConnector.renderLinks[0]?.fromSlot.type, widgetLinkType) &&
-                    firstLink.node.isValidWidgetLink?.(firstLink.fromSlotIndex, node, overWidget) !== false
-                  ) {
-                    const { pos: [nodeX, nodeY] } = node
-                    highlightPos = [nodeX + 10, nodeY + 10 + overWidget.y]
-                    linkConnector.overWidget = overWidget
-                    linkConnector.overWidgetType = widgetLinkType
-                  }
-                }
                 // Node background / title under the pointer
                 if (!linkConnector.overWidget) {
                   const result = node.findInputByType(firstLink.fromSlot.type)

--- a/src/LGraphNode.ts
+++ b/src/LGraphNode.ts
@@ -1929,7 +1929,7 @@ export class LGraphNode implements Positionable, IPinnable, IColorable {
 
     for (const widget of widgets) {
       if (
-        (widget.disabled && !includeDisabled) ||
+        (widget.computedDisabled && !includeDisabled) ||
         !this.isWidgetVisible(widget)
       ) {
         continue
@@ -3370,9 +3370,7 @@ export class LGraphNode implements Positionable, IPinnable, IColorable {
     const isHidden = (
       this.collapsed ||
       widget.hidden ||
-      (widget.advanced && !this.showAdvanced) ||
-      // Hide widget if the value is passed from socket connection.
-      this.getSlotFromWidget(widget)?.link != null
+      (widget.advanced && !this.showAdvanced)
     )
     return !isHidden
   }
@@ -3400,10 +3398,13 @@ export class LGraphNode implements Positionable, IPinnable, IColorable {
       const outline_color = w.advanced ? LiteGraph.WIDGET_ADVANCED_OUTLINE_COLOR : LiteGraph.WIDGET_OUTLINE_COLOR
 
       w.last_y = y
+      // Disable widget if it is disabled or if the value is passed from socket connection.
+      w.computedDisabled = w.disabled || this.getSlotFromWidget(w)?.link != null
+
       ctx.strokeStyle = outline_color
       ctx.fillStyle = "#222"
       ctx.textAlign = "left"
-      if (w.disabled) ctx.globalAlpha *= 0.5
+      if (w.computedDisabled) ctx.globalAlpha *= 0.5
       const widget_width = w.width || width
 
       const WidgetClass: typeof WIDGET_TYPE_MAP[string] = WIDGET_TYPE_MAP[w.type]

--- a/src/LGraphNode.ts
+++ b/src/LGraphNode.ts
@@ -1585,7 +1585,7 @@ export class LGraphNode implements Positionable, IPinnable, IColorable {
     let widgets_height = 0
     if (this.widgets?.length) {
       for (const widget of this.widgets) {
-        if (widget.hidden || (widget.advanced && !this.showAdvanced)) continue
+        if (!this.isWidgetVisible(widget)) continue
 
         let widget_height = 0
         if (widget.computeSize) {
@@ -1930,8 +1930,7 @@ export class LGraphNode implements Positionable, IPinnable, IColorable {
     for (const widget of widgets) {
       if (
         (widget.disabled && !includeDisabled) ||
-        widget.hidden ||
-        (widget.advanced && !this.showAdvanced)
+        !this.isWidgetVisible(widget)
       ) {
         continue
       }
@@ -3364,6 +3363,20 @@ export class LGraphNode implements Positionable, IPinnable, IColorable {
     }
   }
 
+  /**
+   * Returns `true` if the widget is visible, otherwise `false`.
+   */
+  isWidgetVisible(widget: IWidget): boolean {
+    const isHidden = (
+      this.collapsed ||
+      widget.hidden ||
+      (widget.advanced && !this.showAdvanced) ||
+      // Hide widget if the value is passed from socket connection.
+      this.getSlotFromWidget(widget)?.link != null
+    )
+    return !isHidden
+  }
+
   drawWidgets(ctx: CanvasRenderingContext2D, options: {
     lowQuality?: boolean
     editorAlpha?: number
@@ -3381,11 +3394,8 @@ export class LGraphNode implements Positionable, IPinnable, IColorable {
     const margin = 15
 
     for (const w of widgets) {
-      // Hide widget if the value is passed from socket connection.
-      const associatedSlot = this.getSlotFromWidget(w)
-      const associatedSlotConnected = associatedSlot?.link != null
+      if (!this.isWidgetVisible(w)) continue
 
-      if (w.hidden || (w.advanced && !this.showAdvanced) || associatedSlotConnected) continue
       const y = w.y
       const outline_color = w.advanced ? LiteGraph.WIDGET_ADVANCED_OUTLINE_COLOR : LiteGraph.WIDGET_OUTLINE_COLOR
 

--- a/src/LGraphNode.ts
+++ b/src/LGraphNode.ts
@@ -3526,6 +3526,10 @@ export class LGraphNode implements Positionable, IPinnable, IColorable {
     return this.#getMouseOverSlot(slot) === slot
   }
 
+  #isMouseOverWidget(widget: IWidget): boolean {
+    return this.mouseOver?.overWidget === widget
+  }
+
   /**
    * Returns the input slot that is associated with the given widget.
    */
@@ -3561,7 +3565,18 @@ export class LGraphNode implements Positionable, IPinnable, IColorable {
       const labelColor = highlight
         ? this.highlightColor
         : LiteGraph.NODE_TEXT_COLOR
-      ctx.globalAlpha = isValid ? editorAlpha : 0.4 * editorAlpha
+
+      // Show slot if it's not a widget input slot
+      // or if it's a widget input slot and satisfies one of the following:
+      // - the mouse is over the widget
+      // - the slot is valid during link drop
+      // - the slot is connected
+      const showSlot = !isWidgetInputSlot(slot) ||
+        this.#isMouseOverWidget(this.getWidgetFromSlot(slot)!) ||
+        (fromSlot && slotInstance.isValidTarget(fromSlot)) ||
+        slot.link != null
+
+      ctx.globalAlpha = showSlot ? (isValid ? editorAlpha : 0.4 * editorAlpha) : 0
 
       slotInstance.draw(ctx, {
         pos: layoutElement?.center ?? [0, 0],

--- a/src/LGraphNode.ts
+++ b/src/LGraphNode.ts
@@ -3574,7 +3574,7 @@ export class LGraphNode implements Positionable, IPinnable, IColorable {
       const showSlot = !isWidgetInputSlot(slot) ||
         this.#isMouseOverWidget(this.getWidgetFromSlot(slot)!) ||
         (fromSlot && slotInstance.isValidTarget(fromSlot)) ||
-        slot.link != null
+        slotInstance.isConnected()
 
       ctx.globalAlpha = showSlot ? (isValid ? editorAlpha : 0.4 * editorAlpha) : 0
 

--- a/src/LGraphNode.ts
+++ b/src/LGraphNode.ts
@@ -3365,15 +3365,12 @@ export class LGraphNode implements Positionable, IPinnable, IColorable {
   }
 
   drawWidgets(ctx: CanvasRenderingContext2D, options: {
-    colorContext: ConnectionColorContext
-    linkOverWidget: IWidget | null | undefined
-    linkOverWidgetType?: ISlotType
     lowQuality?: boolean
     editorAlpha?: number
   }): void {
     if (!this.widgets) return
 
-    const { colorContext, linkOverWidget, linkOverWidgetType, lowQuality = false, editorAlpha = 1 } = options
+    const { lowQuality = false, editorAlpha = 1 } = options
 
     const width = this.size[0]
     const widgets = this.widgets
@@ -3387,16 +3384,6 @@ export class LGraphNode implements Positionable, IPinnable, IColorable {
       if (w.hidden || (w.advanced && !this.showAdvanced)) continue
       const y = w.y
       const outline_color = w.advanced ? LiteGraph.WIDGET_ADVANCED_OUTLINE_COLOR : LiteGraph.WIDGET_OUTLINE_COLOR
-
-      if (w === linkOverWidget) {
-        // Manually draw a slot next to the widget simulating an input
-        new NodeInputSlot({
-          name: "",
-          // @ts-expect-error https://github.com/Comfy-Org/litegraph.js/issues/616
-          type: linkOverWidgetType,
-          link: 0,
-        }).draw(ctx, { pos: [10, y + 10], colorContext })
-      }
 
       w.last_y = y
       ctx.strokeStyle = outline_color

--- a/src/LGraphNode.ts
+++ b/src/LGraphNode.ts
@@ -3381,7 +3381,11 @@ export class LGraphNode implements Positionable, IPinnable, IColorable {
     const margin = 15
 
     for (const w of widgets) {
-      if (w.hidden || (w.advanced && !this.showAdvanced)) continue
+      // Hide widget if the value is passed from socket connection.
+      const associatedSlot = this.getSlotFromWidget(w)
+      const associatedSlotConnected = associatedSlot?.link != null
+
+      if (w.hidden || (w.advanced && !this.showAdvanced) || associatedSlotConnected) continue
       const y = w.y
       const outline_color = w.advanced ? LiteGraph.WIDGET_ADVANCED_OUTLINE_COLOR : LiteGraph.WIDGET_OUTLINE_COLOR
 
@@ -3509,6 +3513,21 @@ export class LGraphNode implements Positionable, IPinnable, IColorable {
 
   #isMouseOverSlot(slot: INodeSlot): boolean {
     return this.#getMouseOverSlot(slot) === slot
+  }
+
+  /**
+   * Returns the input slot that is associated with the given widget.
+   */
+  getSlotFromWidget(widget: IWidget): INodeInputSlot | undefined {
+    return this.inputs.find(slot => isWidgetInputSlot(slot) && slot.widget.name === widget.name)
+  }
+
+  /**
+   * Returns the widget that is associated with the given input slot.
+   */
+  getWidgetFromSlot(slot: INodeInputSlot): IWidget | undefined {
+    if (!isWidgetInputSlot(slot)) return
+    return this.widgets?.find(w => w.name === slot.widget.name)
   }
 
   /**

--- a/src/NodeSlot.ts
+++ b/src/NodeSlot.ts
@@ -214,7 +214,7 @@ export abstract class NodeSlot implements INodeSlot {
     if (!lowQuality && doStroke) ctx.stroke()
 
     // render slot label
-    const hideLabel = lowQuality || (isWidgetInputSlot(this) && !this.isConnected())
+    const hideLabel = lowQuality || isWidgetInputSlot(this)
     if (!hideLabel) {
       const text = this.renderingLabel
       if (text) {

--- a/src/NodeSlot.ts
+++ b/src/NodeSlot.ts
@@ -214,7 +214,8 @@ export abstract class NodeSlot implements INodeSlot {
     if (!lowQuality && doStroke) ctx.stroke()
 
     // render slot label
-    if (!lowQuality) {
+    const hideLabel = lowQuality || (isWidgetInputSlot(this) && !this.isConnected())
+    if (!hideLabel) {
       const text = this.renderingLabel
       if (text) {
         // TODO: Finish impl.  Highlight text on mouseover unless we're connecting links.

--- a/src/types/widgets.ts
+++ b/src/types/widgets.ts
@@ -174,12 +174,13 @@ export interface IBaseWidget {
   width?: number
   /**
    * Whether the widget is disabled. Disabled widgets are rendered at half opacity.
-   * Overrides {@link IBaseWidget.computedDisabled}.
+   * See also {@link IBaseWidget.computedDisabled}.
    */
   disabled?: boolean
 
   /**
-   * The disabled state used for rendering based on default rendering logic.
+   * The disabled state used for rendering based on various conditions including
+   * {@link IBaseWidget.disabled}.
    * @readonly [Computed] This property is computed by the node.
    */
   computedDisabled?: boolean

--- a/src/types/widgets.ts
+++ b/src/types/widgets.ts
@@ -153,26 +153,36 @@ export interface IBaseWidget {
   /**
    * The computed height of the widget. Used by customized node resize logic.
    * See scripts/domWidget.ts for more details.
-   * [Computed] This property is computed by the node.
+   * @readonly [Computed] This property is computed by the node.
    */
   computedHeight?: number
 
   /**
    * The starting y position of the widget after layout.
-   * [Computed] This property is computed by the node.
+   * @readonly [Computed] This property is computed by the node.
    */
   y: number
 
   /**
    * The y position of the widget after drawing (rendering).
-   * [Computed] This property is computed by the node.
+   * @readonly [Computed] This property is computed by the node.
    * @deprecated There is no longer dynamic y adjustment on rendering anymore.
    * Use {@link IBaseWidget.y} instead.
    */
   last_y?: number
 
   width?: number
+  /**
+   * Whether the widget is disabled. Disabled widgets are rendered at half opacity.
+   * Overrides {@link IBaseWidget.computedDisabled}.
+   */
   disabled?: boolean
+
+  /**
+   * The disabled state used for rendering based on default rendering logic.
+   * @readonly [Computed] This property is computed by the node.
+   */
+  computedDisabled?: boolean
 
   hidden?: boolean
   advanced?: boolean

--- a/src/types/widgets.ts
+++ b/src/types/widgets.ts
@@ -153,16 +153,19 @@ export interface IBaseWidget {
   /**
    * The computed height of the widget. Used by customized node resize logic.
    * See scripts/domWidget.ts for more details.
+   * [Computed] This property is computed by the node.
    */
   computedHeight?: number
 
   /**
    * The starting y position of the widget after layout.
+   * [Computed] This property is computed by the node.
    */
   y: number
 
   /**
    * The y position of the widget after drawing (rendering).
+   * [Computed] This property is computed by the node.
    * @deprecated There is no longer dynamic y adjustment on rendering anymore.
    * Use {@link IBaseWidget.y} instead.
    */

--- a/src/widgets/BaseWidget.ts
+++ b/src/widgets/BaseWidget.ts
@@ -23,6 +23,7 @@ export abstract class BaseWidget implements IBaseWidget {
   last_y?: number
   width?: number
   disabled?: boolean
+  computedDisabled?: boolean
   hidden?: boolean
   advanced?: boolean
   tooltip?: string

--- a/src/widgets/BooleanWidget.ts
+++ b/src/widgets/BooleanWidget.ts
@@ -33,7 +33,7 @@ export class BooleanWidget extends BaseWidget implements IBooleanWidget {
       ctx.roundRect(margin, y, width - margin * 2, height, [height * 0.5])
     else ctx.rect(margin, y, width - margin * 2, height)
     ctx.fill()
-    if (show_text && !this.disabled) ctx.stroke()
+    if (show_text && !this.computedDisabled) ctx.stroke()
     ctx.fillStyle = this.value ? "#89A" : "#333"
     ctx.beginPath()
     ctx.arc(

--- a/src/widgets/ButtonWidget.ts
+++ b/src/widgets/ButtonWidget.ts
@@ -45,7 +45,7 @@ export class ButtonWidget extends BaseWidget implements IButtonWidget {
     ctx.fillRect(margin, y, width - margin * 2, height)
 
     // Draw button outline if not disabled
-    if (show_text && !this.disabled) {
+    if (show_text && !this.computedDisabled) {
       ctx.strokeStyle = this.outline_color
       ctx.strokeRect(margin, y, width - margin * 2, height)
     }

--- a/src/widgets/ComboWidget.ts
+++ b/src/widgets/ComboWidget.ts
@@ -49,7 +49,7 @@ export class ComboWidget extends BaseWidget implements IComboWidget {
     ctx.fill()
 
     if (show_text) {
-      if (!this.disabled) {
+      if (!this.computedDisabled) {
         ctx.stroke()
         // Draw left arrow
         ctx.fillStyle = this.text_color

--- a/src/widgets/KnobWidget.ts
+++ b/src/widgets/KnobWidget.ts
@@ -158,7 +158,7 @@ export class KnobWidget extends BaseWidget implements IKnobWidget {
     ctx.closePath()
 
     // Draw outline if not disabled
-    if (show_text && !this.disabled) {
+    if (show_text && !this.computedDisabled) {
       ctx.strokeStyle = this.outline_color
       // Draw value
       ctx.beginPath()

--- a/src/widgets/NumberWidget.ts
+++ b/src/widgets/NumberWidget.ts
@@ -64,7 +64,7 @@ export class NumberWidget extends BaseWidget implements INumericWidget {
     ctx.fill()
 
     if (show_text) {
-      if (!this.disabled) {
+      if (!this.computedDisabled) {
         ctx.stroke()
         // Draw left arrow
         ctx.fillStyle = this.text_color

--- a/src/widgets/SliderWidget.ts
+++ b/src/widgets/SliderWidget.ts
@@ -54,7 +54,7 @@ export class SliderWidget extends BaseWidget implements ISliderWidget {
     ctx.fillRect(margin, y, nvalue * (width - margin * 2), height)
 
     // Draw outline if not disabled
-    if (show_text && !this.disabled) {
+    if (show_text && !this.computedDisabled) {
       ctx.strokeStyle = this.outline_color
       ctx.strokeRect(margin, y, width - margin * 2, height)
     }

--- a/src/widgets/TextWidget.ts
+++ b/src/widgets/TextWidget.ts
@@ -47,7 +47,7 @@ export class TextWidget extends BaseWidget implements IStringWidget {
     ctx.fill()
 
     if (show_text) {
-      if (!this.disabled) ctx.stroke()
+      if (!this.computedDisabled) ctx.stroke()
       ctx.save()
       ctx.beginPath()
       ctx.rect(margin, y, width - margin * 2, height)


### PR DESCRIPTION
This PR is the litegraph side change necessary for widget sockets feature in ComfyUI_frontend. Changes include

- Add readonly `Widget.computedDisabled` property for getting the computed disabled state. When the associated socket is connected, the widget is disabled
- Dynamically show the associated socket when
      - the mouse is over the widget
      - the slot is valid during link drop
      - the slot is connected
- Removes the legacy widget drop behavior

Ref: https://github.com/Comfy-Org/rfcs/pull/9