### PR TITLE
Revert "[fix] Handle missing _listenerController.abort when loading workflows"

### DIFF
--- a/src/subgraph/SubgraphNode.ts
+++ b/src/subgraph/SubgraphNode.ts
@@ -95,9 +95,7 @@ export class SubgraphNode extends LGraphNode implements BaseLGraph {
   }
 
   #addSubgraphInputListeners(subgraphInput: SubgraphInput, input: INodeInputSlot & Partial<ISubgraphInput>) {
-    if (input._listenerController && typeof input._listenerController.abort === "function") {
-      input._listenerController.abort()
-    }
+    input._listenerController?.abort()
     input._listenerController = new AbortController()
     const { signal } = input._listenerController
 
@@ -133,9 +131,7 @@ export class SubgraphNode extends LGraphNode implements BaseLGraph {
 
   override configure(info: ExportedSubgraphInstance): void {
     for (const input of this.inputs) {
-      if (input._listenerController && typeof input._listenerController.abort === "function") {
-        input._listenerController.abort()
-      }
+      input._listenerController?.abort()
     }
 
     this.inputs.length = 0
@@ -313,9 +309,7 @@ export class SubgraphNode extends LGraphNode implements BaseLGraph {
 
   override onRemoved(): void {
     for (const input of this.inputs) {
-      if (input._listenerController && typeof input._listenerController.abort === "function") {
-        input._listenerController.abort()
-      }
+      input._listenerController?.abort()
     }
   }
 }


### PR DESCRIPTION
Reverts Comfy-Org/litegraph.js#1134

Reverting workaround; will fix cause.