### PR TITLE
[Refactor] Remove redundant code

### DIFF
--- a/src/LGraphNode.ts
+++ b/src/LGraphNode.ts
@@ -3377,7 +3377,7 @@ export class LGraphNode implements Positionable, IPinnable, IColorable {
     const nodeWidth = this.size[0]
     const { widgets } = this
     const H = LiteGraph.NODE_WIDGET_HEIGHT
-    const show_text = !lowQuality
+    const showText = !lowQuality
     ctx.save()
     ctx.globalAlpha = editorAlpha
 
@@ -3399,7 +3399,7 @@ export class LGraphNode implements Positionable, IPinnable, IColorable {
 
       const WidgetClass: typeof WIDGET_TYPE_MAP[string] = WIDGET_TYPE_MAP[widget.type]
       if (WidgetClass) {
-        toClass(WidgetClass, widget).drawWidget(ctx, { width, show_text })
+        toClass(WidgetClass, widget).drawWidget(ctx, { width, showText })
       } else {
         widget.draw?.(ctx, this, width, y, H, lowQuality)
       }

--- a/src/widgets/BaseWidget.ts
+++ b/src/widgets/BaseWidget.ts
@@ -7,7 +7,7 @@ import { LiteGraph } from "@/litegraph"
 
 export interface DrawWidgetOptions {
   width: number
-  show_text?: boolean
+  showText?: boolean
 }
 
 export interface WidgetEventOptions {

--- a/src/widgets/BooleanWidget.ts
+++ b/src/widgets/BooleanWidget.ts
@@ -15,7 +15,7 @@ export class BooleanWidget extends BaseWidget implements IBooleanWidget {
 
   override drawWidget(ctx: CanvasRenderingContext2D, {
     width,
-    show_text = true,
+    showText = true,
   }: DrawWidgetOptions) {
     const { height, y } = this
     const { margin } = BaseWidget
@@ -25,11 +25,11 @@ export class BooleanWidget extends BaseWidget implements IBooleanWidget {
     ctx.fillStyle = this.background_color
     ctx.beginPath()
 
-    if (show_text)
+    if (showText)
       ctx.roundRect(margin, y, width - margin * 2, height, [height * 0.5])
     else ctx.rect(margin, y, width - margin * 2, height)
     ctx.fill()
-    if (show_text && !this.computedDisabled) ctx.stroke()
+    if (showText && !this.computedDisabled) ctx.stroke()
     ctx.fillStyle = this.value ? "#89A" : "#333"
     ctx.beginPath()
     ctx.arc(
@@ -40,7 +40,7 @@ export class BooleanWidget extends BaseWidget implements IBooleanWidget {
       Math.PI * 2,
     )
     ctx.fill()
-    if (show_text) {
+    if (showText) {
       ctx.fillStyle = this.secondary_text_color
       const label = this.label || this.name
       if (label != null) {

--- a/src/widgets/ButtonWidget.ts
+++ b/src/widgets/ButtonWidget.ts
@@ -22,7 +22,7 @@ export class ButtonWidget extends BaseWidget implements IButtonWidget {
    */
   override drawWidget(ctx: CanvasRenderingContext2D, {
     width,
-    show_text = true,
+    showText = true,
   }: DrawWidgetOptions) {
     // Store original context attributes
     const originalTextAlign = ctx.textAlign
@@ -41,13 +41,13 @@ export class ButtonWidget extends BaseWidget implements IButtonWidget {
     ctx.fillRect(margin, y, width - margin * 2, height)
 
     // Draw button outline if not disabled
-    if (show_text && !this.computedDisabled) {
+    if (showText && !this.computedDisabled) {
       ctx.strokeStyle = this.outline_color
       ctx.strokeRect(margin, y, width - margin * 2, height)
     }
 
     // Draw button text
-    if (show_text) {
+    if (showText) {
       ctx.textAlign = "center"
       ctx.fillStyle = this.text_color
       ctx.fillText(

--- a/src/widgets/ComboWidget.ts
+++ b/src/widgets/ComboWidget.ts
@@ -109,7 +109,7 @@ export class ComboWidget extends BaseSteppedWidget implements IComboWidget {
    */
   override drawWidget(ctx: CanvasRenderingContext2D, {
     width,
-    show_text = true,
+    showText = true,
   }: DrawWidgetOptions) {
     // Store original context attributes
     const originalTextAlign = ctx.textAlign
@@ -124,13 +124,13 @@ export class ComboWidget extends BaseSteppedWidget implements IComboWidget {
     ctx.fillStyle = this.background_color
     ctx.beginPath()
 
-    if (show_text)
+    if (showText)
       ctx.roundRect(margin, y, width - margin * 2, height, [height * 0.5])
     else
       ctx.rect(margin, y, width - margin * 2, height)
     ctx.fill()
 
-    if (show_text) {
+    if (showText) {
       if (!this.computedDisabled) {
         ctx.stroke()
         this.drawArrowButtons(ctx, margin, y, width)

--- a/src/widgets/KnobWidget.ts
+++ b/src/widgets/KnobWidget.ts
@@ -44,7 +44,7 @@ export class KnobWidget extends BaseWidget implements IKnobWidget {
     ctx: CanvasRenderingContext2D,
     {
       width,
-      show_text = true,
+      showText = true,
     }: DrawWidgetOptions,
   ): void {
     // Store original context attributes
@@ -156,7 +156,7 @@ export class KnobWidget extends BaseWidget implements IKnobWidget {
     ctx.closePath()
 
     // Draw outline if not disabled
-    if (show_text && !this.computedDisabled) {
+    if (showText && !this.computedDisabled) {
       ctx.strokeStyle = this.outline_color
       // Draw value
       ctx.beginPath()
@@ -178,7 +178,7 @@ export class KnobWidget extends BaseWidget implements IKnobWidget {
     // TODO: TBD later when options work
 
     // Draw text
-    if (show_text) {
+    if (showText) {
       ctx.textAlign = "center"
       ctx.fillStyle = this.text_color
       const fixedValue = Number(this.value).toFixed(this.options.precision ?? 3)

--- a/src/widgets/NumberWidget.ts
+++ b/src/widgets/NumberWidget.ts
@@ -53,7 +53,7 @@ export class NumberWidget extends BaseSteppedWidget implements INumericWidget {
    */
   override drawWidget(ctx: CanvasRenderingContext2D, {
     width,
-    show_text = true,
+    showText = true,
   }: DrawWidgetOptions) {
     // Store original context attributes
     const originalTextAlign = ctx.textAlign
@@ -68,13 +68,13 @@ export class NumberWidget extends BaseSteppedWidget implements INumericWidget {
     ctx.fillStyle = this.background_color
     ctx.beginPath()
 
-    if (show_text)
+    if (showText)
       ctx.roundRect(margin, y, width - margin * 2, height, [height * 0.5])
     else
       ctx.rect(margin, y, width - margin * 2, height)
     ctx.fill()
 
-    if (show_text) {
+    if (showText) {
       if (!this.computedDisabled) {
         ctx.stroke()
         this.drawArrowButtons(ctx, margin, y, width)

--- a/src/widgets/SliderWidget.ts
+++ b/src/widgets/SliderWidget.ts
@@ -26,7 +26,7 @@ export class SliderWidget extends BaseWidget implements ISliderWidget {
    */
   override drawWidget(ctx: CanvasRenderingContext2D, {
     width,
-    show_text = true,
+    showText = true,
   }: DrawWidgetOptions) {
     // Store original context attributes
     const originalTextAlign = ctx.textAlign
@@ -50,7 +50,7 @@ export class SliderWidget extends BaseWidget implements ISliderWidget {
     ctx.fillRect(margin, y, nvalue * (width - margin * 2), height)
 
     // Draw outline if not disabled
-    if (show_text && !this.computedDisabled) {
+    if (showText && !this.computedDisabled) {
       ctx.strokeStyle = this.outline_color
       ctx.strokeRect(margin, y, width - margin * 2, height)
     }
@@ -69,7 +69,7 @@ export class SliderWidget extends BaseWidget implements ISliderWidget {
     }
 
     // Draw text
-    if (show_text) {
+    if (showText) {
       ctx.textAlign = "center"
       ctx.fillStyle = this.text_color
       const fixedValue = Number(this.value).toFixed(this.options.precision ?? 3)

--- a/src/widgets/TextWidget.ts
+++ b/src/widgets/TextWidget.ts
@@ -21,7 +21,7 @@ export class TextWidget extends BaseWidget implements IStringWidget {
    */
   override drawWidget(ctx: CanvasRenderingContext2D, {
     width,
-    show_text = true,
+    showText = true,
   }: DrawWidgetOptions) {
     // Store original context attributes
     const originalTextAlign = ctx.textAlign
@@ -36,13 +36,13 @@ export class TextWidget extends BaseWidget implements IStringWidget {
     ctx.fillStyle = this.background_color
     ctx.beginPath()
 
-    if (show_text)
+    if (showText)
       ctx.roundRect(margin, y, width - margin * 2, height, [height * 0.5])
     else
       ctx.rect(margin, y, width - margin * 2, height)
     ctx.fill()
 
-    if (show_text) {
+    if (showText) {
       if (!this.computedDisabled) ctx.stroke()
       ctx.save()
       ctx.beginPath()


### PR DESCRIPTION
Removes redundant code.  After being refactored out of LGraphCanvas, the class methods were being passed their own properties as params.