### PR TITLE
Add IBaseWidget.serialize flag

### DIFF
--- a/src/LGraphNode.ts
+++ b/src/LGraphNode.ts
@@ -777,6 +777,7 @@ export class LGraphNode implements Positionable, IPinnable, IColorable {
     if (widgets && this.serialize_widgets) {
       o.widgets_values = []
       for (const [i, widget] of widgets.entries()) {
+        if (widget.serialize === false) continue
         // @ts-expect-error #595 No-null
         o.widgets_values[i] = widget ? widget.value : null
       }

--- a/src/types/widgets.ts
+++ b/src/types/widgets.ts
@@ -151,6 +151,12 @@ export interface IBaseWidget {
   value?: TWidgetValue
 
   /**
+   * Whether the widget value should be serialized on node serialization.
+   * @default true
+   */
+  serialize?: boolean
+
+  /**
    * The computed height of the widget. Used by customized node resize logic.
    * See scripts/domWidget.ts for more details.
    * @readonly [Computed] This property is computed by the node.


### PR DESCRIPTION
https://github.com/Comfy-Org/ComfyUI_frontend/pull/3323

Some widgets are only used for display purpose (The preview image widget), their value shouldn't be serialized into the workflow. This PR adds a flag to allow widget to skip value serialization.