### PR TITLE
Fix duplicated inputs on loading nested subgraphs

### DIFF
--- a/src/subgraph/SubgraphNode.ts
+++ b/src/subgraph/SubgraphNode.ts
@@ -60,6 +60,8 @@ export class SubgraphNode extends LGraphNode implements BaseLGraph {
     subgraphEvents.addEventListener("input-added", (e) => {
       const subgraphInput = e.detail.input
       const { name, type } = subgraphInput
+      if (this.inputs.find((i) => i.name == name))
+        return
       const input = this.addInput(name, type)
 
       this.#addSubgraphInputListeners(subgraphInput, input)


### PR DESCRIPTION
Subgraphs are loaded in order of creation. Under most circumstances, this means newer subgraphs are loaded first. With nested subgraphs, this means a subgraph node has it's inputs connected before it's inside is loaded. When the inner subgraph is loaded, input-added events are triggered even though inputs already exist on the subgraph node.

This is resolved by adding a check for if an input of the corresponding name already exists when adding an input.