### PR TITLE
Add fallback for virtual nodes that redirect links

### DIFF
--- a/src/subgraph/ExecutableNodeDTO.ts
+++ b/src/subgraph/ExecutableNodeDTO.ts
@@ -194,6 +194,17 @@ export class ExecutableNodeDTO implements ExecutableLGraphNode {
     if (node.isVirtualNode) {
       if (this.inputs.at(slot)) return this.resolveInput(slot, visited)
 
+      // Fallback check for nodes performing link redirection
+      const virtualLink = this.node.getInputLink(slot)
+      if (virtualLink) {
+        const outputNode = this.graph.getNodeById(virtualLink.origin_id)
+        if (!outputNode) throw new InvalidLinkError(`Virtual node failed to resolve parent [${this.id}] slot [${slot}]`)
+
+        const outputNodeDto = new ExecutableNodeDTO(outputNode, this.subgraphNodePath, this.subgraphNode)
+
+        return outputNodeDto.resolveOutput(virtualLink.origin_slot, type, visited)
+      }
+
       // Virtual nodes without a matching input should be discarded.
       return
     }


### PR DESCRIPTION
KJNodes provides Get and Set nodes that overload getInputLink to to designate the calculated link source.

If the existing check (which simply returns a corresponding input link by slotid) fails, a call to node.getInputLink is attempted. If there are other virtual nodes that were broken by the subgraph implementation (such a switch that has multiple input links, but resolves to only one), this fallback may need to instead replace the existing check.