### PR TITLE
[fix] Preserve tooltips when promoting widgets to subgraph inputs

### DIFF
--- a/src/subgraph/SubgraphNode.ts
+++ b/src/subgraph/SubgraphNode.ts
@@ -216,6 +216,13 @@ export class SubgraphNode extends LGraphNode implements BaseLGraph {
       set label(value) {
         console.warn("Promoted widget: setting label is not allowed", this, value)
       },
+      get tooltip() {
+        // Preserve the original widget's tooltip for promoted widgets
+        return widget.tooltip
+      },
+      set tooltip(value) {
+        console.warn("Promoted widget: setting tooltip is not allowed", this, value)
+      },
     })
 
     this.widgets.push(promotedWidget)


### PR DESCRIPTION
Fixes an issue where promoted widgets in subgraphs were losing their tooltip information during the promotion process.

When widgets are promoted from internal subgraph nodes to the subgraph's external interface, the tooltip property is now preserved through a getter that returns the original widget's tooltip value.