### PR TITLE
[fix] Change parentSubgraphNode type to NodeLike

### DIFF
--- a/src/types/widgets.ts
+++ b/src/types/widgets.ts
@@ -1,6 +1,7 @@
 import type { CanvasColour, Point, RequiredProps, Size } from "../interfaces"
 import type { CanvasPointer, LGraphCanvas, LGraphNode } from "../litegraph"
 import type { CanvasPointerEvent } from "./events"
+import type { NodeLike } from "./NodeLike"
 
 export interface IWidgetOptions<TValues = unknown[]> {
   on?: string
@@ -204,8 +205,10 @@ export interface IBaseWidget<
   /**
    * Reference to the subgraph container node when this widget is promoted from a subgraph.
    * This allows the widget to know which SubgraphNode it belongs to in the parent graph.
+   * @remarks This property is a runtime reference and should not be serialized.
+   * It will be undefined after deserialization and needs to be reconstructed.
    */
-  parentSubgraphNode?: LGraphNode
+  parentSubgraphNode?: NodeLike
 
   // TODO: Confirm this format
   callback?(

--- a/src/widgets/BaseWidget.ts
+++ b/src/widgets/BaseWidget.ts
@@ -1,6 +1,7 @@
 import type { Point } from "@/interfaces"
 import type { CanvasPointer, LGraphCanvas, LGraphNode, Size } from "@/litegraph"
 import type { CanvasPointerEvent } from "@/types/events"
+import type { NodeLike } from "@/types/NodeLike"
 import type { IBaseWidget } from "@/types/widgets"
 
 import { drawTextInArea } from "@/draw"
@@ -60,7 +61,7 @@ export abstract class BaseWidget<TWidget extends IBaseWidget = IBaseWidget> impl
    * Reference to the subgraph container node when this widget is promoted from a subgraph.
    * This allows the widget to know which SubgraphNode it belongs to in the parent graph.
    */
-  parentSubgraphNode?: LGraphNode
+  parentSubgraphNode?: NodeLike
 
   linkedWidgets?: IBaseWidget[]
   name: string


### PR DESCRIPTION
## Summary

The `parentSubgraphNode` property on widgets was typed as `LGraphNode`, which has private fields (`#concreteInputs`, `#concreteOutputs`). This caused TypeScript compilation failures in downstream projects when plain objects (without these private fields) were assigned to this property during deserialization.

This PR changes the type to `NodeLike` interface, which represents the shape of a node without requiring the private fields, allowing both actual `LGraphNode` instances and plain objects to be assigned without type errors.