### PR TITLE
feat: use number inputs in click dialog for number values

### DIFF
--- a/src/LGraphCanvas.ts
+++ b/src/LGraphCanvas.ts
@@ -6469,22 +6469,18 @@ export class LGraphCanvas {
     options = options || {}
 
     const info = node.getPropertyInfo(property)
-    console.log("property info", info)
     const { type } = info
 
     let input_html = ""
 
     if (
       type == "string" ||
+      type == "number" ||
       type == "array" ||
       type == "object"
     ) {
       input_html = "<input autofocus type='text' class='value'/>"
-    }
-      else if (type == "number") {
-      input_html = "<input autofocus type='number' class='value'/>"
-    }
-      else if ((type == "enum" || type == "combo") && info.values) {
+    } else if ((type == "enum" || type == "combo") && info.values) {
       input_html = "<select autofocus type='text' class='value'>"
       for (const i in info.values) {
         const v = Array.isArray(info.values) ? info.values[i] : i

--- a/src/LGraphCanvas.ts
+++ b/src/LGraphCanvas.ts
@@ -5804,8 +5804,9 @@ export class LGraphCanvas {
       className: "graphdialog rounded",
       innerHTML: multiline
         ? "<span class='name'></span> <textarea autofocus class='value'></textarea><button class='rounded'>OK</button>"
-        : stepValue ? `<span class='name'></span> <input autofocus type='number' step=${stepValue} class='value'/><button class='rounded'>OK</button>`
-                    : "<span class='name'></span> <input autofocus type='text' class='value'/><button class='rounded'>OK</button>",
+        : (stepValue
+          ? `<span class='name'></span> <input autofocus type='number' step=${stepValue} class='value'/><button class='rounded'>OK</button>`
+          : "<span class='name'></span> <input autofocus type='text' class='value'/><button class='rounded'>OK</button>"),
       close() {
         that.prompt_box = null
         if (dialog.parentNode) {
@@ -5883,16 +5884,13 @@ export class LGraphCanvas {
           callback(this.value)
         }
         dialog.close()
-      }
-      else if (e.shiftKey && e.code === "ArrowUp" && e.target instanceof HTMLInputElement && e.target.type === "number") { 
-        e.preventDefault();
-        e.target.stepUp(10);
-      }
-      else if (e.shiftKey && e.code === "ArrowDown" && e.target instanceof HTMLInputElement && e.target.type === "number") {
-        e.preventDefault();
-        e.target.stepDown(10);
-      }
-      else {
+      } else if (e.shiftKey && e.code === "ArrowUp" && e.target instanceof HTMLInputElement && e.target.type === "number") {
+        e.preventDefault()
+        e.target.stepUp(10)
+      } else if (e.shiftKey && e.code === "ArrowDown" && e.target instanceof HTMLInputElement && e.target.type === "number") {
+        e.preventDefault()
+        e.target.stepDown(10)
+      } else {
         return
       }
       e.preventDefault()

--- a/src/LGraphCanvas.ts
+++ b/src/LGraphCanvas.ts
@@ -5871,7 +5871,6 @@ export class LGraphCanvas {
 
     const input = value_element
     input.addEventListener("keydown", function (e: KeyboardEvent) {
-      console.log(e);
       dialog.is_modified = true
       if (e.key == "Escape") {
         // ESC

--- a/src/LGraphCanvas.ts
+++ b/src/LGraphCanvas.ts
@@ -5859,6 +5859,7 @@ export class LGraphCanvas {
 
     const input = value_element
     input.addEventListener("keydown", function (e: KeyboardEvent) {
+      console.log(e);
       dialog.is_modified = true
       if (e.key == "Escape") {
         // ESC
@@ -5871,7 +5872,16 @@ export class LGraphCanvas {
           callback(this.value)
         }
         dialog.close()
-      } else {
+      }
+      else if (e.shiftKey && e.code === "ArrowUp" && e.target instanceof HTMLInputElement && e.target.type === "number") { 
+        e.preventDefault();
+        e.target.stepUp(10);
+      }
+      else if (e.shiftKey && e.code === "ArrowDown" && e.target instanceof HTMLInputElement && e.target.type === "number") {
+        e.preventDefault();
+        e.target.stepDown(10);
+      }
+      else {
         return
       }
       e.preventDefault()

--- a/src/LGraphCanvas.ts
+++ b/src/LGraphCanvas.ts
@@ -32,6 +32,7 @@ import type {
   CanvasPointerEvent,
   CanvasPointerExtensions,
 } from "./types/events"
+import type { PromptOptionalParams } from "./types/optionalParams"
 import type { ClipboardItems } from "./types/serialisation"
 import type { IBaseWidget } from "./types/widgets"
 
@@ -5793,8 +5794,7 @@ export class LGraphCanvas {
     value: any,
     callback: (arg0: any) => void,
     event: CanvasMouseEvent,
-    multiline?: boolean,
-    stepValue?: number,
+    optionalParams?: PromptOptionalParams,
   ): HTMLDivElement {
     const that = this
     title = title || ""
@@ -5802,10 +5802,10 @@ export class LGraphCanvas {
     const customProperties = {
       is_modified: false,
       className: "graphdialog rounded",
-      innerHTML: multiline
+      innerHTML: optionalParams && optionalParams.multiline
         ? "<span class='name'></span> <textarea autofocus class='value'></textarea><button class='rounded'>OK</button>"
-        : (stepValue
-          ? `<span class='name'></span> <input autofocus type='number' step=${stepValue} class='value'/><button class='rounded'>OK</button>`
+        : (optionalParams && optionalParams.stepValue
+          ? `<span class='name'></span> <input autofocus type='number' step=${optionalParams && optionalParams.stepValue} class='value'/><button class='rounded'>OK</button>`
           : "<span class='name'></span> <input autofocus type='text' class='value'/><button class='rounded'>OK</button>"),
       close() {
         that.prompt_box = null

--- a/src/LGraphCanvas.ts
+++ b/src/LGraphCanvas.ts
@@ -5779,6 +5779,7 @@ export class LGraphCanvas {
   prompt(
     title: string,
     value: any,
+    stepValue: number,
     callback: (arg0: any) => void,
     event: CanvasMouseEvent,
     multiline?: boolean,
@@ -5791,7 +5792,8 @@ export class LGraphCanvas {
       className: "graphdialog rounded",
       innerHTML: multiline
         ? "<span class='name'></span> <textarea autofocus class='value'></textarea><button class='rounded'>OK</button>"
-        : "<span class='name'></span> <input autofocus type='text' class='value'/><button class='rounded'>OK</button>",
+        : stepValue ? `<span class='name'></span> <input autofocus type='number' step=${stepValue} class='value'/><button class='rounded'>OK</button>`
+                    : "<span class='name'></span> <input autofocus type='text' class='value'/><button class='rounded'>OK</button>",
       close() {
         that.prompt_box = null
         if (dialog.parentNode) {
@@ -6446,18 +6448,22 @@ export class LGraphCanvas {
     options = options || {}
 
     const info = node.getPropertyInfo(property)
+    console.log("property info", info)
     const { type } = info
 
     let input_html = ""
 
     if (
       type == "string" ||
-      type == "number" ||
       type == "array" ||
       type == "object"
     ) {
       input_html = "<input autofocus type='text' class='value'/>"
-    } else if ((type == "enum" || type == "combo") && info.values) {
+    }
+      else if (type == "number") {
+      input_html = "<input autofocus type='number' class='value'/>"
+    }
+      else if ((type == "enum" || type == "combo") && info.values) {
       input_html = "<select autofocus type='text' class='value'>"
       for (const i in info.values) {
         const v = Array.isArray(info.values) ? info.values[i] : i

--- a/src/LGraphCanvas.ts
+++ b/src/LGraphCanvas.ts
@@ -5779,10 +5779,10 @@ export class LGraphCanvas {
   prompt(
     title: string,
     value: any,
-    stepValue: number,
     callback: (arg0: any) => void,
     event: CanvasMouseEvent,
     multiline?: boolean,
+    stepValue?: number,
   ): HTMLDivElement {
     const that = this
     title = title || ""

--- a/src/types/optionalParams.ts
+++ b/src/types/optionalParams.ts
@@ -1,0 +1,4 @@
+export type PromptOptionalParams = {
+  multiline?: boolean
+  stepValue?: number
+}

--- a/src/widgets/NumberWidget.ts
+++ b/src/widgets/NumberWidget.ts
@@ -64,7 +64,7 @@ export class NumberWidget extends BaseSteppedWidget<INumericWidget> implements I
     }
 
     // Handle center click - show prompt
-    canvas.prompt("Value", this.value, step, (v: string) => {
+    canvas.prompt("Value", this.value, (v: string) => {
       // Check if v is a valid equation or a number
       if (/^[\d\s()*+/-]+|\d+\.\d+$/.test(v)) {
         // Solve the equation if possible
@@ -76,7 +76,7 @@ export class NumberWidget extends BaseSteppedWidget<INumericWidget> implements I
       if (!isNaN(newValue)) {
         this.setValue(newValue, { e, node, canvas })
       }
-    }, e)
+    }, e, false, step)
   }
 
   /**

--- a/src/widgets/NumberWidget.ts
+++ b/src/widgets/NumberWidget.ts
@@ -48,6 +48,7 @@ export class NumberWidget extends BaseSteppedWidget<INumericWidget> implements I
   override onClick({ e, node, canvas }: WidgetEventOptions) {
     const x = e.canvasX - node.pos[0]
     const width = this.width || node.size[0]
+    const step = getWidgetStep(this.options)
 
     // Determine if clicked on left/right arrows
     const delta = x < 40
@@ -63,7 +64,7 @@ export class NumberWidget extends BaseSteppedWidget<INumericWidget> implements I
     }
 
     // Handle center click - show prompt
-    canvas.prompt("Value", this.value, (v: string) => {
+    canvas.prompt("Value", this.value, step, (v: string) => {
       // Check if v is a valid equation or a number
       if (/^[\d\s()*+/-]+|\d+\.\d+$/.test(v)) {
         // Solve the equation if possible

--- a/src/widgets/NumberWidget.ts
+++ b/src/widgets/NumberWidget.ts
@@ -76,7 +76,7 @@ export class NumberWidget extends BaseSteppedWidget<INumericWidget> implements I
       if (!isNaN(newValue)) {
         this.setValue(newValue, { e, node, canvas })
       }
-    }, e, false, step)
+    }, e, { stepValue: step })
   }
 
   /**

--- a/src/widgets/TextWidget.ts
+++ b/src/widgets/TextWidget.ts
@@ -37,7 +37,6 @@ export class TextWidget extends BaseWidget<IStringWidget> implements IStringWidg
     canvas.prompt(
       "Value",
       this.value,
-      0,
       (v: string) => {
         if (v !== null) {
           this.setValue(v, { e, node, canvas })
@@ -45,6 +44,7 @@ export class TextWidget extends BaseWidget<IStringWidget> implements IStringWidg
       },
       e,
       this.options?.multiline ?? false,
+      0,
     )
   }
 }

--- a/src/widgets/TextWidget.ts
+++ b/src/widgets/TextWidget.ts
@@ -43,8 +43,9 @@ export class TextWidget extends BaseWidget<IStringWidget> implements IStringWidg
         }
       },
       e,
-      this.options?.multiline ?? false,
-      0,
+      {
+        multiline: this.options?.multiline ?? false,
+      },
     )
   }
 }

--- a/src/widgets/TextWidget.ts
+++ b/src/widgets/TextWidget.ts
@@ -37,6 +37,7 @@ export class TextWidget extends BaseWidget<IStringWidget> implements IStringWidg
     canvas.prompt(
       "Value",
       this.value,
+      0,
       (v: string) => {
         if (v !== null) {
           this.setValue(v, { e, node, canvas })


### PR DESCRIPTION
This PR makes it possible to use number input tags for number values (making it possible to press up/down to increment/decrement)

By default it uses the step value but it is also possible to press shift+up/shift+down to multiple the change by 10. (eg. step of 1 turns to 10, step of 0.1 turns to 1)

How it works in practice:
![numberinputPR](https://github.com/user-attachments/assets/43dc86b0-02b3-4186-b916-a112dfe11aa9)


This feature needs a PR in the frontend as well: https://github.com/Comfy-Org/ComfyUI_frontend/pull/3926

