### PR TITLE
[API] Allow new node to be created without links

### DIFF
--- a/src/LGraphCanvas.ts
+++ b/src/LGraphCanvas.ts
@@ -5484,6 +5484,12 @@ export class LGraphCanvas implements ConnectionColorContext {
             opts.position[1] + opts.posAdd[1] + (opts.posSizeFix[1] ? opts.posSizeFix[1] * newNode.size[1] : 0),
           ]
 
+          // Interim API - allow the link connection to be canceled.
+          // TODO: https://github.com/Comfy-Org/litegraph.js/issues/946
+          const detail = { node: newNode, opts }
+          const mayConnectLinks = this.canvas.dispatchEvent(new CustomEvent("connect-new-default-node", { detail, cancelable: true }))
+          if (!mayConnectLinks) return true
+
           // connect the two!
           if (isFrom) {
             if (!opts.nodeFrom) throw new TypeError("createDefaultNodeForSlot - nodeFrom was null")


### PR DESCRIPTION
When using the Add Node context menus, allows consumers to prevent new nodes from being linked.

- Related: Comfy-Org/ComfyUI_frontend#4713