### PR TITLE
Remove DragAndScale rounding when using trackpad

### DIFF
--- a/src/DragAndScale.ts
+++ b/src/DragAndScale.ts
@@ -122,7 +122,7 @@ export class DragAndScale {
     this.onredraw?.(this)
   }
 
-  changeScale(value: number, zooming_center?: Point): void {
+  changeScale(value: number, zooming_center?: Point, roundToScaleOne = true): void {
     if (value < this.min_scale) {
       value = this.min_scale
     } else if (value > this.max_scale) {
@@ -143,7 +143,7 @@ export class DragAndScale {
     ]
     const center = this.convertCanvasToOffset(normalizedCenter)
     this.scale = value
-    if (Math.abs(this.scale - 1) < 0.01) this.scale = 1
+    if (roundToScaleOne && Math.abs(this.scale - 1) < 0.01) this.scale = 1
     const new_center = this.convertCanvasToOffset(normalizedCenter)
     const delta_offset = [
       new_center[0] - center[0],

--- a/src/LGraphCanvas.ts
+++ b/src/LGraphCanvas.ts
@@ -2974,17 +2974,19 @@ export class LGraphCanvas {
     ) {
       if (e.ctrlKey && !Number.isInteger(e.deltaY)) {
         scale *= 1 + e.deltaY * (1 - this.zoom_speed) * 0.18
+        this.ds.changeScale(scale, [e.clientX, e.clientY], false)
       } else {
         this.ds.offset[0] -= e.deltaX * 1.18 * (1 / scale)
         this.ds.offset[1] -= e.deltaY * 1.18 * (1 / scale)
       }
-    } else if (delta > 0) {
-      scale *= this.zoom_speed
-    } else if (delta < 0) {
-      scale *= 1 / (this.zoom_speed)
+    } else {
+      if (delta > 0) {
+        scale *= this.zoom_speed
+      } else if (delta < 0) {
+        scale *= 1 / (this.zoom_speed)
+      }
+      this.ds.changeScale(scale, [e.clientX, e.clientY])
     }
-
-    this.ds.changeScale(scale, [e.clientX, e.clientY])
 
     this.graph.change()
 


### PR DESCRIPTION
Fixes issue where pinch to zoom would jitter around scale 1 - D&S rounds the value to exactly 1 when it is "close enough".  Good for pointer, poor UX for precision trackpad.