### PR TITLE
[chore] Pin third-party GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -34,7 +34,7 @@ jobs:
 
       - name: Create release
         id: create_release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@da05d552573ad5aba039eaac05058a918a7bf631
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Create release
         id: create_release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@da05d552573ad5aba039eaac05058a918a7bf631
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:


### PR DESCRIPTION
Replace version tags with commit SHAs for third-party GitHub Actions to improve security and ensure reproducible builds. This prevents unexpected changes from new releases and protects against potential supply chain attacks.

Updated actions:
- softprops/action-gh-release@v2 -> da05d552573ad5aba039eaac05058a918a7bf631

Actions from trusted organizations (actions/* and Comfy-Org/*) remain using version tags.