### PR TITLE
Fix control + mouse-wheel zoom in trackpad mode

### DIFF
--- a/src/LGraphCanvas.ts
+++ b/src/LGraphCanvas.ts
@@ -3182,7 +3182,7 @@ export class LGraphCanvas implements CustomEventDispatcher<LGraphCanvasEventMap>
       LiteGraph.macTrackpadGestures &&
       (!LiteGraph.macGesturesRequireMac || navigator.userAgent.includes("Mac"))
     ) {
-      if (e.ctrlKey && !Number.isInteger(e.deltaY)) {
+      if (e.ctrlKey) {
         scale *= 1 + e.deltaY * (1 - this.zoom_speed) * 0.18
         this.ds.changeScale(scale, [e.clientX, e.clientY], false)
       } else {


### PR DESCRIPTION
Holding control when using the mouse will always zoom.  Zoom speed is still *impractical* for most wheel devices in trackpad mode, however the code removed is redundant.