### PR TITLE
Fix inconsistent subgraphNode usage

### DIFF
--- a/src/subgraph/ExecutableNodeDTO.ts
+++ b/src/subgraph/ExecutableNodeDTO.ts
@@ -118,7 +118,7 @@ export class ExecutableNodeDTO implements ExecutableLGraphNode {
 
   /** Returns either the DTO itself, or the DTOs of the inner nodes of the subgraph. */
   getInnerNodes(): ExecutableLGraphNode[] {
-    return this.subgraphNode ? this.subgraphNode.getInnerNodes(this.nodesByExecutionId, this.subgraphNodePath) : [this]
+    return this.node.isSubgraphNode() ? this.node.getInnerNodes(this.nodesByExecutionId, this.subgraphNodePath) : [this]
   }
 
   /**


### PR DESCRIPTION
Prior to this commit, subgraphNode inconsistently refers to either the parent graph, or to indicate the current node is a subgraph.

This corrects the usage of subgraphNode to consistently refer to the subgraph instance as defined in the constructor.

This requires a corresponding frontend commit to function, and solves a bug where graph serialization fails due to an incorrectly reported infinite loop.