### PR TITLE
[fix] Handle missing _listenerController.abort when loading workflows

### DIFF
--- a/src/subgraph/SubgraphNode.ts
+++ b/src/subgraph/SubgraphNode.ts
@@ -95,7 +95,9 @@ export class SubgraphNode extends LGraphNode implements BaseLGraph {
   }
 
   #addSubgraphInputListeners(subgraphInput: SubgraphInput, input: INodeInputSlot & Partial<ISubgraphInput>) {
-    input._listenerController?.abort()
+    if (input._listenerController && typeof input._listenerController.abort === "function") {
+      input._listenerController.abort()
+    }
     input._listenerController = new AbortController()
     const { signal } = input._listenerController
 
@@ -131,7 +133,9 @@ export class SubgraphNode extends LGraphNode implements BaseLGraph {
 
   override configure(info: ExportedSubgraphInstance): void {
     for (const input of this.inputs) {
-      input._listenerController?.abort()
+      if (input._listenerController && typeof input._listenerController.abort === "function") {
+        input._listenerController.abort()
+      }
     }
 
     this.inputs.length = 0
@@ -309,7 +313,9 @@ export class SubgraphNode extends LGraphNode implements BaseLGraph {
 
   override onRemoved(): void {
     for (const input of this.inputs) {
-      input._listenerController?.abort()
+      if (input._listenerController && typeof input._listenerController.abort === "function") {
+        input._listenerController.abort()
+      }
     }
   }
 }


### PR DESCRIPTION
Fixes #1130

## Description
When loading workflows with promoted widgets, a TypeError occurs because `_listenerController` is not properly initialized on deserialized input slots.

## Changes
- Add proper type checking before calling `abort()` on `_listenerController`
- Applied in 3 locations: `#addSubgraphInputListeners`, `configure`, and `onRemoved`

## Testing
- Load a workflow with promoted DOM widgets
- Verify no TypeError occurs
- Verify event listeners are still properly cleaned up when needed