### PR TITLE
Fix a bug that prevented subgraph reuse

### DIFF
--- a/src/subgraph/SubgraphNode.ts
+++ b/src/subgraph/SubgraphNode.ts
@@ -278,7 +278,7 @@ export class SubgraphNode extends LGraphNode implements BaseLGraph {
     /** The list of nodes to add to. */
     nodes: ExecutableLGraphNode[] = [],
     /** The set of visited nodes. */
-    visited = new WeakSet<SubgraphNode>(),
+    visited = new Set<SubgraphNode>(),
     /** The path of subgraph node IDs. */
     subgraphNodePath: readonly NodeId[] = [],
   ): ExecutableLGraphNode[] {
@@ -289,7 +289,7 @@ export class SubgraphNode extends LGraphNode implements BaseLGraph {
 
     for (const node of this.subgraph.nodes) {
       if ("getInnerNodes" in node) {
-        node.getInnerNodes(nodes, visited, subgraphInstanceIdPath)
+        node.getInnerNodes(nodes, new Set(visited), subgraphInstanceIdPath)
       } else {
         // Create minimal DTOs rather than cloning the node
         const aVeryRealNode = new ExecutableNodeDTO(node, subgraphInstanceIdPath, this)


### PR DESCRIPTION
There was a chance of encountering a false "RecursionError" when you had one subgraph used multiple times within another subgraph.

An example workflow where this was broken is attached to this PR.

[RecursionBug.json](https://github.com/user-attachments/files/21047788/RecursionBug.json)
