### PR TITLE
Add canvasNavigationMode for changing left click pan behaviour

### DIFF
--- a/src/LGraphCanvas.ts
+++ b/src/LGraphCanvas.ts
@@ -3188,7 +3188,14 @@ export class LGraphCanvas implements CustomEventDispatcher<LGraphCanvasEventMap>
 
     let { scale } = this.ds
 
-    if (
+    if (LiteGraph.canvasNavigationMode === "legacy" || (LiteGraph.canvasNavigationMode === "standard" && e.ctrlKey)) {
+      if (delta > 0) {
+        scale *= this.zoom_speed
+      } else if (delta < 0) {
+        scale *= 1 / (this.zoom_speed)
+      }
+      this.ds.changeScale(scale, [e.clientX, e.clientY])
+    } else if (
       LiteGraph.macTrackpadGestures &&
       (!LiteGraph.macGesturesRequireMac || navigator.userAgent.includes("Mac"))
     ) {
@@ -3206,13 +3213,6 @@ export class LGraphCanvas implements CustomEventDispatcher<LGraphCanvasEventMap>
         this.ds.offset[0] -= e.deltaX * 1.18 * (1 / scale)
         this.ds.offset[1] -= e.deltaY * 1.18 * (1 / scale)
       }
-    } else {
-      if (delta > 0) {
-        scale *= this.zoom_speed
-      } else if (delta < 0) {
-        scale *= 1 / (this.zoom_speed)
-      }
-      this.ds.changeScale(scale, [e.clientX, e.clientY])
     }
 
     this.graph.change()

--- a/src/LGraphCanvas.ts
+++ b/src/LGraphCanvas.ts
@@ -2302,12 +2302,12 @@ export class LGraphCanvas implements CustomEventDispatcher<LGraphCanvasEventMap>
         pointer.finally = () => this.dragging_canvas = false
         this.dragging_canvas = true
       } else {
-        this.#setupNodeSelectionDrag(e, pointer, undefined)
+        this.#setupNodeSelectionDrag(e, pointer)
       }
     }
   }
 
-  #setupNodeSelectionDrag(e: CanvasPointerEvent, pointer: CanvasPointer, node: LGraphNode | undefined): void {
+  #setupNodeSelectionDrag(e: CanvasPointerEvent, pointer: CanvasPointer, node?: LGraphNode | undefined): void {
     const dragRect = new Float32Array(4)
 
     dragRect[0] = e.canvasX

--- a/src/LGraphCanvas.ts
+++ b/src/LGraphCanvas.ts
@@ -2288,16 +2288,14 @@ export class LGraphCanvas implements CustomEventDispatcher<LGraphCanvasEventMap>
       }
     }
 
-    // allow dragging canvas if canvas is not in standard, or read-only (pan mode in standard)
-    const allowDraggingCanvasOnStandardMode = LiteGraph.canvasNavigationMode !== "standard" || this.read_only
-
     if (
       !pointer.onDragStart &&
       !pointer.onClick &&
       !pointer.onDrag &&
       this.allow_dragcanvas
     ) {
-      if (allowDraggingCanvasOnStandardMode) {
+      // allow dragging canvas if canvas is not in standard, or read-only (pan mode in standard)
+      if (LiteGraph.canvasNavigationMode !== "standard" || this.read_only) {
         pointer.onClick = () => this.processSelect(null, e)
         pointer.finally = () => this.dragging_canvas = false
         this.dragging_canvas = true

--- a/src/LiteGraphGlobal.ts
+++ b/src/LiteGraphGlobal.ts
@@ -296,6 +296,13 @@ export class LiteGraphGlobal {
   macGesturesRequireMac: boolean = true
 
   /**
+   * "standard": change the dragging on left mouse button click to select, enable middle-click or spacebar+left-click dragging
+   * "legacy": Enable dragging on left-click (original behavior)
+   * @default "legacy"
+   */
+  canvasNavigationMode: "standard" | "legacy" = "legacy"
+
+  /**
    * If `true`, widget labels and values will both be truncated (proportionally to size),
    * until they fit within the widget.
    *

--- a/test/__snapshots__/litegraph.test.ts.snap
+++ b/test/__snapshots__/litegraph.test.ts.snap
@@ -151,6 +151,7 @@ LiteGraphGlobal {
   "alwaysRepeatWarnings": false,
   "alwaysSnapToGrid": undefined,
   "auto_load_slot_types": false,
+  "canvasNavigationMode": "legacy",
   "catch_exceptions": true,
   "click_do_break_link_to": false,
   "context_menu_scaling": false,


### PR DESCRIPTION
Feature required in ComfyUI Project V3 https://www.notion.so/drip-art/Standardize-Canvas-Navigation-2166d73d365080c9b84ad3f7b3b265bc?d=21f6d73d3650805eb3d2001ca7e88ed6#2176d73d3650802a9457dc2affe798e0
And it will be used in ComfyUI Frontend PR here.

it will have two mode: standard and legacy.

On standard mode (this is new), we will disable dragging canvas by mouse left click pan, and move canvas will be allowed by mouse middle button or spacebar+left-click

