### PR TITLE
[refactor] Remove parentSubgraphNode property from widgets

### DIFF
--- a/src/subgraph/SubgraphNode.ts
+++ b/src/subgraph/SubgraphNode.ts
@@ -190,9 +190,6 @@ export class SubgraphNode extends LGraphNode implements BaseLGraph {
     // Use the first matching widget
     const promotedWidget = toConcreteWidget(widget, this).createCopyForNode(this)
 
-    // Set parentSubgraphNode for all promoted widgets to track their origin
-    promotedWidget.parentSubgraphNode = this
-
     Object.assign(promotedWidget, {
       get name() {
         return subgraphInput.name
@@ -332,7 +329,6 @@ export class SubgraphNode extends LGraphNode implements BaseLGraph {
   override onRemoved(): void {
     // Clean up all promoted widgets
     for (const widget of this.widgets) {
-      widget.parentSubgraphNode = undefined
       this.subgraph.events.dispatch("widget-demoted", { widget, subgraphNode: this })
     }
 

--- a/src/types/widgets.ts
+++ b/src/types/widgets.ts
@@ -1,7 +1,6 @@
 import type { CanvasColour, Point, RequiredProps, Size } from "../interfaces"
 import type { CanvasPointer, LGraphCanvas, LGraphNode } from "../litegraph"
 import type { CanvasPointerEvent } from "./events"
-import type { NodeLike } from "./NodeLike"
 
 export interface IWidgetOptions<TValues = unknown[]> {
   on?: string
@@ -201,14 +200,6 @@ export interface IBaseWidget<
   advanced?: boolean
 
   tooltip?: string
-
-  /**
-   * Reference to the subgraph container node when this widget is promoted from a subgraph.
-   * This allows the widget to know which SubgraphNode it belongs to in the parent graph.
-   * @remarks This property is a runtime reference and should not be serialized.
-   * It will be undefined after deserialization and needs to be reconstructed.
-   */
-  parentSubgraphNode?: NodeLike
 
   // TODO: Confirm this format
   callback?(

--- a/src/widgets/BaseWidget.ts
+++ b/src/widgets/BaseWidget.ts
@@ -1,7 +1,6 @@
 import type { Point } from "@/interfaces"
 import type { CanvasPointer, LGraphCanvas, LGraphNode, Size } from "@/litegraph"
 import type { CanvasPointerEvent } from "@/types/events"
-import type { NodeLike } from "@/types/NodeLike"
 import type { IBaseWidget } from "@/types/widgets"
 
 import { drawTextInArea } from "@/draw"
@@ -56,12 +55,6 @@ export abstract class BaseWidget<TWidget extends IBaseWidget = IBaseWidget> impl
   get node() {
     return this.#node
   }
-
-  /**
-   * Reference to the subgraph container node when this widget is promoted from a subgraph.
-   * This allows the widget to know which SubgraphNode it belongs to in the parent graph.
-   */
-  parentSubgraphNode?: NodeLike
 
   linkedWidgets?: IBaseWidget[]
   name: string


### PR DESCRIPTION
## Summary
- Removed redundant `parentSubgraphNode` property from widget interfaces and implementations
- Simplified widget promotion by using existing `widget.node` reference instead

## Details
The `parentSubgraphNode` property was causing TypeScript compilation issues in downstream ComfyUI_frontend due to private fields in `LGraphNode`. After investigation, we found the property was redundant since widgets can determine their parent context through the existing `widget.node` reference (after first fixing the `DomWidgetImpl` to properly implement `createCopyForNode`).

Changes:
- Removed `parentSubgraphNode` property from `IBaseWidget` interface
- Removed `parentSubgraphNode` property from `BaseWidget` class
- Updated `SubgraphNode` to not set the property during widget promotion
- Removed cleanup of the property in `SubgraphNode.onRemoved`
- Updated tests to remove `parentSubgraphNode` assertions
- Aligned with recent terminology changes ("widget-demoted" events)

All tests passing, no functional changes.