### PR TITLE
[Test] Fix circular test imports in CI

### DIFF
--- a/src/litegraph.ts
+++ b/src/litegraph.ts
@@ -89,6 +89,7 @@ export interface LGraphNodeConstructor<T extends LGraphNode = LGraphNode> {
 // End backwards compat
 
 export { InputIndicators } from "./canvas/InputIndicators"
+export { LinkConnector } from "./canvas/LinkConnector"
 export { isOverNodeInput, isOverNodeOutput } from "./canvas/measureSlots"
 export { CanvasPointer } from "./CanvasPointer"
 export * as Constants from "./constants"

--- a/test/LinkConnector.integration.test.ts
+++ b/test/LinkConnector.integration.test.ts
@@ -2,8 +2,8 @@ import type { CanvasPointerEvent } from "@/types/events"
 
 import { afterEach, describe, expect, vi } from "vitest"
 
-import { LinkConnector } from "@/canvas/LinkConnector"
 import { LGraph, LGraphNode, LLink, Reroute, type RerouteId } from "@/litegraph"
+import { LinkConnector } from "@/litegraph"
 
 import { test as baseTest } from "./testExtensions"
 

--- a/test/canvas/LinkConnector.test.ts
+++ b/test/canvas/LinkConnector.test.ts
@@ -3,7 +3,7 @@ import type { INodeInputSlot, LGraphNode } from "@/litegraph"
 import { beforeEach, describe, expect, test, vi } from "vitest"
 
 // We don't strictly need RenderLink interface import for the mock
-import { LinkConnector } from "@/canvas/LinkConnector"
+import { LinkConnector } from "@/litegraph"
 
 // Mocks
 const mockSetConnectingLinks = vi.fn()


### PR DESCRIPTION
Fixes broken unit tests from import order changes.

Exports LinkConnector directly at module level.