### PR TITLE
Add Disposable interface & polyfill

### DIFF
--- a/src/canvas/InputIndicators.ts
+++ b/src/canvas/InputIndicators.ts
@@ -13,7 +13,7 @@ import type { LGraphCanvas } from "@/LGraphCanvas"
  * inputIndicators.dispose()
  * ```
  */
-export class InputIndicators {
+export class InputIndicators implements Disposable {
   // #region config
   radius = 8
   startAngle = 0
@@ -163,5 +163,9 @@ export class InputIndicators {
   dispose() {
     this.controller?.abort()
     this.controller = undefined
+  }
+
+  [Symbol.dispose](): void {
+    this.dispose()
   }
 }

--- a/src/polyfills.ts
+++ b/src/polyfills.ts
@@ -1,3 +1,8 @@
+// @ts-expect-error Polyfill
+Symbol.dispose ??= Symbol("Symbol.dispose")
+// @ts-expect-error Polyfill
+Symbol.asyncDispose ??= Symbol("Symbol.asyncDispose")
+
 // API *************************************************
 // like rect but rounded corners
 export function loadPolyfills() {

--- a/src/types/disposable.d.ts
+++ b/src/types/disposable.d.ts
@@ -1,0 +1,23 @@
+/**
+ * Polyfill for disposable type; symbol already registered in modern browsers.
+ */
+
+interface SymbolConstructor {
+  /**
+   * A method that is used to release resources held by an object. Called by the semantics of the `using` statement.
+   */
+  readonly dispose: unique symbol
+
+  /**
+   * A method that is used to asynchronously release resources held by an object. Called by the semantics of the `await using` statement.
+   */
+  readonly asyncDispose: unique symbol
+}
+
+interface Disposable {
+  [Symbol.dispose](): void
+}
+
+interface AsyncDisposable {
+  [Symbol.asyncDispose](): PromiseLike<void>
+}


### PR DESCRIPTION
Adds the `Disposable` and `AsyncDisposable` interfaces via polyfill.

Implements Disposable interface in `InputIndicator`.

Ref: https://www.typescriptlang.org/docs/handbook/release-notes/typescript-5-2.html#using-declarations-and-explicit-resource-management