### PR TITLE
Always create cloned, separate subgraph definintions

### DIFF
--- a/src/subgraph/Subgraph.ts
+++ b/src/subgraph/Subgraph.ts
@@ -211,8 +211,17 @@ export class Subgraph extends LGraph implements BaseLGraph, Serialisable<Exporte
     this.outputNode.draw(ctx, colorContext)
   }
 
-  clone(): Subgraph {
-    return new Subgraph(this.rootGraph, this.asSerialisable())
+  /**
+   * Clones the subgraph, creating an identical copy with a new ID.
+   * @returns A new subgraph with the same configuration, but a new ID.
+   */
+  clone(keepId: boolean = false): Subgraph {
+    const exported = this.asSerialisable()
+    if (!keepId) exported.id = createUuidv4()
+
+    const subgraph = new Subgraph(this.rootGraph, exported)
+    subgraph.configure(exported)
+    return subgraph
   }
 
   override asSerialisable(): ExportedSubgraph & Required<Pick<SerialisableGraph, "nodes" | "groups" | "extra">> {

--- a/src/types/serialisation.ts
+++ b/src/types/serialisation.ts
@@ -180,6 +180,7 @@ export interface ClipboardItems {
   groups?: ISerialisedGroup[]
   reroutes?: SerialisableReroute[]
   links?: SerialisableLLink[]
+  subgraphs?: ExportedSubgraph[]
 }
 
 /** @deprecated */


### PR DESCRIPTION
- Always clones entire subgraphs when copying subgraph nodes.
- Always clones subgraphs when alt-dragging subgraph nodes.

Linked subgraphs will be unavailable in the initial launch, with the plan to add the functionality later.