### PR TITLE
Removed code causing race condition

### DIFF
--- a/src/CanvasPointer.ts
+++ b/src/CanvasPointer.ts
@@ -156,12 +156,6 @@ export class CanvasPointer {
     const { eDown } = this
     if (!eDown) return
 
-    // No buttons down, but eDown exists - clean up & leave
-    if (!e.buttons) {
-      this.reset()
-      return
-    }
-
     // Primary button released - treat as pointerup.
     if (!(e.buttons & eDown.buttons)) {
       this.#completeClick(e)


### PR DESCRIPTION
There is an issue with litegraph where clicking and dragging sometimes doesn't do the thing the user set in "Action on link release" in the settings. The cause is that the onDragEnd event handler is deleted in CanvasPointer.reset function. The reset function was called when a mousemove event is fired with no buttons held down, before the mouseUp event is fired. Since there is no guaranteed ordering of mousemove vs mouseup events, this creates a race condition. If mouseup fired before mousemove, then the correct action would happen. But if mousemove fired before mouseup, then it would reset instead.

The code right below what this PR deleted correctly handles all the cases. Unfortunately, the code would never run, because the condition on top would never allow it to run.