### PR TITLE
[CI] Fix prerelease version tag not set

### DIFF
--- a/.github/workflows/release-version.yml
+++ b/.github/workflows/release-version.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Bump version
         id: bump-version
         run: |
-          npm version ${{ github.event.inputs.version_type }} --no-git-tag-version
+          npm version ${{ github.event.inputs.version_type }} --preid ${{ github.event.inputs.pre_release }} --no-git-tag-version
           NEW_VERSION=$(node -p "require('./package.json').version")
           echo "NEW_VERSION=$NEW_VERSION" >> $GITHUB_OUTPUT
 


### PR DESCRIPTION
Prerelease versions ignored the identifier field, e.g.:

1.24.0-0

instead of

1.24.0-beta.0