### PR TITLE
[fix] Update canvas when removing subgraph IO slots to re-render links

### DIFF
--- a/src/subgraph/SubgraphNode.ts
+++ b/src/subgraph/SubgraphNode.ts
@@ -68,6 +68,7 @@ export class SubgraphNode extends LGraphNode implements BaseLGraph {
       if (widget) this.ensureWidgetRemoved(widget)
 
       this.removeInput(e.detail.index)
+      this.setDirtyCanvas(true, true)
     }, { signal })
 
     subgraphEvents.addEventListener("output-added", (e) => {
@@ -77,6 +78,7 @@ export class SubgraphNode extends LGraphNode implements BaseLGraph {
 
     subgraphEvents.addEventListener("removing-output", (e) => {
       this.removeOutput(e.detail.index)
+      this.setDirtyCanvas(true, true)
     }, { signal })
 
     subgraphEvents.addEventListener("renaming-input", (e) => {


### PR DESCRIPTION
## Summary

This PR fixes the link rendering issue when removing slots from subgraph IO nodes. Previously, when using the "Remove Slot" context menu option on SubgraphInputNode or SubgraphOutputNode, the slot names and colors would shift correctly but the connected links would remain at their old positions until a manual canvas update was triggered.

## Changes

- Added `this.setDirtyCanvas(true, true)` calls in SubgraphNode's event handlers for `removing-input` and `removing-output` events
- This ensures the parent canvas (where the SubgraphNode and its links are rendered) gets updated when slots are removed from the IO nodes

## Notes

We need both layers set dirty (`setDirtyCanvas(true, true)`) because:

1. The foreground needs updating because the node's slots visually shift
2. The background needs updating because the links need to re-render

Fixes #1171