### PR TITLE
Widget promotion

### DIFF
--- a/src/LGraphNode.ts
+++ b/src/LGraphNode.ts
@@ -689,6 +689,9 @@ export class LGraphNode implements NodeLike, Positionable, IPinnable, IColorable
     }
   }
 
+  /** Internal callback for subgraph nodes. Do not implement externally. */
+  _internalConfigureAfterSlots?(): void
+
   /**
    * configure a node from an object containing the serialized info
    */
@@ -753,6 +756,9 @@ export class LGraphNode implements NodeLike, Positionable, IPinnable, IColorable
       }
       this.onOutputAdded?.(output)
     }
+
+    // SubgraphNode callback.
+    this._internalConfigureAfterSlots?.()
 
     if (this.widgets) {
       for (const w of this.widgets) {
@@ -1786,6 +1792,11 @@ export class LGraphNode implements NodeLike, Positionable, IPinnable, IColorable
     const widget = toConcreteWidget(custom_widget, this, false) ?? custom_widget
     this.widgets.push(widget)
     return widget
+  }
+
+  removeWidgetByName(name: string): void {
+    const widget = this.widgets?.find(x => x.name === name)
+    if (widget) this.removeWidget(widget)
   }
 
   removeWidget(widget: IBaseWidget): void {

--- a/src/LLink.ts
+++ b/src/LLink.ts
@@ -13,6 +13,8 @@ import type { Serialisable, SerialisableLLink, SubgraphIO } from "./types/serial
 
 import { SUBGRAPH_INPUT_ID, SUBGRAPH_OUTPUT_ID } from "@/constants"
 
+import { Subgraph } from "./litegraph"
+
 export type LinkId = number
 
 export type SerialisedLLinkArray = [
@@ -405,6 +407,13 @@ export class LLink implements LinkSegment, Serialisable<SerialisableLLink> {
       }
     }
     network.links.delete(this.id)
+
+    if (this.originIsIoNode && network instanceof Subgraph) {
+      const subgraphInput = network.inputs.at(this.origin_slot)
+      if (!subgraphInput) throw new Error("Invalid link - subgraph input not found")
+
+      subgraphInput.events.dispatch("input-disconnected", { input: subgraphInput })
+    }
   }
 
   /**

--- a/src/infrastructure/SubgraphInputEventMap.ts
+++ b/src/infrastructure/SubgraphInputEventMap.ts
@@ -1,0 +1,15 @@
+import type { LGraphEventMap } from "./LGraphEventMap"
+import type { INodeInputSlot } from "@/litegraph"
+import type { SubgraphInput } from "@/subgraph/SubgraphInput"
+import type { IBaseWidget } from "@/types/widgets"
+
+export interface SubgraphInputEventMap extends LGraphEventMap {
+  "input-connected": {
+    input: INodeInputSlot
+    widget: IBaseWidget
+  }
+
+  "input-disconnected": {
+    input: SubgraphInput
+  }
+}

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -2,10 +2,10 @@ import type { ContextMenu } from "./ContextMenu"
 import type { LGraphNode, NodeId } from "./LGraphNode"
 import type { LinkId, LLink } from "./LLink"
 import type { Reroute, RerouteId } from "./Reroute"
-import type { SubgraphInput } from "./subgraph/SubgraphInput"
 import type { SubgraphInputNode } from "./subgraph/SubgraphInputNode"
 import type { SubgraphOutputNode } from "./subgraph/SubgraphOutputNode"
 import type { LinkDirection, RenderShape } from "./types/globalEnums"
+import type { IBaseWidget } from "./types/widgets"
 import type { Rectangle } from "@/infrastructure/Rectangle"
 import type { CanvasPointerEvent } from "@/types/events"
 
@@ -347,6 +347,11 @@ export interface IWidgetLocator {
 export interface INodeInputSlot extends INodeSlot {
   link: LinkId | null
   widget?: IWidgetLocator
+
+  /**
+   * Internal use only; API is not finalised and may change at any time.
+   */
+  _widget?: IBaseWidget
 }
 
 export interface IWidgetInputSlot extends INodeInputSlot {
@@ -436,7 +441,7 @@ export interface DefaultConnectionColors {
 }
 
 export interface ISubgraphInput extends INodeInputSlot {
-  _subgraphSlot: SubgraphInput
+  _listenerController?: AbortController
 }
 
 /**

--- a/src/node/NodeInputSlot.ts
+++ b/src/node/NodeInputSlot.ts
@@ -1,6 +1,7 @@
 import type { INodeInputSlot, INodeOutputSlot, OptionalProps, ReadOnlyPoint } from "@/interfaces"
 import type { LGraphNode } from "@/LGraphNode"
 import type { LinkId } from "@/LLink"
+import type { IBaseWidget } from "@/types/widgets"
 
 import { LabelPosition } from "@/draw"
 import { LiteGraph } from "@/litegraph"
@@ -11,6 +12,17 @@ export class NodeInputSlot extends NodeSlot implements INodeInputSlot {
 
   get isWidgetInputSlot(): boolean {
     return !!this.widget
+  }
+
+  #widget: WeakRef<IBaseWidget> | undefined
+
+  /** Internal use only; API is not finalised and may change at any time. */
+  get _widget(): IBaseWidget | undefined {
+    return this.#widget?.deref()
+  }
+
+  set _widget(widget: IBaseWidget | undefined) {
+    this.#widget = widget ? new WeakRef(widget) : undefined
   }
 
   get collapsedPos(): ReadOnlyPoint {

--- a/src/subgraph/Subgraph.ts
+++ b/src/subgraph/Subgraph.ts
@@ -68,7 +68,9 @@ export class Subgraph extends LGraph implements BaseLGraph, Serialisable<Exporte
     if (inputs) {
       this.inputs.length = 0
       for (const input of inputs) {
-        this.inputs.push(new SubgraphInput(input, this.inputNode))
+        const subgraphInput = new SubgraphInput(input, this.inputNode)
+        this.inputs.push(subgraphInput)
+        this.events.dispatch("input-added", { input: subgraphInput })
       }
     }
 

--- a/src/widgets/BaseWidget.ts
+++ b/src/widgets/BaseWidget.ts
@@ -282,4 +282,19 @@ export abstract class BaseWidget<TWidget extends IBaseWidget = IBaseWidget> impl
     node.onWidgetChanged?.(this.name ?? "", v, oldValue, this)
     if (node.graph) node.graph._version++
   }
+
+  /**
+   * Clones the widget.
+   * @param node The node that will own the cloned widget.
+   * @returns A new widget with the same properties as the original
+   * @remarks Subclasses with custom constructors must override this method.
+   *
+   * Correctly and safely typing this is currently not possible (practical?) in TypeScript 5.8.
+   */
+  createCopyForNode(node: LGraphNode): this {
+    // @ts-expect-error
+    const cloned: this = new (this.constructor as typeof this)(this, node)
+    cloned.value = this.value
+    return cloned
+  }
 }


### PR DESCRIPTION
- Automatically promotes widgets from inside a Subgraph, through the IO nodes, to show on SubgraphNode instances in the parent graph
- Prevents connection of slots with different restrictions
- Automatic clean up