### PR TITLE
Fix "Dragging from input slot connected to SubgraphInputNode creates new link instead of moving existing one"

### DIFF
--- a/src/canvas/LinkConnector.ts
+++ b/src/canvas/LinkConnector.ts
@@ -162,14 +162,16 @@ export class LinkConnector {
 
         try {
           const reroute = network.getReroute(link.parentId)
-          const renderLink = new ToInputFromIoNodeLink(network, network.inputNode, subgraphInput, reroute)
+          const renderLink = new ToInputFromIoNodeLink(network, network.inputNode, subgraphInput, reroute, LinkDirection.CENTER, link)
 
           // Note: We don't dispatch the before-move-input event for subgraph input links
           // as the event type doesn't support ToInputFromIoNodeLink
 
           renderLinks.push(renderLink)
 
-          link.disconnect(network, "input")
+          this.listenUntilReset("input-moved", () => {
+            link.disconnect(network, "input")
+          })
         } catch (error) {
           console.warn(`Could not create render link for subgraph input link id: [${link.id}].`, link, error)
           return
@@ -189,7 +191,9 @@ export class LinkConnector {
           renderLinks.push(renderLink)
 
           this.listenUntilReset("input-moved", (e) => {
-            e.detail.link.disconnect(network, "output")
+            if ("link" in e.detail && e.detail.link) {
+              e.detail.link.disconnect(network, "output")
+            }
           })
         } catch (error) {
           console.warn(`Could not create render link for link id: [${link.id}].`, link, error)

--- a/src/canvas/LinkConnector.ts
+++ b/src/canvas/LinkConnector.ts
@@ -150,25 +150,55 @@ export class LinkConnector {
       const link = network.links.get(linkId)
       if (!link) return
 
-      try {
-        const reroute = network.getReroute(link.parentId)
-        const renderLink = new MovingInputLink(network, link, reroute)
+      // Special handling for links from subgraph input nodes
+      if (link.origin_id === SUBGRAPH_INPUT_ID) {
+        // For subgraph input links, we need to handle them differently
+        // since they don't have a regular output node
+        const subgraphInput = network.inputNode?.slots[link.origin_slot]
+        if (!subgraphInput) {
+          console.warn(`Could not find subgraph input for slot [${link.origin_slot}]`)
+          return
+        }
 
-        const mayContinue = this.events.dispatch("before-move-input", renderLink)
-        if (mayContinue === false) return
+        try {
+          const reroute = network.getReroute(link.parentId)
+          const renderLink = new ToInputFromIoNodeLink(network, network.inputNode, subgraphInput, reroute)
 
-        renderLinks.push(renderLink)
+          // Note: We don't dispatch the before-move-input event for subgraph input links
+          // as the event type doesn't support ToInputFromIoNodeLink
 
-        this.listenUntilReset("input-moved", (e) => {
-          e.detail.link.disconnect(network, "output")
-        })
-      } catch (error) {
-        console.warn(`Could not create render link for link id: [${link.id}].`, link, error)
-        return
+          renderLinks.push(renderLink)
+
+          link.disconnect(network, "input")
+        } catch (error) {
+          console.warn(`Could not create render link for subgraph input link id: [${link.id}].`, link, error)
+          return
+        }
+
+        link._dragging = true
+        inputLinks.push(link)
+      } else {
+        // Regular node links
+        try {
+          const reroute = network.getReroute(link.parentId)
+          const renderLink = new MovingInputLink(network, link, reroute)
+
+          const mayContinue = this.events.dispatch("before-move-input", renderLink)
+          if (mayContinue === false) return
+
+          renderLinks.push(renderLink)
+
+          this.listenUntilReset("input-moved", (e) => {
+            e.detail.link.disconnect(network, "output")
+          })
+        } catch (error) {
+          console.warn(`Could not create render link for link id: [${link.id}].`, link, error)
+          return
+        }
+
+        link._dragging = true
+        inputLinks.push(link)
       }
-
-      link._dragging = true
-      inputLinks.push(link)
     }
 
     state.connectingTo = "input"

--- a/src/infrastructure/LinkConnectorEventMap.ts
+++ b/src/infrastructure/LinkConnectorEventMap.ts
@@ -2,6 +2,7 @@ import type { FloatingRenderLink } from "@/canvas/FloatingRenderLink"
 import type { MovingInputLink } from "@/canvas/MovingInputLink"
 import type { MovingOutputLink } from "@/canvas/MovingOutputLink"
 import type { RenderLink } from "@/canvas/RenderLink"
+import type { ToInputFromIoNodeLink } from "@/canvas/ToInputFromIoNodeLink"
 import type { ToInputRenderLink } from "@/canvas/ToInputRenderLink"
 import type { LGraphNode } from "@/LGraphNode"
 import type { LLink } from "@/LLink"
@@ -26,7 +27,7 @@ export interface LinkConnectorEventMap {
   "before-move-input": MovingInputLink | FloatingRenderLink
   "before-move-output": MovingOutputLink | FloatingRenderLink
 
-  "input-moved": MovingInputLink | FloatingRenderLink
+  "input-moved": MovingInputLink | FloatingRenderLink | ToInputFromIoNodeLink
   "output-moved": MovingOutputLink | FloatingRenderLink
 
   "link-created": LLink | null | undefined

--- a/test/subgraph/SubgraphWidgetPromotion.test.ts
+++ b/test/subgraph/SubgraphWidgetPromotion.test.ts
@@ -1,7 +1,7 @@
 import type { ISlotType } from "@/interfaces"
 import type { TWidgetType } from "@/types/widgets"
 
-import { describe, expect, it, vi } from "vitest"
+import { describe, expect, it } from "vitest"
 
 import { LGraphNode, Subgraph } from "@/litegraph"
 import { BaseWidget } from "@/widgets/BaseWidget"
@@ -339,7 +339,7 @@ describe("SubgraphWidgetPromotion", () => {
 
       // The promoted widget should preserve the original tooltip
       expect(promotedWidget.tooltip).toBe(originalTooltip)
-      
+
       // The promoted widget should still function normally
       expect(promotedWidget.name).toBe("value") // Uses subgraph input name
       expect(promotedWidget.type).toBe("number")


### PR DESCRIPTION
this PR adds a special check for SUBGRAPH_INPUT_ID because of incompatabilities with it being a virtual node.

maybe we can add a cleaner support for this later, but it does fix the issue for now.

https://github.com/user-attachments/assets/3c8a44e1-0b3f-4a93-90a6-08bb735a093f

fixes https://github.com/Comfy-Org/litegraph.js/issues/1170
also, #1182 might need to go in first, this branched off of that