### PR TITLE
[Subgraph] Use color palette colors for subgraph io node slot labels

### DIFF
--- a/src/subgraph/SubgraphSlotBase.ts
+++ b/src/subgraph/SubgraphSlotBase.ts
@@ -137,7 +137,7 @@ export abstract class SubgraphSlot extends SlotBase implements SubgraphIO, Hover
     if (!this.displayName) return
 
     const [x, y] = this.labelPos
-    ctx.fillStyle = this.isPointerOver ? "white" : "#AAA"
+    ctx.fillStyle = this.isPointerOver ? "white" : (LiteGraph.NODE_TEXT_COLOR || "#AAA")
 
     ctx.fillText(this.displayName, x, y)
   }


### PR DESCRIPTION
Use `LiteGraph.NODE_TEXT_COLOR` which is set by the color palette and therefore adjusts to light theme (or any theme set by user).

Before:

<img width="310" height="504" alt="Selection_1826" src="https://github.com/user-attachments/assets/869c064a-720c-49a4-8223-f0d9e60b5d17" />

After:

<img width="434" height="514" alt="Selection_1825" src="https://github.com/user-attachments/assets/acc715b4-66de-498c-aaef-486a99ab6e7d" />
