### PR TITLE
fix: Update repository reference comfyanonymous/ComfyUI → Comfy-Org/ComfyUI

### DIFF
--- a/.github/workflows/test-comfyui-frontend.yml
+++ b/.github/workflows/test-comfyui-frontend.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Checkout ComfyUI
         uses: actions/checkout@v4
         with:
-          repository: "comfyanonymous/ComfyUI"
+          repository: "Comfy-Org/ComfyUI"
           path: "ComfyUI"
           ref: master
 


### PR DESCRIPTION
Updates repository reference after the official rename. GitHub API calls don't follow redirects, which can break CI workflows using actions/checkout with the old repository name.