### PR TITLE
Rename widget _displayValue to resolve conflict

### DIFF
--- a/src/widgets/BaseWidget.ts
+++ b/src/widgets/BaseWidget.ts
@@ -115,7 +115,8 @@ export abstract class BaseWidget<TWidget extends IWidget = IWidget> implements I
     return this.label || this.name
   }
 
-  get displayValue(): string {
+  // TODO: Resolve this workaround. Ref: https://github.com/Comfy-Org/litegraph.js/issues/1022
+  get _displayValue(): string {
     return String(this.value)
   }
 
@@ -171,9 +172,9 @@ export abstract class BaseWidget<TWidget extends IWidget = IWidget> implements I
     const { margin } = BaseWidget
 
     // Measure label and value
-    const { displayName, displayValue } = this
+    const { displayName, _displayValue } = this
     const labelWidth = ctx.measureText(displayName).width
-    const valueWidth = ctx.measureText(displayValue).width
+    const valueWidth = ctx.measureText(_displayValue).width
 
     const gap = BaseWidget.labelValueGap
     const x = margin * 2 + leftPadding
@@ -218,7 +219,7 @@ export abstract class BaseWidget<TWidget extends IWidget = IWidget> implements I
       area.setWidthRightAnchored(cappedValueWidth)
     }
     ctx.fillStyle = this.text_color
-    drawTextInArea({ ctx, text: displayValue, area, align: "right" })
+    drawTextInArea({ ctx, text: _displayValue, area, align: "right" })
   }
 
   /**

--- a/src/widgets/ComboWidget.ts
+++ b/src/widgets/ComboWidget.ts
@@ -22,7 +22,7 @@ function toArray(values: Values): string[] {
 export class ComboWidget extends BaseSteppedWidget<IComboWidget> implements IComboWidget {
   override type = "combo" as const
 
-  override get displayValue() {
+  override get _displayValue() {
     const { values: rawValues } = this.options
     if (rawValues) {
       const values = typeof rawValues === "function" ? rawValues() : rawValues

--- a/src/widgets/NumberWidget.ts
+++ b/src/widgets/NumberWidget.ts
@@ -8,7 +8,7 @@ import { BaseSteppedWidget } from "./BaseSteppedWidget"
 export class NumberWidget extends BaseSteppedWidget<INumericWidget> implements INumericWidget {
   override type = "number" as const
 
-  override get displayValue() {
+  override get _displayValue() {
     return Number(this.value).toFixed(
       this.options.precision !== undefined
         ? this.options.precision


### PR DESCRIPTION
Renames `displayValue` getter to `_displayValue`, to prevent crash on loading VHS nodes.

- Follow-up on Comfy-Org/litegraph.js#1023
- Ref: Comfy-Org/ComfyUI_frontend#4709