### PR TITLE
[API] Add subgraph ID to execution DTO

### DIFF
--- a/src/subgraph/ExecutableNodeDTO.ts
+++ b/src/subgraph/ExecutableNodeDTO.ts
@@ -85,6 +85,10 @@ export class ExecutableNodeDTO implements ExecutableLGraphNode {
     return this.node.widgets
   }
 
+  get subgraphId() {
+    return this.subgraphNode?.subgraph.id
+  }
+
   constructor(
     /** The actual node that this DTO wraps. */
     readonly node: LGraphNode | SubgraphNode,


### PR DESCRIPTION
Allows the containing subgraph ID of a node to be read during execution.