### PR TITLE
[API] Add disconnect links method to LinkConnector

### DIFF
--- a/src/canvas/LinkConnector.ts
+++ b/src/canvas/LinkConnector.ts
@@ -440,17 +440,18 @@ export class LinkConnector {
     const mayContinue = this.events.dispatch("dropped-on-canvas", event)
     if (mayContinue === false) return
 
-    if (this.state.connectingTo === "input") {
-      for (const link of this.renderLinks) {
-        if (link instanceof MovingInputLink) {
-          link.inputNode.disconnectInput(link.inputIndex, true)
-        }
-      }
-    } else if (this.state.connectingTo === "output") {
-      for (const link of this.renderLinks) {
-        if (link instanceof MovingOutputLink) {
-          link.outputNode.disconnectOutput(link.outputIndex, link.inputNode)
-        }
+    this.disconnectLinks()
+  }
+
+  /**
+   * Disconnects all moving links.
+   * @remarks This is called when the links are dropped on the canvas.
+   * May be called by consumers to e.g. drag links into a bin / void.
+   */
+  disconnectLinks(): void {
+    for (const link of this.renderLinks) {
+      if (link instanceof MovingLinkBase) {
+        link.disconnect()
       }
     }
   }

--- a/src/canvas/MovingInputLink.ts
+++ b/src/canvas/MovingInputLink.ts
@@ -76,4 +76,8 @@ export class MovingInputLink extends MovingLinkBase {
   connectToRerouteOutput(): never {
     throw new Error("MovingInputLink cannot connect to an output.")
   }
+
+  disconnect(): boolean {
+    return this.inputNode.disconnectInput(this.inputIndex, true)
+  }
 }

--- a/src/canvas/MovingLinkBase.ts
+++ b/src/canvas/MovingLinkBase.ts
@@ -83,4 +83,6 @@ export abstract class MovingLinkBase implements RenderLink {
   abstract connectToOutput(node: LGraphNode, output: INodeOutputSlot, events?: LinkConnectorEventTarget): void
   abstract connectToRerouteInput(reroute: Reroute, { node, input, link }: { node: LGraphNode, input: INodeInputSlot, link: LLink }, events: LinkConnectorEventTarget, originalReroutes: Reroute[]): void
   abstract connectToRerouteOutput(reroute: Reroute, outputNode: LGraphNode, output: INodeOutputSlot, events: LinkConnectorEventTarget): void
+
+  abstract disconnect(): boolean
 }

--- a/src/canvas/MovingOutputLink.ts
+++ b/src/canvas/MovingOutputLink.ts
@@ -82,4 +82,8 @@ export class MovingOutputLink extends MovingLinkBase {
 
     events.dispatch("output-moved", this)
   }
+
+  disconnect(): boolean {
+    return this.outputNode.disconnectOutput(this.outputIndex, this.inputNode)
+  }
 }


### PR DESCRIPTION
Provides a simple API for consumers to drag & drop links into a bin / void, in order to disconnect them.