### PR TITLE
Don't log every single node being replaced when node defs refreshed

### DIFF
--- a/src/LiteGraphGlobal.ts
+++ b/src/LiteGraphGlobal.ts
@@ -299,7 +299,7 @@ export class LiteGraphGlobal {
     }
 
     const prev = this.registered_node_types[type]
-    if (prev) {
+    if (prev && this.debug) {
       console.log("replacing node type:", type)
     }
 


### PR DESCRIPTION
Currently, when node defs are refreshed (e.g., by pressing "r" shortcut), every single node def is logged, which is useless when there's hundred of nodes and clutters console. This PR changes to only log those messages when in debug mode.