### PR TITLE
[Bug] Remove unused prop LayoutElement.value

### DIFF
--- a/src/LGraphNode.ts
+++ b/src/LGraphNode.ts
@@ -3500,12 +3500,11 @@ export class LGraphNode implements Positionable, IPinnable, IColorable {
     return [...this.inputs, ...this.outputs]
   }
 
-  #measureSlot(slot: INodeSlot, slotIndex: number): LayoutElement<INodeSlot> {
+  #measureSlot(slot: INodeSlot, slotIndex: number): LayoutElement {
     const isInput = isINodeInputSlot(slot)
     const pos = isInput ? this.getInputPos(slotIndex) : this.getOutputPos(slotIndex)
 
     slot._layoutElement = new LayoutElement({
-      value: slot,
       boundingRect: [
         pos[0] - this.pos[0] - LiteGraph.NODE_SLOT_HEIGHT * 0.5,
         pos[1] - this.pos[1] - LiteGraph.NODE_SLOT_HEIGHT * 0.5,
@@ -3517,7 +3516,7 @@ export class LGraphNode implements Positionable, IPinnable, IColorable {
   }
 
   #measureSlots(): ReadOnlyRect | null {
-    const slots: LayoutElement<INodeSlot>[] = []
+    const slots: LayoutElement[] = []
 
     for (const [slotIndex, slot] of this.inputs.entries()) {
       // Unrecognized nodes (Nodes with error) has inputs but no widgets. Treat

--- a/src/NodeSlot.ts
+++ b/src/NodeSlot.ts
@@ -5,8 +5,7 @@ import type { IWidget } from "./types/widgets"
 import { LabelPosition, SlotShape, SlotType } from "./draw"
 import { LiteGraph } from "./litegraph"
 import { LinkDirection, RenderShape } from "./types/globalEnums"
-import { ISerialisableNodeOutput } from "./types/serialisation"
-import { ISerialisableNodeInput } from "./types/serialisation"
+import { ISerialisableNodeInput, ISerialisableNodeOutput } from "./types/serialisation"
 
 export interface ConnectionColorContext {
   default_connection_color: {

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -284,7 +284,7 @@ export interface INodeSlot {
    * A layout element that is used internally to position the slot.
    * Set by {@link LGraphNode.#layoutSlots}.
    */
-  _layoutElement?: LayoutElement<INodeSlot>
+  _layoutElement?: LayoutElement
   /**
    * A list of floating link IDs that are connected to this slot.
    * This is calculated at runtime; it is **not** serialized.
@@ -318,7 +318,7 @@ export interface IWidgetLocator {
 
 export interface INodeInputSlot extends INodeSlot {
   link: LinkId | null
-  _layoutElement?: LayoutElement<INodeInputSlot>
+  _layoutElement?: LayoutElement
   widget?: IWidgetLocator
 }
 
@@ -330,7 +330,7 @@ export interface INodeOutputSlot extends INodeSlot {
   links: LinkId[] | null
   _data?: unknown
   slot_index?: number
-  _layoutElement?: LayoutElement<INodeOutputSlot>
+  _layoutElement?: LayoutElement
 }
 
 /** Links */

--- a/src/utils/layout.ts
+++ b/src/utils/layout.ts
@@ -1,14 +1,11 @@
 import { Point, ReadOnlyRect } from "@/interfaces"
 
-export class LayoutElement<T> {
-  public readonly value: T
+export class LayoutElement {
   public readonly boundingRect: ReadOnlyRect
 
   constructor(o: {
-    value: T
     boundingRect: ReadOnlyRect
   }) {
-    this.value = o.value
     this.boundingRect = o.boundingRect
   }
 


### PR DESCRIPTION
Resolves https://github.com/Comfy-Org/litegraph.js/issues/939

The prop is unused and is causing object clone circular ref issue.