### PR TITLE
[CI] Prevent accidental dev publish on latest tag

### DIFF
--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -46,6 +46,7 @@ jobs:
 
   publish:
     runs-on: ubuntu-latest
+    if: inputs.tag != 'latest'
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
- Follow up of #1059

Silently skips publish if attempting to use `latest` as the npm tag; this is reserved for normal release publishes.