### PR TITLE
feat(widgets): Show widget name when connected, hiding only the value

### DIFF
--- a/src/LGraphNode.ts
+++ b/src/LGraphNode.ts
@@ -3410,46 +3410,60 @@ export class LGraphNode implements Positionable, IPinnable, IColorable {
     )
     return !isHidden
   }
-
+  // sync number of widgets with the number of widgets in the node
   drawWidgets(ctx: CanvasRenderingContext2D, {
     lowQuality = false,
     editorAlpha = 1,
   }: DrawWidgetsOptions): void {
     if (!this.widgets) return
-
+  
     const nodeWidth = this.size[0]
     const { widgets } = this
     const H = LiteGraph.NODE_WIDGET_HEIGHT
     const showText = !lowQuality
     ctx.save()
     ctx.globalAlpha = editorAlpha
-
+  
     for (const widget of widgets) {
-      if (!this.isWidgetVisible(widget)) continue
-
-      const { y } = widget
-      const outlineColour = widget.advanced ? LiteGraph.WIDGET_ADVANCED_OUTLINE_COLOR : LiteGraph.WIDGET_OUTLINE_COLOR
-
-      widget.last_y = y
-      // Disable widget if it is disabled or if the value is passed from socket connection.
-      widget.computedDisabled = widget.disabled || this.getSlotFromWidget(widget)?.link != null
-
-      ctx.strokeStyle = outlineColour
-      ctx.fillStyle = "#222"
-      ctx.textAlign = "left"
-      if (widget.computedDisabled) ctx.globalAlpha *= 0.5
-      const width = widget.width || nodeWidth
-
+      if (!this.isWidgetVisible(widget)) continue;
+    
+      const { y } = widget;
+      const outlineColour = widget.advanced
+        ? LiteGraph.WIDGET_ADVANCED_OUTLINE_COLOR
+        : LiteGraph.WIDGET_OUTLINE_COLOR;
+    
+      widget.last_y = y;
+    
+      // 判断是否锁定：被禁用或有输入连接
+      const connectedSlot = this.getSlotFromWidget(widget);
+      widget.computedDisabled = widget.disabled || connectedSlot?.link != null;
+      (widget as any).hideValue = connectedSlot?.link != null;
+    
+      ctx.strokeStyle = outlineColour;
+      ctx.fillStyle = "#222";
+      ctx.textAlign = "left";
+    
+      if (widget.computedDisabled) ctx.globalAlpha *= 0.5;
+      const width = widget.width || nodeWidth;
+    
+      const forceHideValue = (widget as any).hideValue;
+    
       if (typeof widget.draw === "function") {
-        widget.draw(ctx, this, width, y, H, lowQuality)
+        widget.draw(ctx, this, width, y, H, lowQuality);
       } else {
-        toConcreteWidget(widget, this, false)?.drawWidget(ctx, { width, showText })
+        toConcreteWidget(widget, this, false)?.drawWidget(ctx, {
+          width,
+          showText: !forceHideValue,
+        });
       }
-      ctx.globalAlpha = editorAlpha
+    
+      ctx.globalAlpha = editorAlpha;
     }
+    
+  
     ctx.restore()
   }
-
+  
   /**
    * When {@link LGraphNode.collapsed} is `true`, this method draws the node's collapsed slots.
    */
@@ -3720,4 +3734,6 @@ export class LGraphNode implements Positionable, IPinnable, IColorable {
     )
     ctx.fillStyle = originalFillStyle
   }
+
+
 }

--- a/src/widgets/BaseSteppedWidget.ts
+++ b/src/widgets/BaseSteppedWidget.ts
@@ -1,5 +1,7 @@
 import type { IBaseWidget } from "@/types/widgets"
 
+import { drawTextInArea } from "@/draw"
+import { Rectangle } from "@/infrastructure/Rectangle"
 import { BaseWidget, type DrawWidgetOptions, type WidgetEventOptions } from "./BaseWidget"
 
 /**
@@ -64,6 +66,19 @@ export abstract class BaseSteppedWidget<TWidget extends IBaseWidget = IBaseWidge
       if (!this.computedDisabled) this.drawArrowButtons(ctx, options.width)
 
       this.drawTruncatingText({ ctx, width: options.width })
+    }
+    else {
+      // Just draw the name, truncated
+      const { margin } = BaseWidget
+      const x = margin * 2
+      const area = new Rectangle(x, this.y, options.width - x - margin, this.height * 0.7)
+      ctx.fillStyle = this.secondary_text_color
+      drawTextInArea({
+        ctx,
+        text: this.displayName,
+        area,
+        align: "left",
+      })
     }
 
     // Restore original context attributes

--- a/src/widgets/TextWidget.ts
+++ b/src/widgets/TextWidget.ts
@@ -1,6 +1,8 @@
 import type { LGraphNode } from "@/LGraphNode"
 import type { IStringWidget } from "@/types/widgets"
 
+import { drawTextInArea } from "@/draw"
+import { Rectangle } from "@/infrastructure/Rectangle"
 import { BaseWidget, type DrawWidgetOptions, type WidgetEventOptions } from "./BaseWidget"
 
 export class TextWidget extends BaseWidget<IStringWidget> implements IStringWidget {
@@ -26,6 +28,19 @@ export class TextWidget extends BaseWidget<IStringWidget> implements IStringWidg
 
     if (showText) {
       this.drawTruncatingText({ ctx, width, leftPadding: 0, rightPadding: 0 })
+    }
+    else {
+      // Just draw the name, truncated
+      const { margin } = BaseWidget
+      const x = margin * 2
+      const area = new Rectangle(x, this.y, width - x - margin, this.height * 0.7)
+      ctx.fillStyle = this.secondary_text_color
+      drawTextInArea({
+        ctx,
+        text: this.displayName,
+        area,
+        align: "left",
+      })
     }
 
     // Restore original context attributes


### PR DESCRIPTION
Related to Comfy-Org/ComfyUI_frontend#4025

Previously, when a widget was connected to an input link, the entire widget's text (name and value) would disappear. This made it difficult to identify the widget's function at a glance.

This commit modifies the drawing behavior to:
- Only hide the widget's value when it has an active input connection.
- Continue to display the widget's name/label.

This improves user experience by providing better visual context for connected widgets.

Refactor:
- Introduced a \hideValue\ property in \LGraphNode.drawWidgets\ to decouple value visibility from the widget's disabled state.
- Updated \BaseSteppedWidget\ and \TextWidget\ to render only the \displayName\ when the value is hidden.