### PR TITLE
Add optional icon to LGraphBadge and use for API nodes 

### DIFF
--- a/src/LGraphNode.ts
+++ b/src/LGraphNode.ts
@@ -45,6 +45,8 @@ import { LayoutElement } from "./utils/layout"
 import { distributeSpace } from "./utils/spaceDistribution"
 import { toClass } from "./utils/type"
 import { WIDGET_TYPE_MAP } from "./widgets/widgetMap"
+import { PRIME_ICONS_FONT_FAMILY, PRIME_ICONS_UNICODES } from "./constants/fonts"
+import { BADGE_CONFIGS } from "./constants/badges"
 
 // #region Types
 
@@ -213,6 +215,7 @@ export class LGraphNode implements Positionable, IPinnable, IColorable {
   properties_info: INodePropertyInfo[] = []
   flags: INodeFlags = {}
   widgets?: IWidget[]
+  creditsCost?: number
   /**
    * The amount of space available for widgets to grow into.
    * @see {@link layoutWidgets}
@@ -3314,6 +3317,32 @@ export class LGraphNode implements Positionable, IPinnable, IColorable {
           title_height,
           LiteGraph.NODE_TITLE_TEXT_Y - title_height,
         )
+        if (this.constructor.nodeData?.credits_cost) {
+          const badgeHeight = 20
+          const iconFontSize = 10;
+          const fontSize = iconFontSize + 2;
+
+          const badgeConfig = BADGE_CONFIGS.credits;
+          const badge = new LGraphBadge({
+            fontSize,
+            iconFontSize,
+            text: String(this.constructor.nodeData.credits_cost),
+            fgColor: badgeConfig.badgeText,
+            bgColor: badgeConfig.badgeBg,
+            padding: 6,
+            height: badgeHeight,
+            cornerRadius: 6,
+            iconUnicode: PRIME_ICONS_UNICODES[badgeConfig.icon],
+            iconFontFamily: PRIME_ICONS_FONT_FAMILY,
+            iconColor: badgeConfig.iconColor,
+            iconBgColor: badgeConfig.iconBg,
+          });
+
+          const badgeX = this.size[0] - badge.getWidth(ctx) - 8;
+          const titleBaseline = LiteGraph.NODE_TITLE_TEXT_Y - title_height - 10;
+          const badgeY = titleBaseline - badgeHeight / 2 + fontSize * 0.35;
+          badge.draw(ctx, badgeX, badgeY);
+        }
       }
     }
   }

--- a/src/constants/badges.ts
+++ b/src/constants/badges.ts
@@ -1,0 +1,20 @@
+import { PRIME_ICONS_UNICODES } from './fonts';
+export type PrimeIconKey = keyof typeof PRIME_ICONS_UNICODES;
+
+export interface BadgeConfig {
+  icon: PrimeIconKey;
+  badgeBg: string;
+  badgeText: string;
+  iconBg: string;
+  iconColor: string;
+}
+
+export const BADGE_CONFIGS: Record<string, BadgeConfig> = {
+  credits: {
+    icon: 'pi-dollar',
+    badgeBg: '#8D6932',
+    badgeText: '#fff',
+    iconBg: '#654020',
+    iconColor: '#FABC25',
+  },
+};

--- a/src/constants/fonts.ts
+++ b/src/constants/fonts.ts
@@ -1,0 +1,4 @@
+export const PRIME_ICONS_FONT_FAMILY = 'PrimeIcons'
+export const PRIME_ICONS_UNICODES = {
+  'pi-dollar': '\ue96b',
+}


### PR DESCRIPTION
Adds option to include an icon when creating an `LGraphBadge`. Then, adds the icon to the title of nodes whose `constructor.nodeData` has a non-null `credits_cost` property (API nodes that ComfyUI_frontend was able to successfully query a credit cost for).

![Selection_1228](https://github.com/user-attachments/assets/9b63c0d1-b25b-4066-858f-7f32488eeb38)
