### PR TITLE
Hide widget values when computedDisabled is true

### DIFF
--- a/src/widgets/BaseWidget.ts
+++ b/src/widgets/BaseWidget.ts
@@ -142,7 +142,7 @@ export abstract class BaseWidget<TWidget extends IBaseWidget = IBaseWidget> impl
 
   // TODO: Resolve this workaround. Ref: https://github.com/Comfy-Org/litegraph.js/issues/1022
   get _displayValue(): string {
-    return String(this.value)
+    return this.computedDisabled ? "" : String(this.value)
   }
 
   get labelBaseline() {

--- a/src/widgets/ComboWidget.ts
+++ b/src/widgets/ComboWidget.ts
@@ -23,6 +23,7 @@ export class ComboWidget extends BaseSteppedWidget<IStringComboWidget | IComboWi
   override type = "combo" as const
 
   override get _displayValue() {
+    if (this.computedDisabled) return ""
     const { values: rawValues } = this.options
     if (rawValues) {
       const values = typeof rawValues === "function" ? rawValues() : rawValues

--- a/src/widgets/NumberWidget.ts
+++ b/src/widgets/NumberWidget.ts
@@ -9,6 +9,7 @@ export class NumberWidget extends BaseSteppedWidget<INumericWidget> implements I
   override type = "number" as const
 
   override get _displayValue() {
+    if (this.computedDisabled) return ""
     return Number(this.value).toFixed(
       this.options.precision !== undefined
         ? this.options.precision


### PR DESCRIPTION
Modifies widgets using the new truncated text logic (number, combo, text) to display no value when their input slot is connected to a link.

This removes confusion around the actual value.  In the future, we can update the value if available via connected wiget, or the result of execution.